### PR TITLE
Fix/mediapipe jetson imports

### DIFF
--- a/nectar/nectar/vision/algorithms/mediapipe/face_tracker.py
+++ b/nectar/nectar/vision/algorithms/mediapipe/face_tracker.py
@@ -7,9 +7,26 @@ from typing import List, Optional, Tuple
 import cv2
 import mediapipe as mp
 import numpy as np
-from mediapipe.framework.formats import landmark_pb2
 from mediapipe.tasks import python
 from mediapipe.tasks.python import vision
+from mediapipe.tasks.python.vision import (
+    FaceLandmarksConnections,
+)
+
+try:
+    from mediapipe.tasks.python.vision import (
+        drawing_styles as mp_styles,
+    )
+    from mediapipe.tasks.python.vision import (
+        drawing_utils as mp_drawing,
+    )
+except ImportError:
+    from mediapipe.python.solutions import (
+        drawing_styles as mp_styles,
+    )
+    from mediapipe.python.solutions import (
+        drawing_utils as mp_drawing,
+    )
 
 
 class FaceLandmarkRegion:
@@ -317,20 +334,12 @@ class FaceMeshTracker:
         self._detection_result: Optional[vision.FaceLandmarkerResult] = None
         self._is_running = False
 
-        self._mp_face_mesh = mp.solutions.face_mesh
-        self._mp_drawing = mp.solutions.drawing_utils
-        self._mp_drawing_styles = mp.solutions.drawing_styles
-        self._face_tesselation = self._mp_face_mesh.FACEMESH_TESSELATION
-        self._face_contours = (
-            self._mp_face_mesh.FACEMESH_CONTOURS
-            | self._mp_face_mesh.FACEMESH_LEFT_EYE
-            | self._mp_face_mesh.FACEMESH_RIGHT_EYE
-            | self._mp_face_mesh.FACEMESH_LEFT_EYEBROW
-            | self._mp_face_mesh.FACEMESH_RIGHT_EYEBROW
-            | self._mp_face_mesh.FACEMESH_LIPS
-        )
+        # Drawing connections
+        self._face_tesselation = FaceLandmarksConnections.FACE_LANDMARKS_TESSELATION
+        self._face_contours = FaceLandmarksConnections.FACE_LANDMARKS_CONTOURS
         self._face_irises = (
-            self._mp_face_mesh.FACEMESH_LEFT_IRIS | self._mp_face_mesh.FACEMESH_RIGHT_IRIS
+            FaceLandmarksConnections.FACE_LANDMARKS_LEFT_IRIS
+            + FaceLandmarksConnections.FACE_LANDMARKS_RIGHT_IRIS
         )
 
     def __enter__(self) -> "FaceMeshTracker":
@@ -461,40 +470,31 @@ class FaceMeshTracker:
             return image
 
         for face_landmarks in self._detection_result.face_landmarks:
-            # Convert to protobuf format for drawing (MediaPipe 0.10.18)
-            face_landmarks_proto = landmark_pb2.NormalizedLandmarkList()
-            face_landmarks_proto.landmark.extend(
-                [
-                    landmark_pb2.NormalizedLandmark(x=landmark.x, y=landmark.y, z=landmark.z)
-                    for landmark in face_landmarks
-                ]
-            )
-
             if draw_tesselation:
