### PR TITLE
fix: transform detector.detector-draw to @staticmethod

### DIFF
--- a/nectar/nectar/ai/detection/detector.py
+++ b/nectar/nectar/ai/detection/detector.py
@@ -295,6 +295,7 @@ class Detector:
             raise RuntimeError("Model not loaded. Call load() first.")
         return self._model.evaluate(config)
 
+    @staticmethod
     def draw_detections(
         self,
         image: np.ndarray,

--- a/nectar/nectar/ai/detection/detector.py
+++ b/nectar/nectar/ai/detection/detector.py
@@ -297,7 +297,6 @@ class Detector:
 
     @staticmethod
     def draw_detections(
-        self,
         image: np.ndarray,
         result: DetectionResult,
         show_labels: bool = True,


### PR DESCRIPTION
## Title

Refactor: convert `Detector.detector_draw` to static method

## Description

This PR refactors the `Detector.detector_draw` method by converting it into a `@staticmethod`. The method does not rely on instance-specific data, so making it static improves code clarity, enforces proper usage, and avoids unnecessary object dependencies.

## Pull Request Type

Please check the type of change your PR introduces:

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, renaming)
* [x] Refactoring (no functional changes, no API changes)
* [ ] Build-related changes
* [ ] Documentation content changes
* [ ] Other (please describe):

## Current Behavior

The `detector_draw` method is currently defined as an instance method within the `Detector` class, even though it does not use any instance attributes or state.

Issue Number: N/A (Optional)

## New Behavior

The `detector_draw` method is now defined as a `@staticmethod`, making it callable without requiring an instance of the `Detector` class. This improves code organization and makes the method's purpose clearer.

### Modified/Created Files

* detector.py
  Changes: Converted `detector_draw` method to `@staticmethod` and updated its definition accordingly.

## Does This Introduce a Breaking Change?

* [ ] Yes
* [x] No

### Impact and Migration Path

* **Impact:** No breaking changes. Existing functionality remains the same.
* **Migration Path:** No migration required. If previously called via instance, it will continue to work, but can now also be called directly via the class.

## Additional Information (Optional)

* **Before Screenshot:** N/A
* **After Screenshot:** N/A
