### PR TITLE
refactor: lazy import

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -206,6 +206,23 @@ When adding new components:
 4. **Export**: Add public symbols to `__init__.py`
 5. **Document**: Update module README.md
 
+### Import-time Contract
+
+Heavy third-party dependencies (`torch`, `transformers`, `rfdetr`, `tensorflow`, `jax`, `matplotlib`, `mediapipe`, `pyrealsense2`, `depthai`, `supervision`, `ultralytics`, `pandas`, `geopy`) **must not** be imported at module load time on the path of `from nectar.ai import Detector`, `from nectar.vision import ImageHandler`, or `from nectar.control import MavrosConfig`.
+
+Two patterns are used to enforce this, both standard ([PEP 562](https://peps.python.org/pep-0562/), the same approach as scikit-learn / NumPy / SciPy):
+
+1. **Lazy package surface in `__init__.py`**: heavy re-exports go through a `_LAZY_ATTRS` dict and `__getattr__`. Lightweight types (dataclasses, enums, exceptions) stay eager. See `nectar/ai/detection/__init__.py` and `nectar/vision/__init__.py` for the canonical pattern.
+2. **Local imports in functions**: when a module needs `matplotlib` / `pandas` only inside a plotting helper, the import lives inside the function body, not at the top of the file. See `nectar/vision/algorithms/distance/calibrator.py::ModelCalibrator.plot`.
+
+The contract is enforced by `nectar/test/test_lazy_imports.py`, which spawns a fresh interpreter and asserts that the forbidden modules are not in `sys.modules` after the public import. Run it locally with:
+
+```bash
+python -m pytest nectar/test/test_lazy_imports.py
+```
+
+If you add a new heavy dependency or re-export, either add it to `_LAZY_ATTRS` or extend the forbidden list and the test together.
+
 ## Review Process 👀
 
 After submission:

--- a/nectar/nectar/ai/__init__.py
+++ b/nectar/nectar/ai/__init__.py
@@ -1,5 +1,11 @@
+"""
+Nectar SDK - AI module.
+"""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.ai.detection import (
-    BaseDetectionModel,
     Detection,
     DetectionInput,
     DetectionResult,
@@ -7,35 +13,85 @@ from nectar.ai.detection import (
     EvaluationConfig,
     EvaluationMetrics,
     Framework,
-    ModelLoader,
-    ObjectDetectionEvaluator,
     Prediction,
-    RFDETRModel,
     TrainingConfig,
-    TransformersModel,
-    UltralyticsModel,
 )
-from nectar.ai.detection.datasets.upload import RoboflowUploader
-from nectar.ai.segmentation import (
-    BaseSegmentationModel,
-    RFDETRSegModel,
-    RoboflowSegHandler,
-    SegDatasetAnalyzer,
-    SegDatasetHandlerRegistry,
-    SegEvaluationConfig,
-    SegEvaluationMetrics,
-    SegFormatConverter,
-    Segmentation,
-    SegmentationEvaluator,
-    SegmentationInput,
-    SegmentationResult,
-    Segmentor,
-    SegPrediction,
-    SegTrainingConfig,
-    TransformersSegModel,
-    UltralyticsSegHandler,
-    UltralyticsSegModel,
-)
+
+_LAZY_ATTRS = {
+    # Detection (heavy)
+    "BaseDetectionModel": "nectar.ai.detection",
+    "ModelLoader": "nectar.ai.detection",
+    "UltralyticsModel": "nectar.ai.detection",
+    "TransformersModel": "nectar.ai.detection",
+    "RFDETRModel": "nectar.ai.detection",
+    "ObjectDetectionEvaluator": "nectar.ai.detection",
+    "RoboflowUploader": "nectar.ai.detection.datasets.upload",
+    # Segmentation (heavy: torch, transformers, rfdetr, matplotlib)
+    "Segmentor": "nectar.ai.segmentation",
+    "BaseSegmentationModel": "nectar.ai.segmentation",
+    "UltralyticsSegModel": "nectar.ai.segmentation",
+    "TransformersSegModel": "nectar.ai.segmentation",
+    "RFDETRSegModel": "nectar.ai.segmentation",
+    "Segmentation": "nectar.ai.segmentation",
+    "SegmentationResult": "nectar.ai.segmentation",
+    "SegmentationInput": "nectar.ai.segmentation",
+    "SegPrediction": "nectar.ai.segmentation",
+    "SegTrainingConfig": "nectar.ai.segmentation",
+    "SegEvaluationConfig": "nectar.ai.segmentation",
+    "SegEvaluationMetrics": "nectar.ai.segmentation",
+    "SegmentationEvaluator": "nectar.ai.segmentation",
+    "SegFormatConverter": "nectar.ai.segmentation",
+    "SegDatasetAnalyzer": "nectar.ai.segmentation",
+    "SegDatasetHandlerRegistry": "nectar.ai.segmentation",
+    "UltralyticsSegHandler": "nectar.ai.segmentation",
+    "RoboflowSegHandler": "nectar.ai.segmentation",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.detection import (
+        BaseDetectionModel,
+        ModelLoader,
+        ObjectDetectionEvaluator,
+        RFDETRModel,
+        TransformersModel,
+        UltralyticsModel,
+    )
+    from nectar.ai.detection.datasets.upload import RoboflowUploader
+    from nectar.ai.segmentation import (
+        BaseSegmentationModel,
+        RFDETRSegModel,
+        RoboflowSegHandler,
+        SegDatasetAnalyzer,
+        SegDatasetHandlerRegistry,
+        SegEvaluationConfig,
+        SegEvaluationMetrics,
+        SegFormatConverter,
+        Segmentation,
+        SegmentationEvaluator,
+        SegmentationInput,
+        SegmentationResult,
+        Segmentor,
+        SegPrediction,
+        SegTrainingConfig,
+        TransformersSegModel,
+        UltralyticsSegHandler,
+        UltralyticsSegModel,
+    )
+
 
 __all__ = [
     # Detection API

--- a/nectar/nectar/ai/detection/__init__.py
+++ b/nectar/nectar/ai/detection/__init__.py
@@ -2,8 +2,6 @@
 Detection module for object detection training, evaluation, and inference.
 
 Unified interface for object detection across multiple frameworks
-(Ultralytics YOLO, HuggingFace Transformers DETR, RF-DETR) with
-comprehensive training, evaluation, and post-processing capabilities.
 
 Examples
 --------
@@ -32,9 +30,9 @@ Examples
 >>> result = detector.train(config)
 """
 
-from nectar.ai.detection.core.base import BaseDetectionModel
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-# Configuration classes
 from nectar.ai.detection.core.configs import (
     EvaluationConfig,
     EvaluationMetrics,
@@ -42,8 +40,6 @@ from nectar.ai.detection.core.configs import (
     TrainingMetrics,
     TrainingResult,
 )
-
-# Exceptions
 from nectar.ai.detection.core.exceptions import (
     ConfigurationError,
     DatasetError,
@@ -57,8 +53,6 @@ from nectar.ai.detection.core.exceptions import (
     SlicingError,
     TrainingError,
 )
-
-# Core types and data classes
 from nectar.ai.detection.core.types import (
     BatchImageType,
     Detection,
@@ -69,42 +63,78 @@ from nectar.ai.detection.core.types import (
 )
 from nectar.ai.detection.detector import Detector, Framework
 
-# Evaluation
-from nectar.ai.detection.evaluation import ObjectDetectionEvaluator
+_LAZY_ATTRS = {
+    "BaseDetectionModel": "nectar.ai.detection.core.base",
+    # Models (heavy: pull torch, ultralytics, transformers, rfdetr)
+    "ModelLoader": "nectar.ai.detection.models.model_loader",
+    "UltralyticsModel": "nectar.ai.detection.models.ultralytics",
+    "TransformersModel": "nectar.ai.detection.models.transformers",
+    "RFDETRModel": "nectar.ai.detection.models.rfdetr",
+    "CocoDetectionDataset": "nectar.ai.detection.models.dataset",
+    "load_detection_dataset": "nectar.ai.detection.models.dataset",
+    # Evaluation (heavy: pulls matplotlib, supervision)
+    "ObjectDetectionEvaluator": "nectar.ai.detection.evaluation",
+    # Post-processing (light, but kept lazy for symmetry)
+    "BaseMergingStrategy": "nectar.ai.detection.postprocess",
+    "NMSStrategy": "nectar.ai.detection.postprocess",
+    "SoftNMSStrategy": "nectar.ai.detection.postprocess",
+    "WBFStrategy": "nectar.ai.detection.postprocess",
+    "NMMStrategy": "nectar.ai.detection.postprocess",
+    "PerClassConfidenceFilter": "nectar.ai.detection.postprocess",
+    # Slicing (pulls supervision)
+    "SlicingConfig": "nectar.ai.detection.slicing",
+    "SlicingStrategy": "nectar.ai.detection.slicing",
+    "SlicingInference": "nectar.ai.detection.slicing",
+    # Utilities
+    "HuggingFaceUploader": "nectar.ai.detection.utils.huggingface",
+    "get_device": "nectar.ai.detection.utils.device",
+    "DeviceManager": "nectar.ai.detection.utils.device",
+}
 
-# Model implementations
-from nectar.ai.detection.models import (
-    CocoDetectionDataset,
-    ModelLoader,
-    RFDETRModel,
-    TransformersModel,
-    UltralyticsModel,
-    load_detection_dataset,
-)
 
-# Post-processing
-from nectar.ai.detection.postprocess import (
-    BaseMergingStrategy,
-    NMMStrategy,
-    NMSStrategy,
-    PerClassConfidenceFilter,
-    SoftNMSStrategy,
-    WBFStrategy,
-)
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
 
-# Slicing inference
-from nectar.ai.detection.slicing import (
-    SlicingConfig,
-    SlicingInference,
-    SlicingStrategy,
-)
 
-# Utilities
-from nectar.ai.detection.utils import (
-    DeviceManager,
-    HuggingFaceUploader,
-    get_device,
-)
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.detection.core.base import BaseDetectionModel
+    from nectar.ai.detection.evaluation import ObjectDetectionEvaluator
+    from nectar.ai.detection.models import (
+        CocoDetectionDataset,
+        ModelLoader,
+        RFDETRModel,
+        TransformersModel,
+        UltralyticsModel,
+        load_detection_dataset,
+    )
+    from nectar.ai.detection.postprocess import (
+        BaseMergingStrategy,
+        NMMStrategy,
+        NMSStrategy,
+        PerClassConfidenceFilter,
+        SoftNMSStrategy,
+        WBFStrategy,
+    )
+    from nectar.ai.detection.slicing import (
+        SlicingConfig,
+        SlicingInference,
+        SlicingStrategy,
+    )
+    from nectar.ai.detection.utils import (
+        DeviceManager,
+        HuggingFaceUploader,
+        get_device,
+    )
+
 
 __all__ = [
     # Simple API

--- a/nectar/nectar/ai/detection/core/base.py
+++ b/nectar/nectar/ai/detection/core/base.py
@@ -2,19 +2,12 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import numpy as np
 
-try:
-    import torch
-except ImportError:
-    torch = None
-
-try:
-    import supervision as sv
-except ImportError:
-    sv = None
+if TYPE_CHECKING:
+    pass
 
 from nectar.ai.detection.core.configs import (
     EvaluationConfig,
@@ -187,6 +180,11 @@ class BaseDetectionModel(ABC):
         Prediction
             Batch prediction results.
         """
+        try:
+            import supervision as sv
+        except ImportError:
+            sv = None
+
         images = detection_input.image
         batch_detections = []
         image_paths = []
@@ -395,6 +393,8 @@ class BaseDetectionModel(ABC):
         if self._slicing_inference is None:
             raise RuntimeError("Slicing not enabled. Call enable_slicing() first.")
 
+        import supervision as sv
+
         def inference_callback(image):
             """Callback for slice inference."""
             slice_input = DetectionInput(
@@ -527,8 +527,12 @@ class BaseDetectionModel(ABC):
         >>> annotated = model.draw_detections(image, result)
         >>> cv2.imshow("Detections", annotated)
         """
-        if sv is None:
-            raise ImportError("supervision is required. Install with: pip install supervision")
+        try:
+            import supervision as sv
+        except ImportError as e:
+            raise ImportError(
+                "supervision is required. Install with: pip install supervision"
+            ) from e
 
         if not result.detections:
             return image.copy()

--- a/nectar/nectar/ai/detection/core/types.py
+++ b/nectar/nectar/ai/detection/core/types.py
@@ -4,24 +4,14 @@ Core data types for object detection.
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 
-try:
-    import torch
-except ImportError:
-    torch = None
-
-try:
+if TYPE_CHECKING:
     import supervision as sv
-except ImportError:
-    sv = None
-
-try:
+    import torch
     from PIL import Image
-except ImportError:
-    Image = None
 
 
 ImageType = Union[str, Path, np.ndarray, "torch.Tensor", "Image.Image"]
@@ -285,8 +275,12 @@ class DetectionResult:
         ImportError
             If supervision is not installed.
         """
-        if sv is None:
-            raise ImportError("supervision is required. Install with: pip install supervision")
+        try:
+            import supervision as sv
+        except ImportError as e:
+            raise ImportError(
+                "supervision is required. Install with: pip install supervision"
+            ) from e
 
         if not self.detections:
             return sv.Detections.empty()
@@ -408,7 +402,11 @@ class DetectionInput:
         """bool: Check if input contains a batch of images."""
         if isinstance(self.image, (list, tuple)):
             return True
-        if torch is not None and isinstance(self.image, torch.Tensor):
+        try:
+            import torch
+        except ImportError:
+            return False
+        if isinstance(self.image, torch.Tensor):
             return self.image.dim() == 4
         return False
 

--- a/nectar/nectar/ai/detection/datasets/__init__.py
+++ b/nectar/nectar/ai/detection/datasets/__init__.py
@@ -1,6 +1,8 @@
 """Dataset management utilities for object detection."""
 
-from nectar.ai.detection.datasets.analyze import DatasetAnalyzer
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.ai.detection.datasets.augment import (
     AUG_AERIAL,
     AUG_AGGRESSIVE,
@@ -16,20 +18,53 @@ from nectar.ai.detection.datasets.handlers import (
     RoboflowHandler,
     VisDroneHandler,
 )
-from nectar.ai.detection.datasets.hf_converter import (
-    coco_to_hf,
-    generate_dataset_card,
-    hf_to_coco,
-    hf_to_yolo,
-    yolo_to_hf,
-)
-from nectar.ai.detection.datasets.merge import DatasetMerger
-from nectar.ai.detection.datasets.stratify import Stratifier
 from nectar.ai.detection.datasets.subset import SubsetCreator
-from nectar.ai.detection.datasets.upload import (
-    HuggingFaceDatasetUploader,
-    RoboflowUploader,
-)
+
+_LAZY_ATTRS = {
+    # Pulls matplotlib for plots
+    "DatasetAnalyzer": "nectar.ai.detection.datasets.analyze",
+    "DatasetMerger": "nectar.ai.detection.datasets.merge",
+    "Stratifier": "nectar.ai.detection.datasets.stratify",
+    # Pull huggingface_hub / datasets / roboflow
+    "RoboflowUploader": "nectar.ai.detection.datasets.upload",
+    "HuggingFaceDatasetUploader": "nectar.ai.detection.datasets.upload",
+    "coco_to_hf": "nectar.ai.detection.datasets.hf_converter",
+    "yolo_to_hf": "nectar.ai.detection.datasets.hf_converter",
+    "hf_to_coco": "nectar.ai.detection.datasets.hf_converter",
+    "hf_to_yolo": "nectar.ai.detection.datasets.hf_converter",
+    "generate_dataset_card": "nectar.ai.detection.datasets.hf_converter",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.detection.datasets.analyze import DatasetAnalyzer
+    from nectar.ai.detection.datasets.hf_converter import (
+        coco_to_hf,
+        generate_dataset_card,
+        hf_to_coco,
+        hf_to_yolo,
+        yolo_to_hf,
+    )
+    from nectar.ai.detection.datasets.merge import DatasetMerger
+    from nectar.ai.detection.datasets.stratify import Stratifier
+    from nectar.ai.detection.datasets.upload import (
+        HuggingFaceDatasetUploader,
+        RoboflowUploader,
+    )
+
 
 __all__ = [
     "FormatDetector",

--- a/nectar/nectar/ai/detection/datasets/analyze.py
+++ b/nectar/nectar/ai/detection/datasets/analyze.py
@@ -1,23 +1,19 @@
 """Dataset analysis and visualization."""
 
+import importlib.util
 import json
 import logging
 from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Dict, Optional
 
+import cv2
+import numpy as np
 import yaml
 
-try:
-    import cv2
-    import matplotlib.pyplot as plt
-    import numpy as np
-
-    MATPLOTLIB_AVAILABLE = True
-except ImportError:
-    MATPLOTLIB_AVAILABLE = False
-
 from nectar.ai.detection.datasets.format import FormatDetector
+
+MATPLOTLIB_AVAILABLE = importlib.util.find_spec("matplotlib") is not None
 
 logger = logging.getLogger(__name__)
 
@@ -330,6 +326,8 @@ class DatasetAnalyzer:
         self._print(f"Saved: {path}")
 
     def _plot_class_distribution(self, results: Dict, class_ids, labels, splits) -> None:
+        import matplotlib.pyplot as plt
+
         totals = [results["class_distribution"][cid] for cid in class_ids]
         sorted_idx = np.argsort(totals)[::-1]
         sorted_labels = [labels[i] for i in sorted_idx]
@@ -391,6 +389,8 @@ class DatasetAnalyzer:
         if not centers:
             return
 
+        import matplotlib.pyplot as plt
+
         grid_size = 100
         heatmap = np.zeros((grid_size, grid_size))
         for cx, cy in centers:
@@ -420,6 +420,8 @@ class DatasetAnalyzer:
         dims = [(w, h) for w, h in dims if w > 0 and h > 0]
         if not dims:
             return
+
+        import matplotlib.pyplot as plt
 
         widths = np.array([d[0] for d in dims])
         heights = np.array([d[1] for d in dims])
@@ -476,6 +478,8 @@ class DatasetAnalyzer:
         if len(sizes) == 0:
             return
 
+        import matplotlib.pyplot as plt
+
         fig, ax = plt.subplots(figsize=(10, 5))
         ax.hist(sizes, bins=60, color=_TEAL, alpha=0.85, edgecolor="white", linewidth=0.3)
         med = np.median(sizes)
@@ -503,6 +507,8 @@ class DatasetAnalyzer:
             all_api.extend(stats.get("annotations_per_image", []))
         if not all_api:
             return
+
+        import matplotlib.pyplot as plt
 
         api = np.array(all_api)
         null_count = int(np.sum(api == 0))

--- a/nectar/nectar/ai/detection/evaluation/__init__.py
+++ b/nectar/nectar/ai/detection/evaluation/__init__.py
@@ -2,7 +2,30 @@
 Evaluation module for detection models.
 """
 
-from nectar.ai.detection.evaluation.evaluator import ObjectDetectionEvaluator
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "ObjectDetectionEvaluator": "nectar.ai.detection.evaluation.evaluator",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.detection.evaluation.evaluator import ObjectDetectionEvaluator
+
 
 __all__ = [
     "ObjectDetectionEvaluator",

--- a/nectar/nectar/ai/detection/evaluation/visualizations.py
+++ b/nectar/nectar/ai/detection/evaluation/visualizations.py
@@ -1,13 +1,15 @@
-"""Visualization for evaluation"""
+"""Visualization for evaluation."""
 
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import cv2
-import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import supervision as sv
 
 try:
     import supervision as sv
@@ -35,6 +37,8 @@ def plot_pr_curve(
     output_dir: Path,
 ) -> str:
     """Plot Precision-Recall curve (Ultralytics style)."""
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     fig, ax = plt.subplots(1, 1, figsize=(9, 6), tight_layout=True)
 
@@ -79,6 +83,8 @@ def plot_confidence_curve(
     filename: str = "curve.png",
 ) -> str:
     """Plot metric-vs-confidence curve (Ultralytics mc_curve style)."""
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     fig, ax = plt.subplots(1, 1, figsize=(9, 6), tight_layout=True)
 
@@ -116,6 +122,8 @@ def plot_confusion_matrix(
     output_dir: Path,
     classes: List[str],
 ) -> str:
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     fig = cm.plot(classes=classes)
     fig.set_size_inches(12, 10)
@@ -133,6 +141,9 @@ def plot_error_analysis(
     class_names: List[str],
     output_dir: Path,
 ) -> str:
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
     output_dir.mkdir(parents=True, exist_ok=True)
     num_classes = len(class_names)
 
@@ -264,11 +275,13 @@ def plot_error_analysis(
 
 
 def plot_performance_analysis(
-    per_class_df: pd.DataFrame,
+    per_class_df: "pd.DataFrame",
     output_dir: Path,
 ) -> str:
     if per_class_df.empty or "ap50" not in per_class_df.columns:
         return ""
+
+    import matplotlib.pyplot as plt
 
     output_dir.mkdir(parents=True, exist_ok=True)
     fig, axes = plt.subplots(2, 1, figsize=(14, 10))
@@ -351,6 +364,8 @@ def plot_performance_analysis(
 
 
 def plot_metrics_summary(metrics: Dict[str, float], output_dir: Path) -> str:
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     fig, ax = plt.subplots(1, 1, figsize=(10, 5), tight_layout=True)
 
@@ -394,6 +409,9 @@ def plot_prediction_samples(
 ) -> Optional[str]:
     if not images or sv is None:
         return None
+
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     n = min(max_samples, len(images))
     indices = np.random.choice(len(images), n, replace=False)
@@ -448,6 +466,8 @@ def plot_prediction_samples(
 
 
 def save_per_class_metrics(per_class_metrics: List[Dict], output_dir: Path) -> Tuple[str, str]:
+    import pandas as pd
+
     output_dir.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame(per_class_metrics)
     csv_path = output_dir / "per_class_metrics.csv"

--- a/nectar/nectar/ai/detection/models/__init__.py
+++ b/nectar/nectar/ai/detection/models/__init__.py
@@ -1,19 +1,47 @@
 """
 Detection model implementations.
-
-Model implementations for different frameworks (Ultralytics, Transformers, RF-DETR).
 """
 
-from nectar.ai.detection.models.dataset import (
-    CocoDetectionDataset,
-    DetectionDataset,
-    collate_fn,
-    load_detection_dataset,
-)
-from nectar.ai.detection.models.model_loader import ModelLoader
-from nectar.ai.detection.models.rfdetr import RFDETRModel
-from nectar.ai.detection.models.transformers import TransformersModel
-from nectar.ai.detection.models.ultralytics import UltralyticsModel
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "ModelLoader": "nectar.ai.detection.models.model_loader",
+    "UltralyticsModel": "nectar.ai.detection.models.ultralytics",
+    "TransformersModel": "nectar.ai.detection.models.transformers",
+    "RFDETRModel": "nectar.ai.detection.models.rfdetr",
+    "CocoDetectionDataset": "nectar.ai.detection.models.dataset",
+    "DetectionDataset": "nectar.ai.detection.models.dataset",
+    "load_detection_dataset": "nectar.ai.detection.models.dataset",
+    "collate_fn": "nectar.ai.detection.models.dataset",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.detection.models.dataset import (
+        CocoDetectionDataset,
+        DetectionDataset,
+        collate_fn,
+        load_detection_dataset,
+    )
+    from nectar.ai.detection.models.model_loader import ModelLoader
+    from nectar.ai.detection.models.rfdetr import RFDETRModel
+    from nectar.ai.detection.models.transformers import TransformersModel
+    from nectar.ai.detection.models.ultralytics import UltralyticsModel
+
 
 __all__ = [
     "ModelLoader",

--- a/nectar/nectar/ai/segmentation/__init__.py
+++ b/nectar/nectar/ai/segmentation/__init__.py
@@ -12,7 +12,9 @@ Examples
 >>> result = segmentor.segment(image)
 """
 
-from nectar.ai.segmentation.core.base import BaseSegmentationModel
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.ai.segmentation.core.configs import (
     SegEvaluationConfig,
     SegEvaluationMetrics,
@@ -24,18 +26,53 @@ from nectar.ai.segmentation.core.types import (
     SegmentationResult,
     SegPrediction,
 )
-from nectar.ai.segmentation.datasets import (
-    RoboflowSegHandler,
-    SegDatasetAnalyzer,
-    SegDatasetHandlerRegistry,
-    SegFormatConverter,
-    UltralyticsSegHandler,
-)
-from nectar.ai.segmentation.evaluation.evaluator import SegmentationEvaluator
-from nectar.ai.segmentation.models.rfdetr import RFDETRSegModel
-from nectar.ai.segmentation.models.transformers import TransformersSegModel
-from nectar.ai.segmentation.models.ultralytics import UltralyticsSegModel
-from nectar.ai.segmentation.segmentor import Segmentor
+
+_LAZY_ATTRS = {
+    "BaseSegmentationModel": "nectar.ai.segmentation.core.base",
+    # Heavy: pull torch + framework
+    "Segmentor": "nectar.ai.segmentation.segmentor",
+    "RFDETRSegModel": "nectar.ai.segmentation.models.rfdetr",
+    "TransformersSegModel": "nectar.ai.segmentation.models.transformers",
+    "UltralyticsSegModel": "nectar.ai.segmentation.models.ultralytics",
+    # Pulls matplotlib via visualizations
+    "SegmentationEvaluator": "nectar.ai.segmentation.evaluation.evaluator",
+    # Datasets (re-exported)
+    "RoboflowSegHandler": "nectar.ai.segmentation.datasets",
+    "SegDatasetAnalyzer": "nectar.ai.segmentation.datasets",
+    "SegDatasetHandlerRegistry": "nectar.ai.segmentation.datasets",
+    "SegFormatConverter": "nectar.ai.segmentation.datasets",
+    "UltralyticsSegHandler": "nectar.ai.segmentation.datasets",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.segmentation.core.base import BaseSegmentationModel
+    from nectar.ai.segmentation.datasets import (
+        RoboflowSegHandler,
+        SegDatasetAnalyzer,
+        SegDatasetHandlerRegistry,
+        SegFormatConverter,
+        UltralyticsSegHandler,
+    )
+    from nectar.ai.segmentation.evaluation.evaluator import SegmentationEvaluator
+    from nectar.ai.segmentation.models.rfdetr import RFDETRSegModel
+    from nectar.ai.segmentation.models.transformers import TransformersSegModel
+    from nectar.ai.segmentation.models.ultralytics import UltralyticsSegModel
+    from nectar.ai.segmentation.segmentor import Segmentor
+
 
 __all__ = [
     # Facade

--- a/nectar/nectar/ai/segmentation/core/base.py
+++ b/nectar/nectar/ai/segmentation/core/base.py
@@ -4,14 +4,12 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import numpy as np
 
-try:
-    import supervision as sv
-except ImportError:
-    sv = None
+if TYPE_CHECKING:
+    pass
 
 from nectar.ai.detection.core.configs import TrainingResult
 from nectar.ai.segmentation.core.configs import (
@@ -72,6 +70,11 @@ class BaseSegmentationModel(ABC):
 
     def _predict_batch(self, seg_input: SegmentationInput) -> SegPrediction:
         """Run inference on a batch of images (default: sequential)."""
+        try:
+            import supervision as sv
+        except ImportError:
+            sv = None
+
         images = seg_input.image
         batch_detections = []
         image_paths = []
@@ -219,8 +222,12 @@ class BaseSegmentationModel(ABC):
         np.ndarray
             Annotated image.
         """
-        if sv is None:
-            raise ImportError("supervision is required. Install with: pip install supervision")
+        try:
+            import supervision as sv
+        except ImportError as e:
+            raise ImportError(
+                "supervision is required. Install with: pip install supervision"
+            ) from e
 
         if not result.segmentations:
             return image.copy()

--- a/nectar/nectar/ai/segmentation/core/types.py
+++ b/nectar/nectar/ai/segmentation/core/types.py
@@ -2,29 +2,20 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import numpy as np
-
-try:
-    import torch
-except ImportError:
-    torch = None
-
-try:
-    import supervision as sv
-except ImportError:
-    sv = None
-
-try:
-    from PIL import Image
-except ImportError:
-    Image = None
 
 try:
     import cv2
 except ImportError:
     cv2 = None
+
+if TYPE_CHECKING:
+    import supervision as sv
+    import torch
+    from PIL import Image
+
 
 ImageType = Union[str, Path, np.ndarray, "torch.Tensor", "Image.Image"]
 BatchImageType = Union[
@@ -199,8 +190,12 @@ class SegmentationResult:
 
     def to_supervision(self) -> "sv.Detections":
         """Convert instance segmentations to supervision Detections with masks."""
-        if sv is None:
-            raise ImportError("supervision is required. Install with: pip install supervision")
+        try:
+            import supervision as sv
+        except ImportError as e:
+            raise ImportError(
+                "supervision is required. Install with: pip install supervision"
+            ) from e
         if not self.segmentations:
             return sv.Detections.empty()
 
@@ -307,7 +302,11 @@ class SegmentationInput:
         """Check if input contains a batch of images."""
         if isinstance(self.image, (list, tuple)):
             return True
-        if torch is not None and isinstance(self.image, torch.Tensor):
+        try:
+            import torch
+        except ImportError:
+            return False
+        if isinstance(self.image, torch.Tensor):
             return self.image.dim() == 4
         return False
 

--- a/nectar/nectar/ai/segmentation/datasets/__init__.py
+++ b/nectar/nectar/ai/segmentation/datasets/__init__.py
@@ -1,11 +1,9 @@
 """Dataset management utilities for image segmentation."""
 
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.ai.detection.datasets.subset import SubsetCreator
-from nectar.ai.detection.datasets.upload import (
-    HuggingFaceDatasetUploader,
-    RoboflowUploader,
-)
-from nectar.ai.segmentation.datasets.analyze import SegDatasetAnalyzer
 from nectar.ai.segmentation.datasets.format import SegFormatConverter
 from nectar.ai.segmentation.datasets.handlers import (
     BaseDatasetHandler,
@@ -13,6 +11,34 @@ from nectar.ai.segmentation.datasets.handlers import (
     SegDatasetHandlerRegistry,
     UltralyticsSegHandler,
 )
+
+_LAZY_ATTRS = {
+    "SegDatasetAnalyzer": "nectar.ai.segmentation.datasets.analyze",
+    "RoboflowUploader": "nectar.ai.detection.datasets.upload",
+    "HuggingFaceDatasetUploader": "nectar.ai.detection.datasets.upload",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.detection.datasets.upload import (
+        HuggingFaceDatasetUploader,
+        RoboflowUploader,
+    )
+    from nectar.ai.segmentation.datasets.analyze import SegDatasetAnalyzer
+
 
 __all__ = [
     "SegFormatConverter",

--- a/nectar/nectar/ai/segmentation/datasets/analyze.py
+++ b/nectar/nectar/ai/segmentation/datasets/analyze.py
@@ -1,23 +1,19 @@
 """Segmentation dataset analysis and visualization."""
 
+import importlib.util
 import json
 import logging
 from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+import cv2
+import numpy as np
 import yaml
 
-try:
-    import cv2
-    import matplotlib.pyplot as plt
-    import numpy as np
-
-    MATPLOTLIB_AVAILABLE = True
-except ImportError:
-    MATPLOTLIB_AVAILABLE = False
-
 from nectar.ai.detection.datasets.format import FormatDetector
+
+MATPLOTLIB_AVAILABLE = importlib.util.find_spec("matplotlib") is not None
 
 logger = logging.getLogger(__name__)
 
@@ -417,6 +413,8 @@ class SegDatasetAnalyzer:
         self._print(f"Saved: {path}")
 
     def _plot_class_distribution(self, results: Dict, class_ids, labels, splits) -> None:
+        import matplotlib.pyplot as plt
+
         totals = [results["class_distribution"][cid] for cid in class_ids]
         sorted_idx = np.argsort(totals)[::-1]
         sorted_labels = [labels[i] for i in sorted_idx]
@@ -478,6 +476,8 @@ class SegDatasetAnalyzer:
         if len(areas) == 0:
             return
 
+        import matplotlib.pyplot as plt
+
         fig, ax = plt.subplots(figsize=(10, 5))
         ax.hist(areas, bins=60, color=_TEAL, alpha=0.85, edgecolor="white", linewidth=0.3)
         med = float(np.median(areas))
@@ -499,6 +499,8 @@ class SegDatasetAnalyzer:
             all_api.extend(stats.get("annotations_per_image", []))
         if not all_api:
             return
+
+        import matplotlib.pyplot as plt
 
         api = np.array(all_api)
         null_count = int(np.sum(api == 0))
@@ -546,6 +548,8 @@ class SegDatasetAnalyzer:
         dims = [(w, h) for w, h in results.get("image_dims", []) if w > 0 and h > 0]
         if not dims:
             return
+
+        import matplotlib.pyplot as plt
 
         widths = np.array([d[0] for d in dims])
         heights = np.array([d[1] for d in dims])

--- a/nectar/nectar/ai/segmentation/evaluation/__init__.py
+++ b/nectar/nectar/ai/segmentation/evaluation/__init__.py
@@ -1,5 +1,28 @@
 """Segmentation evaluation."""
 
-from nectar.ai.segmentation.evaluation.evaluator import SegmentationEvaluator
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "SegmentationEvaluator": "nectar.ai.segmentation.evaluation.evaluator",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.segmentation.evaluation.evaluator import SegmentationEvaluator
+
 
 __all__ = ["SegmentationEvaluator"]

--- a/nectar/nectar/ai/segmentation/evaluation/visualizations.py
+++ b/nectar/nectar/ai/segmentation/evaluation/visualizations.py
@@ -7,12 +7,14 @@ samples instead of ``BoxAnnotator``.
 import json
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import cv2
-import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import supervision as sv
 
 try:
     import supervision as sv
@@ -46,6 +48,8 @@ def plot_pr_curve(
     title: str = "Precision-Recall Curve",
     filename: str = "PR_curve.png",
 ) -> str:
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     fig, ax = plt.subplots(1, 1, figsize=(9, 6), tight_layout=True)
 
@@ -80,6 +84,8 @@ def plot_confidence_curve(
     ylabel: str = "Metric",
     filename: str = "curve.png",
 ) -> str:
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     fig, ax = plt.subplots(1, 1, figsize=(9, 6), tight_layout=True)
 
@@ -122,6 +128,8 @@ def plot_confusion_matrix(
     output_dir: Path,
     classes: List[str],
 ) -> str:
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     fig = cm.plot(classes=classes)
     fig.set_size_inches(12, 10)
@@ -144,6 +152,9 @@ def plot_error_analysis(
     class_names: List[str],
     output_dir: Path,
 ) -> str:
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
     output_dir.mkdir(parents=True, exist_ok=True)
     num_classes = len(class_names)
 
@@ -262,9 +273,11 @@ def plot_error_analysis(
 # ---------------------------------------------------------------------------
 
 
-def plot_performance_analysis(per_class_df: pd.DataFrame, output_dir: Path) -> str:
+def plot_performance_analysis(per_class_df: "pd.DataFrame", output_dir: Path) -> str:
     if per_class_df.empty or "ap50" not in per_class_df.columns:
         return ""
+
+    import matplotlib.pyplot as plt
 
     output_dir.mkdir(parents=True, exist_ok=True)
     fig, axes = plt.subplots(2, 1, figsize=(14, 10))
@@ -350,6 +363,8 @@ def plot_performance_analysis(per_class_df: pd.DataFrame, output_dir: Path) -> s
 
 
 def plot_metrics_summary(metrics: Dict[str, float], output_dir: Path) -> str:
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
 
     has_box = "box_map50" in metrics
@@ -411,6 +426,9 @@ def plot_prediction_samples(
 ) -> Optional[str]:
     if not images or sv is None:
         return None
+
+    import matplotlib.pyplot as plt
+
     output_dir.mkdir(parents=True, exist_ok=True)
     n = min(max_samples, len(images))
     indices = np.random.choice(len(images), n, replace=False)
@@ -477,6 +495,8 @@ def plot_prediction_samples(
 
 
 def save_per_class_metrics(per_class_metrics: List[Dict], output_dir: Path) -> Tuple[str, str]:
+    import pandas as pd
+
     output_dir.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame(per_class_metrics)
     csv_path = output_dir / "per_class_metrics.csv"

--- a/nectar/nectar/ai/segmentation/models/__init__.py
+++ b/nectar/nectar/ai/segmentation/models/__init__.py
@@ -1,12 +1,43 @@
-"""Segmentation model implementations."""
+"""Segmentation model implementations.
 
-from nectar.ai.segmentation.models.dataset import (
-    SegmentationDataset,
-    load_segmentation_dataset,
-)
-from nectar.ai.segmentation.models.rfdetr import RFDETRSegModel
-from nectar.ai.segmentation.models.transformers import TransformersSegModel
-from nectar.ai.segmentation.models.ultralytics import UltralyticsSegModel
+Each model class is loaded lazily. Importing this package does
+not pull torch / ultralytics / transformers / rfdetr.
+"""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "RFDETRSegModel": "nectar.ai.segmentation.models.rfdetr",
+    "TransformersSegModel": "nectar.ai.segmentation.models.transformers",
+    "UltralyticsSegModel": "nectar.ai.segmentation.models.ultralytics",
+    "SegmentationDataset": "nectar.ai.segmentation.models.dataset",
+    "load_segmentation_dataset": "nectar.ai.segmentation.models.dataset",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.ai.segmentation.models.dataset import (
+        SegmentationDataset,
+        load_segmentation_dataset,
+    )
+    from nectar.ai.segmentation.models.rfdetr import RFDETRSegModel
+    from nectar.ai.segmentation.models.transformers import TransformersSegModel
+    from nectar.ai.segmentation.models.ultralytics import UltralyticsSegModel
+
 
 __all__ = [
     "UltralyticsSegModel",

--- a/nectar/nectar/control/__init__.py
+++ b/nectar/nectar/control/__init__.py
@@ -61,7 +61,6 @@ _LAZY_ATTRS = {
     "GPSUtils": "nectar.control.mavros.gps_utils",
     # Camera-based obstacle detectors (pyrealsense2 / sklearn)
     "DepthObstacleDetector": "nectar.control.obstacles.depth_camera",
-    "T265ObstacleDetector": "nectar.control.obstacles.t265_obstacle",
 }
 
 
@@ -85,7 +84,6 @@ if TYPE_CHECKING:
     from nectar.control.mavros.gps_utils import GPSUtils
     from nectar.control.mavros.navigator import MavrosNavigator
     from nectar.control.obstacles.depth_camera import DepthObstacleDetector
-    from nectar.control.obstacles.t265_obstacle import T265ObstacleDetector
 
 
 __all__ = [
@@ -124,7 +122,6 @@ __all__ = [
     "GPSUtils",
     "BaseObstacleDetector",
     "DepthObstacleDetector",
-    "T265ObstacleDetector",
     "ObstacleInfo",
     "ObstacleDirection",
     "ObstacleHandlerConfig",

--- a/nectar/nectar/control/__init__.py
+++ b/nectar/nectar/control/__init__.py
@@ -1,5 +1,9 @@
+"""Nectar SDK - Control module."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.control.base import BaseDrone
-from nectar.control.bebop import BebopDrone
 from nectar.control.config import (
     SITL_CONFIG,
     SITL_GAZEBO_CONFIG,
@@ -10,7 +14,6 @@ from nectar.control.config import (
     DroneConfig,
     MavrosConfig,
 )
-from nectar.control.crazyflie import CrazyflieDrone
 from nectar.control.driver_monitor import (
     DRIVER_INFO,
     DriverInfo,
@@ -25,16 +28,14 @@ from nectar.control.exceptions import (
     TakeoffPositionNotSetError,
 )
 from nectar.control.factory import DroneFactory
-from nectar.control.mavros import GPSUtils, MavrosDrone, SetpointNavConfig
+from nectar.control.mavros import SetpointNavConfig
 from nectar.control.obstacles import (
     BaseObstacleDetector,
-    DepthObstacleDetector,
     ObstacleDirection,
     ObstacleHandler,
     ObstacleHandlerConfig,
     ObstacleInfo,
     ObstacleManager,
-    T265ObstacleDetector,
     strategies,
 )
 from nectar.control.pid import (
@@ -49,6 +50,43 @@ from nectar.control.types import (
     PoseSource,
     RTLMethod,
 )
+
+_LAZY_ATTRS = {
+    # Concrete drones (heavy: MAVROS / olympe / cflib)
+    "MavrosDrone": "nectar.control.mavros.drone",
+    "MavrosNavigator": "nectar.control.mavros.navigator",
+    "BebopDrone": "nectar.control.bebop.drone",
+    "CrazyflieDrone": "nectar.control.crazyflie.drone",
+    # GPS helpers (pull geopy + pygeodesy; only used for GPS missions)
+    "GPSUtils": "nectar.control.mavros.gps_utils",
+    # Camera-based obstacle detectors (pyrealsense2 / sklearn)
+    "DepthObstacleDetector": "nectar.control.obstacles.depth_camera",
+    "T265ObstacleDetector": "nectar.control.obstacles.t265_obstacle",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.control.bebop.drone import BebopDrone
+    from nectar.control.crazyflie.drone import CrazyflieDrone
+    from nectar.control.mavros.drone import MavrosDrone
+    from nectar.control.mavros.gps_utils import GPSUtils
+    from nectar.control.mavros.navigator import MavrosNavigator
+    from nectar.control.obstacles.depth_camera import DepthObstacleDetector
+    from nectar.control.obstacles.t265_obstacle import T265ObstacleDetector
+
 
 __all__ = [
     "MoveReference",
@@ -80,6 +118,7 @@ __all__ = [
     "SetpointNavConfig",
     "BaseDrone",
     "MavrosDrone",
+    "MavrosNavigator",
     "BebopDrone",
     "CrazyflieDrone",
     "GPSUtils",

--- a/nectar/nectar/control/bebop/__init__.py
+++ b/nectar/nectar/control/bebop/__init__.py
@@ -1,5 +1,28 @@
-from nectar.control.bebop.drone import BebopDrone
+"""Parrot Bebop drone control."""
 
-__all__ = [
-    "BebopDrone",
-]
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "BebopDrone": "nectar.control.bebop.drone",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.control.bebop.drone import BebopDrone
+
+
+__all__ = ["BebopDrone"]

--- a/nectar/nectar/control/crazyflie/__init__.py
+++ b/nectar/nectar/control/crazyflie/__init__.py
@@ -1,5 +1,28 @@
-from nectar.control.crazyflie.drone import CrazyflieDrone
+"""Crazyflie drone control."""
 
-__all__ = [
-    "CrazyflieDrone",
-]
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "CrazyflieDrone": "nectar.control.crazyflie.drone",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.control.crazyflie.drone import CrazyflieDrone
+
+
+__all__ = ["CrazyflieDrone"]

--- a/nectar/nectar/control/factory.py
+++ b/nectar/nectar/control/factory.py
@@ -1,4 +1,5 @@
-from typing import Callable, Dict
+from importlib import import_module
+from typing import Callable, Dict, Tuple
 
 from rclpy.node import Node
 
@@ -6,6 +7,16 @@ from nectar.control.config import DroneConfig
 from nectar.control.protocols import Drone
 
 BuilderFunc = Callable[[DroneConfig, Node], Drone]
+
+# Built-in drone types are lazy-loaded so importing ``nectar.control`` does
+# not pull MAVROS / olympe (Bebop) / cflib (Crazyflie) until needed.
+# Each entry: drone_type -> (module_path, class_name); ``<class>.from_config``
+# is used as the builder.
+_BUILTINS: Dict[str, Tuple[str, str]] = {
+    "mavros": ("nectar.control.mavros.drone", "MavrosDrone"),
+    "bebop": ("nectar.control.bebop.drone", "BebopDrone"),
+    "crazyflie": ("nectar.control.crazyflie.drone", "CrazyflieDrone"),
+}
 
 
 class DroneFactory:
@@ -28,6 +39,31 @@ class DroneFactory:
             Factory function with signature (DroneConfig, Node) -> Drone.
         """
         cls._builders[drone_type.lower()] = builder
+
+    @classmethod
+    def _resolve(cls, drone_type: str) -> BuilderFunc:
+        """Resolve a builder, lazy-importing built-ins on first use."""
+        key = drone_type.lower()
+        builder = cls._builders.get(key)
+        if builder is not None:
+            return builder
+
+        target = _BUILTINS.get(key)
+        if target is None:
+            available = ", ".join(sorted({*cls._builders, *_BUILTINS}))
+            raise ValueError(f"Unknown drone type: '{drone_type}'. Available types: {available}")
+
+        module_path, class_name = target
+        # Importing the drone module triggers its own bottom-of-file
+        # ``DroneFactory.register(...)`` call, populating ``_builders``.
+        import_module(module_path)
+        builder = cls._builders.get(key)
+        if builder is None:
+            # Fallback if the module did not self-register: read class directly.
+            cls_obj = getattr(import_module(module_path), class_name)
+            builder = cls_obj.from_config
+            cls._builders[key] = builder
+        return builder
 
     @classmethod
     def create(
@@ -58,11 +94,7 @@ class DroneFactory:
         ValueError
             If drone_type not registered.
         """
-        builder = cls._builders.get(drone_type.lower())
-        if not builder:
-            available = ", ".join(cls._builders.keys())
-            raise ValueError(f"Unknown drone type: '{drone_type}'. Available types: {available}")
-        return builder(config, node)
+        return cls._resolve(drone_type)(config, node)
 
     @classmethod
     def available_types(cls) -> list[str]:
@@ -72,9 +104,10 @@ class DroneFactory:
         Returns
         -------
         list[str]
-            Available drone type identifiers.
+            Available drone type identifiers, including built-ins that
+            have not been imported yet.
         """
-        return list(cls._builders.keys())
+        return sorted({*cls._builders, *_BUILTINS})
 
     @classmethod
     def is_registered(cls, drone_type: str) -> bool:
@@ -89,6 +122,7 @@ class DroneFactory:
         Returns
         -------
         bool
-            True if type is registered.
+            True if type is registered (explicitly or as a built-in).
         """
-        return drone_type.lower() in cls._builders
+        key = drone_type.lower()
+        return key in cls._builders or key in _BUILTINS

--- a/nectar/nectar/control/mavros/__init__.py
+++ b/nectar/nectar/control/mavros/__init__.py
@@ -1,8 +1,37 @@
-from nectar.control.mavros.drone import MavrosDrone
-from nectar.control.mavros.gps_utils import GPSUtils
-from nectar.control.mavros.navigator import MavrosNavigator
+"""MAVROS drone control."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.control.mavros.setpoint_config import SetpointNavConfig
-from nectar.control.mavros.target_computer import TargetComputer
+
+_LAZY_ATTRS = {
+    "GPSUtils": "nectar.control.mavros.gps_utils",
+    "MavrosDrone": "nectar.control.mavros.drone",
+    "MavrosNavigator": "nectar.control.mavros.navigator",
+    "TargetComputer": "nectar.control.mavros.target_computer",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.control.mavros.drone import MavrosDrone
+    from nectar.control.mavros.gps_utils import GPSUtils
+    from nectar.control.mavros.navigator import MavrosNavigator
+    from nectar.control.mavros.target_computer import TargetComputer
+
 
 __all__ = [
     "MavrosDrone",

--- a/nectar/nectar/control/obstacles/__init__.py
+++ b/nectar/nectar/control/obstacles/__init__.py
@@ -1,13 +1,42 @@
+"""Obstacle detection and avoidance."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.control.obstacles import strategies
 from nectar.control.obstacles.base import BaseObstacleDetector
-from nectar.control.obstacles.depth_camera import DepthObstacleDetector
 from nectar.control.obstacles.handler import ObstacleHandler, ObstacleManager
 from nectar.control.obstacles.types import ObstacleHandlerConfig
 from nectar.control.protocols import ObstacleDirection, ObstacleInfo
 
+_LAZY_ATTRS = {
+    "DepthObstacleDetector": "nectar.control.obstacles.depth_camera",
+    "T265ObstacleDetector": "nectar.control.obstacles.t265_obstacle",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.control.obstacles.depth_camera import DepthObstacleDetector
+    from nectar.control.obstacles.t265_obstacle import T265ObstacleDetector
+
+
 __all__ = [
     "BaseObstacleDetector",
     "DepthObstacleDetector",
+    "T265ObstacleDetector",
     "ObstacleHandlerConfig",
     "ObstacleHandler",
     "ObstacleManager",

--- a/nectar/nectar/control/obstacles/__init__.py
+++ b/nectar/nectar/control/obstacles/__init__.py
@@ -11,7 +11,6 @@ from nectar.control.protocols import ObstacleDirection, ObstacleInfo
 
 _LAZY_ATTRS = {
     "DepthObstacleDetector": "nectar.control.obstacles.depth_camera",
-    "T265ObstacleDetector": "nectar.control.obstacles.t265_obstacle",
 }
 
 
@@ -30,13 +29,11 @@ def __dir__():
 
 if TYPE_CHECKING:
     from nectar.control.obstacles.depth_camera import DepthObstacleDetector
-    from nectar.control.obstacles.t265_obstacle import T265ObstacleDetector
 
 
 __all__ = [
     "BaseObstacleDetector",
     "DepthObstacleDetector",
-    "T265ObstacleDetector",
     "ObstacleHandlerConfig",
     "ObstacleHandler",
     "ObstacleManager",

--- a/nectar/nectar/interface/tabs/vision_tab.py
+++ b/nectar/nectar/interface/tabs/vision_tab.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 if TYPE_CHECKING:
     pass
 import json
+import logging
 import os
 import time
 
@@ -34,6 +35,8 @@ from nectar.interface.widgets import (
     DualVideoDisplay,
     LabeledSlider,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ColorCalibrationManager:
@@ -2074,12 +2077,15 @@ class OpenCVUtils:
                 self._hand_tracker.start()
             except Exception as e:
                 self._hand_init_failed = True
-                print(f"[nectar] HandTracker init failed: {e}")
+                logger.error("HandTracker init failed: %s", e, exc_info=True)
                 return frame
 
         try:
             return self._hand_tracker.detect(frame, draw=True)
-        except Exception:
+        except Exception as e:
+            if not getattr(self, "_hand_detect_warned", False):
+                self._hand_detect_warned = True
+                logger.error("HandTracker.detect failed: %s", e, exc_info=True)
             return frame
 
     def detect_faces(self, frame: np.ndarray) -> np.ndarray:
@@ -2094,12 +2100,15 @@ class OpenCVUtils:
                 self._face_tracker.start()
             except Exception as e:
                 self._face_init_failed = True
-                print(f"[nectar] FaceMeshTracker init failed: {e}")
+                logger.error("FaceMeshTracker init failed: %s", e, exc_info=True)
                 return frame
 
         try:
             return self._face_tracker.detect(frame, draw=True)
-        except Exception:
+        except Exception as e:
+            if not getattr(self, "_face_detect_warned", False):
+                self._face_detect_warned = True
+                logger.error("FaceMeshTracker.detect failed: %s", e, exc_info=True)
             return frame
 
     def detect_aruco_markers(self, frame: np.ndarray, dict_type: str) -> np.ndarray:

--- a/nectar/nectar/vision/__init__.py
+++ b/nectar/nectar/vision/__init__.py
@@ -1,66 +1,126 @@
+"""Nectar SDK - Vision module."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.vision.algorithms import (
     AdaptiveHoughLinesP,
     Aruco,
-    CalibrationResult,
     ColorDetector,
     ColorSpace,
     DistanceEstimator,
-    FaceLandmarkRegion,
-    FaceMeshTracker,
-    FaceMeshTrackerConfig,
-    FaceResult,
     FitEllipse,
-    HandLandmark,
-    HandResult,
-    # MediaPipe
-    HandTracker,
-    HandTrackerConfig,
     HoughLinesP,
     ILineEstimationMethod,
     LineDetector,
-    ModelCalibrator,
     ModelType,
     RansacLine,
     RotatedRect,
 )
 from nectar.vision.camera import (
     AbstractCam,
-    C920Cam,
     C920Config,
     Calibration,
     CameraConfig,
     CameraFactory,
     DepthCam,
-    FileImageCam,
     FileImageConfig,
     ImageHandler,
-    IMX219Cam,
     IMX219Config,
-    OakdCam,
-    OakdCameraResolution,
     OakDConfig,
-    OpenCVCam,
     OpenCVConfig,
     QoSDurability,
     QoSReliability,
-    RealsenseCam,
     RealSenseConfig,
-    ROSCam,
     ROSConfig,
-    ROSDepthCam,
     ROSDepthConfig,
-    T265Cam,
     T265Config,
-    T265Pose,
 )
-from nectar.vision.nodes import (
-    ArucoNode,
-    CameraPublisherNode,
-    ClickColorCalibrationNode,
-    ColorCalibrationNode,
-    LineDetectionNode,
-)
-from nectar.vision.utils import ImageCalculus
+
+_LAZY_ATTRS = {
+    # ImageCalculus pulls geopy (geodesic distance helpers)
+    "ImageCalculus": "nectar.vision.utils",
+    # Distance calibration (matplotlib)
+    "ModelCalibrator": "nectar.vision.algorithms",
+    "CalibrationResult": "nectar.vision.algorithms",
+    # MediaPipe (TFLite)
+    "FaceLandmarkRegion": "nectar.vision.algorithms",
+    "FaceMeshTracker": "nectar.vision.algorithms",
+    "FaceMeshTrackerConfig": "nectar.vision.algorithms",
+    "FaceResult": "nectar.vision.algorithms",
+    "HandLandmark": "nectar.vision.algorithms",
+    "HandResult": "nectar.vision.algorithms",
+    "HandTracker": "nectar.vision.algorithms",
+    "HandTrackerConfig": "nectar.vision.algorithms",
+    # Camera drivers (pyrealsense2 / depthai / cv2 backends)
+    "C920Cam": "nectar.vision.camera",
+    "FileImageCam": "nectar.vision.camera",
+    "IMX219Cam": "nectar.vision.camera",
+    "OakdCam": "nectar.vision.camera",
+    "OakdCameraResolution": "nectar.vision.camera",
+    "OpenCVCam": "nectar.vision.camera",
+    "RealsenseCam": "nectar.vision.camera",
+    "ROSCam": "nectar.vision.camera",
+    "ROSDepthCam": "nectar.vision.camera",
+    "T265Cam": "nectar.vision.camera",
+    "T265Pose": "nectar.vision.camera",
+    # ROS 2 nodes (entry points; imported only when explicitly requested)
+    "ArucoNode": "nectar.vision.nodes",
+    "CameraPublisherNode": "nectar.vision.nodes",
+    "ClickColorCalibrationNode": "nectar.vision.nodes",
+    "ColorCalibrationNode": "nectar.vision.nodes",
+    "LineDetectionNode": "nectar.vision.nodes",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.vision.algorithms import (
+        CalibrationResult,
+        FaceLandmarkRegion,
+        FaceMeshTracker,
+        FaceMeshTrackerConfig,
+        FaceResult,
+        HandLandmark,
+        HandResult,
+        HandTracker,
+        HandTrackerConfig,
+        ModelCalibrator,
+    )
+    from nectar.vision.camera import (
+        C920Cam,
+        FileImageCam,
+        IMX219Cam,
+        OakdCam,
+        OakdCameraResolution,
+        OpenCVCam,
+        RealsenseCam,
+        ROSCam,
+        ROSDepthCam,
+        T265Cam,
+        T265Pose,
+    )
+    from nectar.vision.nodes import (
+        ArucoNode,
+        CameraPublisherNode,
+        ClickColorCalibrationNode,
+        ColorCalibrationNode,
+        LineDetectionNode,
+    )
+    from nectar.vision.utils import ImageCalculus
+
 
 __all__ = [
     # Camera

--- a/nectar/nectar/vision/algorithms/__init__.py
+++ b/nectar/nectar/vision/algorithms/__init__.py
@@ -1,9 +1,14 @@
+"""Vision algorithms (markers, color, line, distance, MediaPipe)."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from .color import ColorDetector, ColorSpace
 from .distance import (
-    CalibrationResult,
     DistanceEstimator,
-    ModelCalibrator,
+    EstimationModel,
     ModelType,
+    create_model,
 )
 from .line import (
     AdaptiveHoughLinesP,
@@ -15,16 +20,49 @@ from .line import (
     RotatedRect,
 )
 from .markers import Aruco
-from .mediapipe import (
-    FaceLandmarkRegion,
-    FaceMeshTracker,
-    FaceMeshTrackerConfig,
-    FaceResult,
-    HandLandmark,
-    HandResult,
-    HandTracker,
-    HandTrackerConfig,
-)
+
+_LAZY_ATTRS = {
+    # Distance calibration (matplotlib)
+    "ModelCalibrator": "nectar.vision.algorithms.distance",
+    "CalibrationResult": "nectar.vision.algorithms.distance",
+    # MediaPipe (TFLite)
+    "FaceLandmarkRegion": "nectar.vision.algorithms.mediapipe",
+    "FaceMeshTracker": "nectar.vision.algorithms.mediapipe",
+    "FaceMeshTrackerConfig": "nectar.vision.algorithms.mediapipe",
+    "FaceResult": "nectar.vision.algorithms.mediapipe",
+    "HandLandmark": "nectar.vision.algorithms.mediapipe",
+    "HandResult": "nectar.vision.algorithms.mediapipe",
+    "HandTracker": "nectar.vision.algorithms.mediapipe",
+    "HandTrackerConfig": "nectar.vision.algorithms.mediapipe",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from .distance import CalibrationResult, ModelCalibrator
+    from .mediapipe import (
+        FaceLandmarkRegion,
+        FaceMeshTracker,
+        FaceMeshTrackerConfig,
+        FaceResult,
+        HandLandmark,
+        HandResult,
+        HandTracker,
+        HandTrackerConfig,
+    )
+
 
 __all__ = [
     # Markers
@@ -43,6 +81,8 @@ __all__ = [
     # Distance
     "DistanceEstimator",
     "ModelType",
+    "EstimationModel",
+    "create_model",
     "ModelCalibrator",
     "CalibrationResult",
     # MediaPipe

--- a/nectar/nectar/vision/algorithms/distance/__init__.py
+++ b/nectar/nectar/vision/algorithms/distance/__init__.py
@@ -30,16 +30,42 @@ Example
 >>> distance_cm = estimator.estimate(pixel_height=25.0)
 """
 
-from nectar.vision.algorithms.distance.calibrator import (
-    CalibrationResult,
-    ModelCalibrator,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.vision.algorithms.distance.estimator import DistanceEstimator
 from nectar.vision.algorithms.distance.models import (
     EstimationModel,
     ModelType,
     create_model,
 )
+
+_LAZY_ATTRS = {
+    # Pulls matplotlib for calibration plots
+    "ModelCalibrator": "nectar.vision.algorithms.distance.calibrator",
+    "CalibrationResult": "nectar.vision.algorithms.distance.calibrator",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.vision.algorithms.distance.calibrator import (
+        CalibrationResult,
+        ModelCalibrator,
+    )
+
 
 __all__ = [
     "ModelType",

--- a/nectar/nectar/vision/algorithms/distance/calibrator.py
+++ b/nectar/nectar/vision/algorithms/distance/calibrator.py
@@ -3,12 +3,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import matplotlib
 import numpy as np
 import yaml
-
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 
 from nectar.vision.algorithms.distance.models import (
     ModelType,
@@ -269,6 +265,11 @@ class ModelCalibrator:
         """
         if not self.results:
             raise ValueError("No models fitted. Call fit_all() first.")
+
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
 
         fig, axes = plt.subplots(2, 2, figsize=(14, 10))
         colors = plt.cm.tab10(np.linspace(0, 1, len(self.results)))

--- a/nectar/nectar/vision/algorithms/mediapipe/__init__.py
+++ b/nectar/nectar/vision/algorithms/mediapipe/__init__.py
@@ -1,17 +1,48 @@
 """MediaPipe tracking solutions for hands and faces."""
 
-from .face_tracker import (
-    FaceLandmarkRegion,
-    FaceMeshTracker,
-    FaceMeshTrackerConfig,
-    FaceResult,
-)
-from .hand_tracker import (
-    HandLandmark,
-    HandResult,
-    HandTracker,
-    HandTrackerConfig,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    # Pull mediapipe (TFLite)
+    "FaceLandmarkRegion": "nectar.vision.algorithms.mediapipe.face_tracker",
+    "FaceMeshTracker": "nectar.vision.algorithms.mediapipe.face_tracker",
+    "FaceMeshTrackerConfig": "nectar.vision.algorithms.mediapipe.face_tracker",
+    "FaceResult": "nectar.vision.algorithms.mediapipe.face_tracker",
+    "HandLandmark": "nectar.vision.algorithms.mediapipe.hand_tracker",
+    "HandResult": "nectar.vision.algorithms.mediapipe.hand_tracker",
+    "HandTracker": "nectar.vision.algorithms.mediapipe.hand_tracker",
+    "HandTrackerConfig": "nectar.vision.algorithms.mediapipe.hand_tracker",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from .face_tracker import (
+        FaceLandmarkRegion,
+        FaceMeshTracker,
+        FaceMeshTrackerConfig,
+        FaceResult,
+    )
+    from .hand_tracker import (
+        HandLandmark,
+        HandResult,
+        HandTracker,
+        HandTrackerConfig,
+    )
+
 
 __all__ = [
     # Hand tracking

--- a/nectar/nectar/vision/camera/__init__.py
+++ b/nectar/nectar/vision/camera/__init__.py
@@ -1,3 +1,8 @@
+"""Camera package."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from nectar.vision.camera.abstract import AbstractCam, DepthCam
 from nectar.vision.camera.calibration import Calibration
 from nectar.vision.camera.config import (
@@ -15,21 +20,48 @@ from nectar.vision.camera.config import (
     T265Config,
 )
 from nectar.vision.camera.config_builder import ConfigBuilder
-from nectar.vision.camera.drivers import (
-    C920Cam,
-    FileImageCam,
-    IMX219Cam,
-    OakdCam,
-    OakdCameraResolution,
-    OpenCVCam,
-    RealsenseCam,
-    ROSCam,
-    ROSDepthCam,
-    T265Cam,
-    T265Pose,
-)
 from nectar.vision.camera.factory import CameraFactory
 from nectar.vision.camera.handler import ImageHandler
+
+_LAZY_ATTRS = {
+    "C920Cam": "nectar.vision.camera.drivers.c920_cam",
+    "FileImageCam": "nectar.vision.camera.drivers.file_cam",
+    "IMX219Cam": "nectar.vision.camera.drivers.imx219_cam",
+    "OakdCam": "nectar.vision.camera.drivers.oakd_cam",
+    "OakdCameraResolution": "nectar.vision.camera.drivers.oakd_cam",
+    "OpenCVCam": "nectar.vision.camera.drivers.opencv_cam",
+    "RealsenseCam": "nectar.vision.camera.drivers.realsense_cam",
+    "ROSCam": "nectar.vision.camera.drivers.ros_cam",
+    "ROSDepthCam": "nectar.vision.camera.drivers.ros_depth_cam",
+    "T265Cam": "nectar.vision.camera.drivers.t265_cam",
+    "T265Pose": "nectar.vision.camera.drivers.t265_cam",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.vision.camera.drivers.c920_cam import C920Cam
+    from nectar.vision.camera.drivers.file_cam import FileImageCam
+    from nectar.vision.camera.drivers.imx219_cam import IMX219Cam
+    from nectar.vision.camera.drivers.oakd_cam import OakdCam, OakdCameraResolution
+    from nectar.vision.camera.drivers.opencv_cam import OpenCVCam
+    from nectar.vision.camera.drivers.realsense_cam import RealsenseCam
+    from nectar.vision.camera.drivers.ros_cam import ROSCam
+    from nectar.vision.camera.drivers.ros_depth_cam import ROSDepthCam
+    from nectar.vision.camera.drivers.t265_cam import T265Cam, T265Pose
+
 
 __all__ = [
     "AbstractCam",

--- a/nectar/nectar/vision/camera/drivers/__init__.py
+++ b/nectar/nectar/vision/camera/drivers/__init__.py
@@ -1,12 +1,47 @@
-from .c920_cam import C920Cam
-from .file_cam import FileImageCam
-from .imx219_cam import IMX219Cam
-from .oakd_cam import OakdCam, OakdCameraResolution
-from .opencv_cam import OpenCVCam
-from .realsense_cam import RealsenseCam
-from .ros_cam import ROSCam
-from .ros_depth_cam import ROSDepthCam
-from .t265_cam import T265Cam, T265Pose
+"""Camera driver implementations."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "C920Cam": "nectar.vision.camera.drivers.c920_cam",
+    "FileImageCam": "nectar.vision.camera.drivers.file_cam",
+    "IMX219Cam": "nectar.vision.camera.drivers.imx219_cam",
+    "OakdCam": "nectar.vision.camera.drivers.oakd_cam",
+    "OakdCameraResolution": "nectar.vision.camera.drivers.oakd_cam",
+    "OpenCVCam": "nectar.vision.camera.drivers.opencv_cam",
+    "RealsenseCam": "nectar.vision.camera.drivers.realsense_cam",
+    "ROSCam": "nectar.vision.camera.drivers.ros_cam",
+    "ROSDepthCam": "nectar.vision.camera.drivers.ros_depth_cam",
+    "T265Cam": "nectar.vision.camera.drivers.t265_cam",
+    "T265Pose": "nectar.vision.camera.drivers.t265_cam",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from .c920_cam import C920Cam
+    from .file_cam import FileImageCam
+    from .imx219_cam import IMX219Cam
+    from .oakd_cam import OakdCam, OakdCameraResolution
+    from .opencv_cam import OpenCVCam
+    from .realsense_cam import RealsenseCam
+    from .ros_cam import ROSCam
+    from .ros_depth_cam import ROSDepthCam
+    from .t265_cam import T265Cam, T265Pose
+
 
 __all__ = [
     "FileImageCam",

--- a/nectar/nectar/vision/camera/factory.py
+++ b/nectar/nectar/vision/camera/factory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Optional, Type
+from typing import Callable, Dict, Optional
 
 from rclpy.node import Node
 
@@ -18,42 +18,132 @@ from nectar.vision.camera.config import (
     ROSDepthConfig,
     T265Config,
 )
-from nectar.vision.camera.drivers import (
-    C920Cam,
-    FileImageCam,
-    IMX219Cam,
-    OakdCam,
-    OpenCVCam,
-    RealsenseCam,
-    ROSCam,
-    ROSDepthCam,
-    T265Cam,
-)
+
+# Builder signature: (config, node) -> AbstractCam.
+# Each built-in builder lazily imports its driver module so that the
+# factory module itself does not pull pyrealsense2, depthai, etc.
+_BuilderFunc = Callable[[Optional[CameraConfig], Optional[Node]], AbstractCam]
+
+
+def _build_opencv(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.opencv_cam import OpenCVCam
+
+    return OpenCVCam(config or OpenCVConfig())
+
+
+def _build_c920(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.c920_cam import C920Cam
+
+    return C920Cam(config or C920Config())
+
+
+def _build_imx219(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.imx219_cam import IMX219Cam
+
+    return IMX219Cam(config or IMX219Config())
+
+
+def _build_realsense(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.realsense_cam import RealsenseCam
+
+    cfg = config or RealSenseConfig()
+    if isinstance(cfg, RealSenseConfig) and cfg.use_ros_topics:
+        if node is None:
+            raise ValueError(
+                "RealsenseCam with use_ros_topics=True requires a ROS node. "
+                "Consider using ROSDepthCam instead."
+            )
+        return RealsenseCam(cfg, node)
+    return RealsenseCam(cfg)
+
+
+def _build_t265(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.t265_cam import T265Cam
+
+    cfg = config or T265Config()
+    if isinstance(cfg, T265Config) and cfg.use_ros_topics:
+        if node is None:
+            raise ValueError("T265Cam with use_ros_topics=True requires a ROS node.")
+        return T265Cam(cfg, node)
+    return T265Cam(cfg)
+
+
+def _build_oakd(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.oakd_cam import OakdCam
+
+    return OakdCam(config or OakDConfig())
+
+
+def _build_ros(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.ros_cam import ROSCam
+
+    cfg = config or ROSConfig()
+    if not isinstance(cfg, ROSConfig):
+        raise ValueError("ROSCam requires a ROSConfig.")
+    return ROSCam(node, cfg)
+
+
+def _build_ros_depth(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.ros_depth_cam import ROSDepthCam
+
+    cfg = config or ROSDepthConfig()
+    if not isinstance(cfg, ROSDepthConfig):
+        raise ValueError("ROSDepthCam requires a ROSDepthConfig.")
+    if node is None:
+        raise ValueError("ROSDepthCam requires a ROS node.")
+    return ROSDepthCam(node, cfg)
+
+
+def _build_file(config: Optional[CameraConfig], node: Optional[Node]) -> AbstractCam:
+    from nectar.vision.camera.drivers.file_cam import FileImageCam
+
+    return FileImageCam(config or FileImageConfig())
+
+
+_BUILTINS: Dict[str, _BuilderFunc] = {
+    "webcam": _build_opencv,
+    "opencv": _build_opencv,
+    "c920": _build_c920,
+    "imx219": _build_imx219,
+    "realsense": _build_realsense,
+    "t265": _build_t265,
+    "oakd": _build_oakd,
+    "ros": _build_ros,
+    "ros_depth": _build_ros_depth,
+    "file": _build_file,
+}
 
 
 class CameraFactory:
     """
     Factory for creating camera instances from source identifiers.
 
+    Built-in drivers are loaded lazily on first use to keep the import
+    cost of ``nectar.vision`` low (no eager pyrealsense2 / depthai /
+    mediapipe loads).
+
     Attributes
     ----------
     _builders : dict
-        Registry mapping source keys to camera classes.
+        Registry mapping source keys to builder callables or camera
+        classes registered via :meth:`register`. Built-in drivers live
+        in a separate internal registry.
     """
 
-    _builders: Dict[str, Type[AbstractCam]] = {}
+    _builders: Dict[str, _BuilderFunc] = {}
 
     @classmethod
-    def register(cls, key: str, builder: Type[AbstractCam]) -> None:
+    def register(cls, key: str, builder) -> None:
         """
-        Register a camera class with a source key.
+        Register a camera builder under ``key``.
 
         Parameters
         ----------
         key : str
             Source identifier (case-insensitive).
-        builder : Type[AbstractCam]
-            Camera class to instantiate for this key.
+        builder : Type[AbstractCam] or callable
+            Either a camera class instantiated as ``builder(config)``,
+            or a callable with signature ``(config, node) -> AbstractCam``.
         """
         cls._builders[key.lower()] = builder
 
@@ -94,77 +184,26 @@ class CameraFactory:
             If source type is unknown or config type mismatches.
         """
         if os.path.isfile(source):
+            from nectar.vision.camera.drivers.file_cam import FileImageCam
+
             return FileImageCam(config or FileImageConfig(path=source))
 
         if source.startswith("/"):
+            from nectar.vision.camera.drivers.ros_cam import ROSCam
+
             return ROSCam(node, config or ROSConfig(topic=source))
 
         key = source.lower()
-        builder = cls._builders.get(key)
 
-        if not builder:
+        # User-registered builders take precedence over built-ins.
+        external = cls._builders.get(key)
+        if external is not None:
+            if isinstance(external, type):
+                return external(config or CameraConfig(name=key))
+            return external(config, node)
+
+        builtin = _BUILTINS.get(key)
+        if builtin is None:
             raise ValueError(f"Unknown camera source type: {source}")
 
-        if config is None:
-            if key == "realsense":
-                config = RealSenseConfig()
-            elif key == "t265":
-                config = T265Config()
-            elif key == "webcam":
-                config = OpenCVConfig()
-            elif key == "c920":
-                config = C920Config()
-            elif key == "imx219":
-                config = IMX219Config()
-            elif key == "oakd":
-                config = OakDConfig()
-            else:
-                config = CameraConfig(name=key)
-
-        if builder is ROSCam:
-            if not isinstance(config, ROSConfig):
-                raise ValueError("ROSCam requires a ROSConfig.")
-            return builder(node, config)
-
-        if builder is ROSDepthCam:
-            if not isinstance(config, ROSDepthConfig):
-                raise ValueError("ROSDepthCam requires a ROSDepthConfig.")
-            if node is None:
-                raise ValueError("ROSDepthCam requires a ROS node.")
-            return builder(node, config)
-
-        if builder is OakdCam:
-            if not isinstance(config, OakDConfig):
-                raise ValueError("OakdCam requires an OakDConfig.")
-            return builder(config)
-
-        if builder is RealsenseCam:
-            if isinstance(config, RealSenseConfig) and config.use_ros_topics:
-                if node is None:
-                    raise ValueError(
-                        "RealsenseCam with use_ros_topics=True requires a ROS node. "
-                        "Consider using ROSDepthCam instead."
-                    )
-                return builder(config, node)
-            return builder(config)
-
-        if builder is T265Cam:
-            if isinstance(config, T265Config) and config.use_ros_topics:
-                if node is None:
-                    raise ValueError("T265Cam with use_ros_topics=True requires a ROS node.")
-                return builder(config, node)
-            return builder(config)
-
-        return builder(config)
-
-
-CameraFactory.register("realsense", RealsenseCam)
-CameraFactory.register("t265", T265Cam)
-CameraFactory.register("webcam", OpenCVCam)
-CameraFactory.register("opencv", OpenCVCam)
-CameraFactory.register("c920", C920Cam)
-CameraFactory.register("imx219", IMX219Cam)
-CameraFactory.register("oakd", OakdCam)
-CameraFactory.register("ros", ROSCam)
-CameraFactory.register("ros_depth", ROSDepthCam)
-CameraFactory.register("file", FileImageCam)
+        return builtin(config, node)

--- a/nectar/nectar/vision/nodes/__init__.py
+++ b/nectar/nectar/vision/nodes/__init__.py
@@ -1,8 +1,37 @@
-from .aruco_node import ArucoNode
-from .camera_publisher_node import CameraPublisherNode
-from .click_color_calibration_node import ClickColorCalibrationNode
-from .color_calibration_node import ColorCalibrationNode
-from .line_detection_node import LineDetectionNode
+"""ROS 2 vision nodes."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "ArucoNode": "nectar.vision.nodes.aruco_node",
+    "CameraPublisherNode": "nectar.vision.nodes.camera_publisher_node",
+    "ClickColorCalibrationNode": "nectar.vision.nodes.click_color_calibration_node",
+    "ColorCalibrationNode": "nectar.vision.nodes.color_calibration_node",
+    "LineDetectionNode": "nectar.vision.nodes.line_detection_node",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from .aruco_node import ArucoNode
+    from .camera_publisher_node import CameraPublisherNode
+    from .click_color_calibration_node import ClickColorCalibrationNode
+    from .color_calibration_node import ColorCalibrationNode
+    from .line_detection_node import LineDetectionNode
+
 
 __all__ = [
     "ArucoNode",

--- a/nectar/nectar/vision/utils/__init__.py
+++ b/nectar/nectar/vision/utils/__init__.py
@@ -1,3 +1,28 @@
-from .image_calculus import ImageCalculus
+"""Vision utilities."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "ImageCalculus": "nectar.vision.utils.image_calculus",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from .image_calculus import ImageCalculus
+
 
 __all__ = ["ImageCalculus"]


### PR DESCRIPTION
# refactor: lazy-load heavy imports across the SDK

## Problem

`import nectar.ai` / `nectar.vision` / `nectar.control` eagerly pulled `torch`, `transformers`, `rfdetr`, `ultralytics`, `supervision`, `matplotlib`, `mediapipe`, `pyrealsense2`, `depthai`, `pandas`, `geopy`, etc. — regardless of which feature the caller used.

Two symptoms in practice:

- The `matplotlib` `Axes3D` `UserWarning` printed on every `import nectar.*`.
- Mission startup logged `jax / tensorflow / rfdetr / transformers` initialization even when only YOLO was used (`transformers` probes TF/JAX at import time).

The `Detector` was already designed with deferred per-framework builders, but the package-level re-exports forced every framework to load anyway.

## Solution

Two standard patterns:

1. **PEP 562 module `__getattr__` in `__init__.py`** for re-exports that pull heavy deps. Light items (dataclasses, enums, exceptions) stay eager; IDE autocomplete is preserved with `TYPE_CHECKING` imports. This is the same approach used by scikit-learn, NumPy, SciPy, JAX, Polars, Pandas.
2. **Local imports inside plotting helpers** for `matplotlib` / `pandas` in calibration, evaluation, and dataset-analysis modules.

`CameraFactory` and `DroneFactory` were also adjusted so built-in drivers / drones are resolved with deferred imports inside per-key builder functions. Public API and external `register(...)` extension points are unchanged.

## Results

Methodology: `colcon build` on each branch, then a fresh `python -c "<import>"` subprocess per scenario, best of 5 wall-clock runs, full `sys.modules` snapshot. Same machine, Python 3.10. The "mission startup" scenario imports the same four symbols [`bouncing/states/initialize.py`](https://github.com/Black-Bee-Drones/SAE-2026/blob/main/bouncing/bouncing/states/initialize.py) uses.

| Scenario | dev | this PR | speedup | modules loaded |
|---|---:|---:|---:|---:|
| `from nectar.ai import Detector` | 8 735 ms | 168 ms | 52× | 6 157 → 267 |
| `from nectar.vision import ImageHandler` | 1 666 ms | 291 ms | 5.7× | 1 428 → 471 |
| `from nectar.control import MavrosConfig, DroneFactory` | 3 186 ms | 144 ms | 22× | 2 813 → 248 |
| Mission startup (drone + camera + detector) | 11 730 ms | 952 ms | 12× | 7 082 → 1 201 |

Heavy modules eagerly loaded at each scenario, before vs after:

| Scenario | dev | this PR |
|---|---|---|
| `ai_detector` | torch, transformers, rfdetr, ultralytics, supervision, matplotlib, pandas, sklearn, accelerate, albumentations, datasets, huggingface_hub | — |
| `vision_image_handler` | matplotlib, mediapipe, pyrealsense2, depthai, geopy | — |
| `control_mavros_config` | matplotlib, mediapipe, pyrealsense2, depthai, geopy, pygeodesy, pandas, sklearn | — |
| Mission startup | all 17 above | geopy, pygeodesy¹ |

¹ Required by `GPSUtils`, which is used by `MavrosDrone` itself — unavoidable once the user actually instantiates a MAVROS drone.

The `matplotlib` `Axes3D` warning no longer appears on `import nectar.*`.