-                self._mp_drawing.draw_landmarks(
+                mp_drawing.draw_landmarks(
                     image=image,
-                    landmark_list=face_landmarks_proto,
+                    landmark_list=face_landmarks,
                     connections=self._face_tesselation,
                     landmark_drawing_spec=None,
-                    connection_drawing_spec=self._mp_drawing_styles.get_default_face_mesh_tesselation_style(),
+                    connection_drawing_spec=mp_styles.get_default_face_mesh_tesselation_style(),
                 )
 
             if draw_contours:
-                self._mp_drawing.draw_landmarks(
+                mp_drawing.draw_landmarks(
                     image=image,
-                    landmark_list=face_landmarks_proto,
+                    landmark_list=face_landmarks,
                     connections=self._face_contours,
                     landmark_drawing_spec=None,
-                    connection_drawing_spec=self._mp_drawing_styles.get_default_face_mesh_contours_style(),
+                    connection_drawing_spec=mp_styles.get_default_face_mesh_contours_style(),
                 )
 
             if draw_irises:
-                self._mp_drawing.draw_landmarks(
+                mp_drawing.draw_landmarks(
                     image=image,
-                    landmark_list=face_landmarks_proto,
+                    landmark_list=face_landmarks,
                     connections=self._face_irises,
                     landmark_drawing_spec=None,
-                    connection_drawing_spec=self._mp_drawing_styles.get_default_face_mesh_iris_connections_style(),
+                    connection_drawing_spec=mp_styles.get_default_face_mesh_iris_connections_style(),
                 )
 
         return image

--- a/nectar/nectar/vision/algorithms/mediapipe/hand_tracker.py
+++ b/nectar/nectar/vision/algorithms/mediapipe/hand_tracker.py
@@ -8,9 +8,26 @@ from typing import List, Optional, Tuple
 import cv2
 import mediapipe as mp
 import numpy as np
-from mediapipe.framework.formats import landmark_pb2
 from mediapipe.tasks import python
 from mediapipe.tasks.python import vision
+from mediapipe.tasks.python.vision import (
+    HandLandmarksConnections,
+)
+
+try:
+    from mediapipe.tasks.python.vision import (
+        drawing_styles as mp_styles,
+    )
+    from mediapipe.tasks.python.vision import (
+        drawing_utils as mp_drawing,
+    )
+except ImportError:
+    from mediapipe.python.solutions import (
+        drawing_styles as mp_styles,
+    )
+    from mediapipe.python.solutions import (
+        drawing_utils as mp_drawing,
+    )
 
 
 class HandLandmark(IntEnum):
@@ -167,11 +184,8 @@ class HandTracker:
         self._detection_result: Optional[vision.HandLandmarkerResult] = None
         self._is_running = False
 
-        # MediaPipe 0.10.18 drawing utilities
-        self._mp_hands = mp.solutions.hands
-        self._mp_drawing = mp.solutions.drawing_utils
-        self._mp_drawing_styles = mp.solutions.drawing_styles
-        self._hand_connections = self._mp_hands.HAND_CONNECTIONS
+        # drawing utilities (Tasks API)
+        self._hand_connections = HandLandmarksConnections.HAND_CONNECTIONS
 
         self._depth_coeffs = np.polyfit(self._DEPTH_CALIB_X, self._DEPTH_CALIB_Y, 2)
 
@@ -299,19 +313,13 @@ class HandTracker:
         for idx, hand_landmarks in enumerate(self._detection_result.hand_landmarks):
             handedness = self._detection_result.handedness[idx]
 
-            hand_landmarks_proto = landmark_pb2.NormalizedLandmarkList()
-            hand_landmarks_proto.landmark.extend(
-                [
-                    landmark_pb2.NormalizedLandmark(x=landmark.x, y=landmark.y, z=landmark.z)
-                    for landmark in hand_landmarks
-                ]
-            )
-            self._mp_drawing.draw_landmarks(
+            # Draw landmarks and connections (Tasks API)
+            mp_drawing.draw_landmarks(
                 image,
-                hand_landmarks_proto,
+                hand_landmarks,
                 self._hand_connections,
-                self._mp_drawing_styles.get_default_hand_landmarks_style(),
-                self._mp_drawing_styles.get_default_hand_connections_style(),
+                mp_styles.get_default_hand_landmarks_style(),
+                mp_styles.get_default_hand_connections_style(),
             )
 
             # Draw handedness label


### PR DESCRIPTION
## fix: add fallback imports for mediapipe drawing utils on Jetson

## Description
This PR adds a try/except ImportError fallback in both [face_tracker.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [hand_tracker.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to import from [mediapipe.python.solutions](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when the primary import path fails, ensuring compatibility with both desktop and Jetson environments. 
