### PR TITLE
feat: tfluna

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Thin wrapper around scripts/setup.sh.
 
 .PHONY: help setup system update ros2 geographiclib ros2-env rosdep-init \
-        python python-control python-vision python-ai python-interface \
+        python python-control python-vision python-ai python-interface python-sensors \
         install-all install-full pytorch \
         clone ros2-deps build build-pkg clean verify test \
         realsense realsense-verify \
@@ -35,6 +35,7 @@ python-control:     ; @$(SETUP) python control
 python-vision:      ; @$(SETUP) python vision
 python-ai:          ; @$(SETUP) python ai
 python-interface:   ; @$(SETUP) python interface
+python-sensors:     ; @$(SETUP) python sensors
 install-all:        ; @$(SETUP) python all
 install-full:       ; @$(SETUP) python full
 pytorch:            ; @$(SETUP) pytorch

--- a/nectar/CMakeLists.txt
+++ b/nectar/CMakeLists.txt
@@ -46,7 +46,9 @@ install(PROGRAMS
   nectar/examples/vision/t265_example.py
   nectar/examples/vision/collect_photos.py
   nectar/examples/ai/detector_example.py
+  nectar/examples/sensors/rangefinder_example.py
   nectar/control/pid/pid_node.py
+  nectar/sensors/nodes/rangefinder_node.py
   ../scripts/simulation/vision_pose_bridge.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/nectar/nectar/control/README.md
+++ b/nectar/nectar/control/README.md
@@ -196,6 +196,13 @@ classDiagram
     DroneConfig <|-- BebopConfig
 ```
 
+## Spinning Model
+
+The SDK supports two usage patterns transparently:
+
+- **SDK-owned spin (Pattern A)**: user creates a plain `Node` (or subclasses one) and passes it to `DroneFactory.create`. No external executor is bound. The SDK drives ROS internally via `BaseDrone._wait`, which calls `rclpy.spin_once` and restores `node.executor` afterwards. Examples: [examples/control/sensors.py](examples/control/sensors.py), [examples/control/basic.py](examples/control/basic.py).
+- **User-owned spin (Pattern B)**: user passes a node already attached to an executor running in a background thread (Yasmin's `YasminNode`, the GUI's `ROSExecutor`, any custom `MultiThreadedExecutor`). The SDK detects this at init and `_wait` just sleeps; the user's executor keeps firing callbacks. The SDK never mutates `node.executor`, so subscriptions added after the drone is created (camera handler, custom subs in Yasmin states, etc.) still wake the right executor and stay fresh.
+
 ## Core Components
 
 ### DroneFactory

--- a/nectar/nectar/control/__init__.py
+++ b/nectar/nectar/control/__init__.py
@@ -61,6 +61,8 @@ _LAZY_ATTRS = {
     "GPSUtils": "nectar.control.mavros.gps_utils",
     # Camera-based obstacle detectors (pyrealsense2 / sklearn)
     "DepthObstacleDetector": "nectar.control.obstacles.depth_camera",
+    # Direct MAVLink connection (pymavlink)
+    "MavlinkConnection": "nectar.control.mavlink.connection",
 }
 
 
@@ -80,6 +82,7 @@ def __dir__():
 if TYPE_CHECKING:
     from nectar.control.bebop.drone import BebopDrone
     from nectar.control.crazyflie.drone import CrazyflieDrone
+    from nectar.control.mavlink.connection import MavlinkConnection
     from nectar.control.mavros.drone import MavrosDrone
     from nectar.control.mavros.gps_utils import GPSUtils
     from nectar.control.mavros.navigator import MavrosNavigator
@@ -120,6 +123,7 @@ __all__ = [
     "BebopDrone",
     "CrazyflieDrone",
     "GPSUtils",
+    "MavlinkConnection",
     "BaseObstacleDetector",
     "DepthObstacleDetector",
     "ObstacleInfo",

--- a/nectar/nectar/control/base.py
+++ b/nectar/nectar/control/base.py
@@ -1,10 +1,10 @@
+import time
 from abc import ABC, abstractmethod
 from typing import Callable, List, Optional, Union
 
 import rclpy
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.client import Client
-from rclpy.duration import Duration
 from rclpy.node import Node
 from rclpy.publisher import Publisher
 from rclpy.qos import QoSProfile
@@ -50,6 +50,7 @@ class BaseDrone(ABC):
         self._callback_group = ReentrantCallbackGroup()
         self._driver_running = False
         self._obstacle_manager = ObstacleManager()
+        self._owns_spin = node.executor is None
 
         if config.start_driver:
             self._init_driver()
@@ -774,14 +775,14 @@ class BaseDrone(ABC):
 
         if sync:
             future = client.call_async(request)
-            start_time = self._node.get_clock().now()
+            deadline = time.time() + timeout
 
             while not future.done():
-                rclpy.spin_once(self._node, timeout_sec=0.05)
-                if (self._node.get_clock().now() - start_time).nanoseconds / 1e9 > timeout:
+                if time.time() > deadline:
                     if fail_msg:
                         self._node.get_logger().error(f"{fail_msg}: Timeout waiting for response")
                     return None
+                self._wait(0.05)
 
             try:
                 result = future.result()
@@ -820,20 +821,41 @@ class BaseDrone(ABC):
 
     def delay(self, seconds: float) -> None:
         """
-        Delay with ROS spinning.
-
-        Maintains ROS communication during delay with spin_once.
+        Delay while keeping ROS communication alive.
 
         Parameters
         ----------
         seconds : float
             Delay duration in seconds.
         """
-        duration = Duration(seconds=seconds)
-        start_time = self._node.get_clock().now()
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self._wait(min(0.05, deadline - time.time()))
 
-        while (self._node.get_clock().now() - start_time) < duration:
-            rclpy.spin_once(self._node, timeout_sec=0.1)
+    def _wait(self, timeout_sec: float) -> None:
+        """
+        Cooperative wait tick.
+
+        When the SDK owns ROS spinning (no external executor was bound to
+        the node at init), spins the global executor once with the user's
+        ``node.executor`` binding restored after the call so future
+        ``create_subscription`` wakes still target the right executor.
+        Otherwise sleeps so the user's executor keeps driving callbacks.
+
+        Parameters
+        ----------
+        timeout_sec : float
+            Maximum time to block in seconds. ``0`` is non-blocking.
+        """
+        if self._owns_spin:
+            saved = self._node.executor
+            try:
+                rclpy.spin_once(self._node, timeout_sec=max(timeout_sec, 0.0))
+            finally:
+                self._node.executor = saved
+        else:
+            if timeout_sec > 0.0:
+                time.sleep(timeout_sec)
 
     def cleanup(self) -> None:
         """

--- a/nectar/nectar/control/crazyflie/drone.py
+++ b/nectar/nectar/control/crazyflie/drone.py
@@ -280,7 +280,7 @@ class CrazyflieDrone(BaseDrone):
         start = self._node.get_clock().now()
 
         while self._node.get_clock().now() - start < timeout:
-            rclpy.spin_once(self._node, timeout_sec=0.1)
+            self._wait(0.1)
             if self._status is not None:
                 self._connected = True
                 self._node.get_logger().info(
@@ -403,7 +403,7 @@ class CrazyflieDrone(BaseDrone):
         deadline = Duration(seconds=timeout)
 
         while self._node.get_clock().now() - start < deadline:
-            rclpy.spin_once(self._node, timeout_sec=0.05)
+            self._wait(0.05)
             if self.height >= threshold:
                 self.delay(1.0)
                 self._node.get_logger().info(
@@ -469,7 +469,7 @@ class CrazyflieDrone(BaseDrone):
         deadline = Duration(seconds=timeout)
 
         while self._node.get_clock().now() - start < deadline:
-            rclpy.spin_once(self._node, timeout_sec=0.05)
+            self._wait(0.05)
             if self.height <= landed_threshold:
                 self.delay(0.5)
                 self._node.get_logger().info(f"Landing complete (height={self.height:.3f}m)")
@@ -876,7 +876,7 @@ class CrazyflieDrone(BaseDrone):
         start = self._node.get_clock().now()
         timeout = Duration(seconds=10.0)
         while not future.done():
-            rclpy.spin_once(self._node, timeout_sec=0.05)
+            self._wait(0.05)
             if self._node.get_clock().now() - start > timeout:
                 self._node.get_logger().error("Upload trajectory timeout")
                 return
@@ -976,7 +976,7 @@ class CrazyflieDrone(BaseDrone):
         start = self._node.get_clock().now()
         timeout = Duration(seconds=5.0)
         while not future.done():
-            rclpy.spin_once(self._node, timeout_sec=0.05)
+            self._wait(0.05)
             if self._node.get_clock().now() - start > timeout:
                 self._node.get_logger().error(f"Get param {name} timeout")
                 return None
@@ -1056,10 +1056,10 @@ class CrazyflieDrone(BaseDrone):
         log_interval = Duration(seconds=2.0)
 
         while self._node.get_clock().now() - start < duration_deadline:
-            rclpy.spin_once(self._node, timeout_sec=0.05)
+            self._wait(0.05)
 
         while self._node.get_clock().now() - start < deadline:
-            rclpy.spin_once(self._node, timeout_sec=0.05)
+            self._wait(0.05)
             dist = self._distance_to(goal)
 
             if dist <= precision:

--- a/nectar/nectar/control/mavlink/README.md
+++ b/nectar/nectar/control/mavlink/README.md
@@ -1,0 +1,48 @@
+# Direct MAVLink Control
+
+A direct [pymavlink](https://mavlink.io/en/mavgen_python/) path for cases where the [MAVROS](../mavros/README.md) bridge is unavailable, undesired, or insufficient. Currently ships only the connection wrapper used by companion-side sensor publishers (e.g. [`RangefinderPublisher`](../../sensors/rangefinder_publisher.py)).
+
+A full `MavlinkDrone` parallel to [`MavrosDrone`](../mavros/drone.py) — implementing the same `Drone` protocol but talking pymavlink directly — is planned but not yet implemented.
+
+## Current scope
+
+### `MavlinkConnection`
+
+Thin wrapper around `mavutil.mavlink_connection` in [`connection.py`](connection.py). Opens a single MAVLink endpoint to the FCU, performs the heartbeat handshake to discover `target_system` / `target_component`, and exposes the raw pymavlink connection via `.master` so callers can send any MAVLink message.
+
+```python
+from nectar.control import MavlinkConnection
+from pymavlink import mavutil
+
+conn = MavlinkConnection(
+    source_system=1,
+    source_component=mavutil.mavlink.MAV_COMP_ID_ONBOARD_COMPUTER,
+    heartbeat_timeout=30.0,
+)
+
+conn.connect("udp:127.0.0.1:14551")            # UDP listener
+# or
+conn.connect("/dev/ttyUSB0", baud=921600)      # serial
+# or
+conn.connect("tcp:192.168.1.10:5760")          # TCP
+
+conn.master.mav.heartbeat_send(
+    mavutil.mavlink.MAV_TYPE_ONBOARD_CONTROLLER,
+    mavutil.mavlink.MAV_AUTOPILOT_INVALID, 0, 0, 0,
+)
+
+conn.close()
+```
+
+## Planned: `MavlinkDrone`
+
+A future addition will provide a `MavlinkDrone(BaseDrone)` implementing the full [`Drone` protocol](../protocols.py) (connect, arm, takeoff, land, move_velocity, move_to, move_to_gps, rtl, ...) directly via pymavlink, so missions can run without MAVROS. It will be registered with [`DroneFactory`](../factory.py) as the `"mavlink"` drone type and will reuse `MavlinkConnection` as its transport.
+
+Until that lands, use [`MavrosDrone`](../mavros/README.md) for full drone control. `MavlinkConnection` is enough on its own for simple message-publishing tasks (sensors, custom commands, telemetry probes).
+
+## References
+
+- [pymavlink documentation](https://mavlink.io/en/mavgen_python/)
+- [MAVLink common messages](https://mavlink.io/en/messages/common.html)
+- [ArduPilot MAVLink basics](https://ardupilot.org/dev/docs/mavlink-basics.html)
+- [mavlink-router](https://github.com/mavlink-router/mavlink-router) — fan out the FCU's serial to multiple endpoints (MAVROS + this connection)

--- a/nectar/nectar/control/mavlink/__init__.py
+++ b/nectar/nectar/control/mavlink/__init__.py
@@ -1,0 +1,28 @@
+"""Direct MAVLink (pymavlink) control path."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "MavlinkConnection": "nectar.control.mavlink.connection",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.control.mavlink.connection import MavlinkConnection
+
+
+__all__ = ["MavlinkConnection"]

--- a/nectar/nectar/control/mavlink/connection.py
+++ b/nectar/nectar/control/mavlink/connection.py
@@ -60,7 +60,7 @@ class MavlinkConnection:
         """
         Open the MAVLink endpoint and complete the heartbeat handshake.
 
-        Blocks until the first non-GCS heartbeat arrives or until 
+        Blocks until the first non-GCS heartbeat arrives or until
         ``heartbeat_timeout``
         elapses.
 

--- a/nectar/nectar/control/mavlink/connection.py
+++ b/nectar/nectar/control/mavlink/connection.py
@@ -1,0 +1,121 @@
+"""Minimal pymavlink connection wrapper."""
+
+import time
+from typing import Optional
+
+from pymavlink import mavutil
+
+
+class MavlinkConnection:
+    """
+    Thin wrapper around ``pymavlink.mavutil.mavlink_connection``.
+
+    Parameters
+    ----------
+    device : str
+        Connection string. Examples:
+
+        - ``"udp:127.0.0.1:14551"`` (UDP listener)
+        - ``"udpout:192.168.1.10:14550"`` (UDP sender)
+        - ``"tcp:192.168.1.10:5760"`` (TCP)
+        - ``"/dev/ttyUSB0"`` (serial; requires ``baud``)
+    baud : int, optional
+        Serial baud rate. Ignored for network connections. Default 921600.
+    source_system : int, optional
+        MAVLink system ID this connection presents itself as. Default 1
+        (same system as the FCU; ArduPilot accepts companion-computer
+        messages from the same system ID).
+    source_component : int, optional
+        MAVLink component ID. Default ``MAV_COMP_ID_ONBOARD_COMPUTER``
+        (191), the ArduPilot convention for companion computers.
+    heartbeat_timeout : float, optional
+        Maximum seconds to wait for the first FCU heartbeat during
+        :meth:`connect`. Default 30.
+
+    Attributes
+    ----------
+    master : mavutil.mavfile
+        Underlying pymavlink connection. Use ``master.mav.<message>_send(...)``
+        to transmit. ``None`` until :meth:`connect` succeeds.
+    """
+
+    def __init__(
+        self,
+        *,
+        source_system: int = 1,
+        source_component: int = mavutil.mavlink.MAV_COMP_ID_ONBOARD_COMPUTER,
+        heartbeat_timeout: float = 30.0,
+    ) -> None:
+        self._source_system = source_system
+        self._source_component = source_component
+        self._heartbeat_timeout = heartbeat_timeout
+        self.master: Optional[mavutil.mavfile] = None
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the heartbeat handshake completed."""
+        return self.master is not None and self.master.target_system != 0
+
+    def connect(self, device: str, baud: int = 921600) -> None:
+        """
+        Open the MAVLink endpoint and complete the heartbeat handshake.
+
+        Blocks until the first non-GCS heartbeat arrives or until 
+        ``heartbeat_timeout``
+        elapses.
+
+        Parameters
+        ----------
+        device : str
+            Connection string passed to ``mavutil.mavlink_connection``.
+        baud : int, optional
+            Serial baud rate. Ignored for non-serial connections.
+
+        Raises
+        ------
+        TimeoutError
+            If no FCU heartbeat is received within ``heartbeat_timeout``.
+        """
+        self.master = mavutil.mavlink_connection(
+            device,
+            baud=baud,
+            source_system=self._source_system,
+            source_component=self._source_component,
+        )
+
+        if not self._await_heartbeat():
+            raise TimeoutError(
+                f"No FCU heartbeat received within {self._heartbeat_timeout}s on {device}"
+            )
+
+    def close(self) -> None:
+        """Close the underlying pymavlink connection."""
+        if self.master is not None:
+            try:
+                self.master.close()
+            finally:
+                self.master = None
+
+    def _await_heartbeat(self) -> bool:
+        """Wait for the first non-GCS HEARTBEAT to set target_system/component."""
+        deadline = time.monotonic() + self._heartbeat_timeout
+        skip_types = (
+            mavutil.mavlink.MAV_TYPE_GCS,
+            mavutil.mavlink.MAV_TYPE_ONBOARD_CONTROLLER,
+        )
+
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            msg = self.master.recv_match(
+                type="HEARTBEAT", blocking=True, timeout=max(remaining, 0.1)
+            )
+            if msg is None:
+                continue
+            if msg.type in skip_types:
+                continue
+
+            self.master.target_system = msg.get_srcSystem()
+            self.master.target_component = msg.get_srcComponent()
+            return True
+
+        return False

--- a/nectar/nectar/control/mavros/README.md
+++ b/nectar/nectar/control/mavros/README.md
@@ -1127,14 +1127,15 @@ reached, distance, alt_diff = GPSUtils.check_reached(
 
 All MAVROS service calls use `_call_service` with automatic response validation and deadlock-safe execution.
 
-Per [ROS 2 guidelines](https://docs.ros.org/en/humble/How-To-Guides/Sync-Vs-Async.html), we use `call_async()` with a spin loop to avoid deadlock:
+Per [ROS 2 guidelines](https://docs.ros.org/en/humble/How-To-Guides/Sync-Vs-Async.html), we use `call_async()` with a cooperative wait that drives the global executor when no external one is bound to the node, and just sleeps when the user owns spinning (Yasmin singleton, Qt executor, etc.). The wait helper preserves `node.executor` so subscriptions added after a service call still wake the right executor:
 
 ```python
 future = service.call_async(request)
+deadline = time.time() + timeout
 while not future.done():
-    rclpy.spin_once(self._node, timeout_sec=0.05)
-    if elapsed > timeout:
+    if time.time() > deadline:
         raise TimeoutError(...)
+    self._wait(0.05)  # spin_once with executor-binding restore, or time.sleep
 result = future.result()
 ```
 

--- a/nectar/nectar/control/mavros/drone.py
+++ b/nectar/nectar/control/mavros/drone.py
@@ -1,8 +1,8 @@
+import time
 from pathlib import Path
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
-import rclpy
 from geographic_msgs.msg import GeoPoseStamped
 from geometry_msgs.msg import PoseStamped, PoseWithCovarianceStamped
 from mavros_msgs.msg import GlobalPositionTarget, PositionTarget, State
@@ -437,47 +437,45 @@ class MavrosDrone(BaseDrone):
         Stores initial altitude and heading for GPS offset calculations.
         """
         config: MavrosConfig = self._config
-        timeout = Duration(seconds=config.sensor_timeout)
+        timeout = config.sensor_timeout
 
         self._node.get_logger().info("Starting sensor initialization...")
 
         if config.expect_lidar:
-            start = self._node.get_clock().now()
-            while self._node.get_clock().now() - start < timeout:
-                rclpy.spin_once(self._node, timeout_sec=0.1)
-                if self._rng_alt is not None:
-                    self._node.get_logger().info("LiDAR available")
-                    break
-            if self._rng_alt is None:
+            if self._wait_until(lambda: self._rng_alt is not None, timeout):
+                self._node.get_logger().info("LiDAR available")
+            else:
                 self._node.get_logger().warn("LiDAR not available")
         else:
             self._node.get_logger().info("LiDAR not checked")
 
-        start = self._node.get_clock().now()
-        sensors_ok = False
-
         if self.is_indoor:
-            while self._node.get_clock().now() - start < timeout:
-                rclpy.spin_once(self._node, timeout_sec=0.1)
-                if self._vision_pos is not None:
-                    sensors_ok = True
-                    self._node.get_logger().info("Vision pose received")
-                    break
+            sensors_ok = self._wait_until(lambda: self._vision_pos is not None, timeout)
+            if sensors_ok:
+                self._node.get_logger().info("Vision pose received")
             self._initial_altitude = 0.0
             self._initial_heading = 0.0
         else:
-            while self._node.get_clock().now() - start < timeout:
-                rclpy.spin_once(self._node, timeout_sec=0.1)
-                if self._gps is not None and self._heading is not None:
-                    sensors_ok = True
-                    self._node.get_logger().info("GPS and heading received")
-                    break
+            sensors_ok = self._wait_until(
+                lambda: self._gps is not None and self._heading is not None,
+                timeout,
+            )
             if sensors_ok:
+                self._node.get_logger().info("GPS and heading received")
                 self._initial_altitude = self._gps.altitude
                 self._initial_heading = self._heading.data
 
         if not sensors_ok:
             self._node.get_logger().warn("Sensor initialization incomplete")
+
+    def _wait_until(self, predicate: Callable[[], bool], timeout: float) -> bool:
+        """Wait until ``predicate()`` is true or ``timeout`` seconds elapse."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if predicate():
+                return True
+            self._wait(0.05)
+        return predicate()
 
     def _load_pid_config(self) -> None:
         """Load PID configuration from file or use defaults based on indoor/outdoor mode."""
@@ -791,7 +789,7 @@ class MavrosDrone(BaseDrone):
                 self._node.get_logger().error("Arm failed, cannot takeoff")
                 return False
 
-            self.delay(3.0)
+            self.delay(6.0)
 
             if attempt == 0:
                 if not self._set_takeoff_position():
@@ -814,7 +812,7 @@ class MavrosDrone(BaseDrone):
                 self._node.get_logger().error(f"Takeoff service timeout: {e}")
                 return False
 
-            self.delay(altitude * 4)
+            self.delay(altitude * 5)
 
             current_alt = self.get_altitude() or 0.0
             height_gain = abs(current_alt - takeoff_height)
@@ -822,7 +820,7 @@ class MavrosDrone(BaseDrone):
             self._node.get_logger().info(
                 f"Height gain: {height_gain:.2f}m, Armed: {self._mavros_state.armed}"
             )
-            if height_gain >= 0.1 or self._mavros_state.armed:
+            if height_gain >= 0.1 and self._mavros_state.armed:
                 self._node.get_logger().info(f"Takeoff successful (gained {height_gain:.2f}m)")
 
                 if adjust_altitude:
@@ -887,14 +885,7 @@ class MavrosDrone(BaseDrone):
             if not res:
                 return False
 
-            duration = Duration(seconds=timeout)
-            start = self._node.get_clock().now()
-
-            while self._node.get_clock().now() - start < duration:
-                rclpy.spin_once(self._node, timeout_sec=0.1)
-                if not self._mavros_state.armed:
-                    break
-
+            self._wait_until(lambda: not self._mavros_state.armed, timeout)
             self.delay(0.1)
             return not self._mavros_state.armed
         except TimeoutError as e:

--- a/nectar/nectar/examples/control/README.md
+++ b/nectar/nectar/examples/control/README.md
@@ -7,6 +7,7 @@
 | `pid_simulation.py` | PID controller simulation | `--kp --ki --plot` |
 | `mavros_navigation.py` | Navigation test (BODY, TAKEOFF, GPS) | `--mode --strategy --test --distance` |
 | `interactive_nav.py` | Interactive REPL — type waypoints live | `--mode --strategy --altitude` |
+| `servo_test.py` | Interactive REPL — pre-flight servo / PWM tester via `MAV_CMD_DO_SET_SERVO` | `--channel --hold --release` |
 | `mavros_obstacles.py` | Obstacle avoidance | - |
 
 ## Basic Flight
@@ -119,3 +120,39 @@ nav> land
 | `pid-ekf` | PID velocity control using EKF local position |
 | `position` | Local position setpoint via `setpoint_raw/local` |
 | `position-global` | GPS global setpoint (outdoor only, long range) |
+
+## Servo / PWM Test
+
+Drives `MavrosDrone.do_servo` (`MAV_CMD_DO_SET_SERVO`, 183) from a REPL so you
+can verify the correct AUX OUT channel and the PWM endpoints (e.g. hook hold /
+release) on the bench. The script never arms the drone and never takes off —
+keep props off.
+
+```bash
+# MAVROS already running. Defaults: channel=3 (FCU ch 11 = AUX OUT 3),
+# hold=1000us, release=2000us.
+python3 servo_test.py
+
+# Custom channel and presets
+python3 servo_test.py --channel 4 --hold 1100 --release 1900
+```
+
+At the `servo>` prompt:
+
+```
+servo> 1500              # send PWM 1500 to current channel
+servo> ch 3              # switch to AUX OUT 3 (FCU ch 11)
+servo> hold              # send 'hold' preset
+servo> release           # send 'release' preset
+servo> sweep 1000 2000 100 0.3
+servo> cycle 3 0.8       # toggle hold<->release 3 times, 0.8s apart
+servo> set hold 1100     # update presets at runtime
+servo> status            # channel, last PWM, FCU state
+```
+
+`do_servo(N, pwm)` maps to FCU servo number `N + 8`, so `ch 3` drives AUX OUT 3
+on a Pixhawk-style FCU (Copter recommends AUX OUT 1-4 for hobby servos at 50 Hz;
+avoid MAIN OUT 1-8, which run at 400 Hz). If a write returns `OK` but the servo
+does not move, check the safety switch and that `SERVOx_FUNCTION = 0` in
+ArduPilot. See [common-servo](https://ardupilot.org/copter/docs/common-servo.html)
+and [MAV_CMD_DO_SET_SERVO](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_SERVO).

--- a/nectar/nectar/examples/sensors/README.md
+++ b/nectar/nectar/examples/sensors/README.md
@@ -2,7 +2,7 @@
 
 | File | Description | Args |
 |------|-------------|------|
-| `rangefinder_example.py` | Bench-test the TF-Luna -> filter -> MAVLink `DISTANCE_SENSOR` pipeline (no ROS) | `--port --mavlink --filter --obstacle-height --rate --duration` |
+| `rangefinder_example.py` | Bench-test the TF-Luna -> filter -> MAVLink `DISTANCE_SENSOR` pipeline (no ROS) | `--port --mavlink --filter --obstacle-height --estimate-lock-s --rate --duration` |
 
 ## Bench test
 
@@ -12,14 +12,19 @@ python3 rangefinder_example.py \
     --port /dev/ttyUSB0 \
     --mavlink udp:127.0.0.1:14551
 
-# Hook mission setup: mask the 1.7m sphere, run for 60 seconds.
+# Hook mission and similar: auto-detect the obstacle height. No prior knowledge needed.
+python3 rangefinder_example.py \
+    --port /dev/ttyUSB0 \
+    --mavlink udp:127.0.0.1:14551 \
+    --filter obstacle_mask \
+    --duration 60
+
+# Fixed-height override (SITL, known fixtures): lock to 1.7 m.
 python3 rangefinder_example.py \
     --port /dev/ttyUSB0 \
     --mavlink udp:127.0.0.1:14551 \
     --filter obstacle_mask \
     --obstacle-height 1.7 \
-    --max-change 0.30 \
-    --avg-window 10 \
     --duration 60
 ```
 
@@ -39,7 +44,7 @@ For ROS deployments use the `rangefinder_node.py` entry point instead:
 ros2 run nectar rangefinder_node.py --ros-args \
     -p serial_port:=/dev/ttyUSB0 \
     -p mavlink_url:=udp:127.0.0.1:14551 \
-    -p filter:=obstacle_mask -p obstacle_height_m:=1.7
+    -p filter:=obstacle_mask
 ```
 
 See [`nectar/sensors/README.md`](../../sensors/README.md) for the full

--- a/nectar/nectar/examples/sensors/README.md
+++ b/nectar/nectar/examples/sensors/README.md
@@ -1,0 +1,46 @@
+# Sensors Module Examples
+
+| File | Description | Args |
+|------|-------------|------|
+| `rangefinder_example.py` | Bench-test the TF-Luna -> filter -> MAVLink `DISTANCE_SENSOR` pipeline (no ROS) | `--port --mavlink --filter --obstacle-height --rate --duration` |
+
+## Bench test
+
+```bash
+# Raw passthrough; runs until Ctrl-C.
+python3 rangefinder_example.py \
+    --port /dev/ttyUSB0 \
+    --mavlink udp:127.0.0.1:14551
+
+# Hook mission setup: mask the 1.7m sphere, run for 60 seconds.
+python3 rangefinder_example.py \
+    --port /dev/ttyUSB0 \
+    --mavlink udp:127.0.0.1:14551 \
+    --filter obstacle_mask \
+    --obstacle-height 1.7 \
+    --max-change 0.30 \
+    --avg-window 10 \
+    --duration 60
+```
+
+While the script is running, in another terminal echo the FCU rangefinder
+topic to confirm the masked stream is reaching the EKF via MAVROS:
+
+```bash
+ros2 topic echo /mavros/rangefinder/rangefinder
+```
+
+Drop a known-height object under the sensor; the topic value should jump
+by roughly the object's height and recover when removed.
+
+For ROS deployments use the `rangefinder_node.py` entry point instead:
+
+```bash
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551 \
+    -p filter:=obstacle_mask -p obstacle_height_m:=1.7
+```
+
+See [`nectar/sensors/README.md`](../../sensors/README.md) for the full
+parameter list, ArduPilot configuration steps, and troubleshooting.

--- a/nectar/nectar/examples/sensors/rangefinder_example.py
+++ b/nectar/nectar/examples/sensors/rangefinder_example.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Standalone TF-Luna rangefinder bench test (no ROS).
+
+Wires :class:`TFLuna`, :class:`MavlinkConnection`, and
+:class:`RangefinderPublisher` (with optional :class:`ObstacleMaskFilter`)
+into a single process. Useful for verifying the sensor + transport before
+running the full ROS2 node, or for non-ROS deployments.
+
+Usage::
+
+    python rangefinder_example.py --port /dev/ttyUSB0 \\
+        --mavlink udp:127.0.0.1:14551 \\
+        --filter obstacle_mask --obstacle-height 1.7
+"""
+
+import argparse
+import time
+
+from nectar.control import MavlinkConnection
+from nectar.sensors import ObstacleMaskFilter, RangefinderPublisher, TFLuna
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--port", default="/dev/ttyUSB0", help="TF-Luna serial port")
+    parser.add_argument("--baud", type=int, default=115200, help="TF-Luna baud")
+    parser.add_argument(
+        "--mavlink",
+        default="udp:127.0.0.1:14551",
+        help="MAVLink connection string (UDP/TCP/serial)",
+    )
+    parser.add_argument(
+        "--mavlink-baud",
+        type=int,
+        default=921600,
+        help="Serial baud for MAVLink endpoints (ignored for UDP/TCP)",
+    )
+    parser.add_argument(
+        "--filter",
+        choices=["none", "obstacle_mask"],
+        default="none",
+        help="Filter to apply before publishing (default: none)",
+    )
+    parser.add_argument(
+        "--obstacle-height", type=float, default=1.7, help="Obstacle height in meters"
+    )
+    parser.add_argument("--max-change", type=float, default=0.30)
+    parser.add_argument("--avg-window", type=int, default=10)
+    parser.add_argument("--timeout-s", type=float, default=5.0)
+    parser.add_argument("--rate", type=float, default=50.0, help="Publish rate (Hz)")
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=0.0,
+        help="Run for this many seconds. 0 = run until Ctrl-C.",
+    )
+    return parser.parse_args()
+
+
+def build_filter(args: argparse.Namespace):
+    if args.filter == "none":
+        return None
+    timeout = args.timeout_s if args.timeout_s > 0 else None
+    return ObstacleMaskFilter(
+        obstacle_height_m=args.obstacle_height,
+        max_change_m=args.max_change,
+        avg_window=args.avg_window,
+        timeout_s=timeout,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+
+    sensor = TFLuna(port=args.port, baudrate=args.baud)
+    connection = MavlinkConnection()
+    print(f"Connecting to {args.mavlink} ...")
+    connection.connect(args.mavlink, baud=args.mavlink_baud)
+    print(
+        f"FCU heartbeat received "
+        f"(sys={connection.master.target_system}, "
+        f"comp={connection.master.target_component})"
+    )
+
+    publisher = RangefinderPublisher(
+        sensor=sensor,
+        connection=connection,
+        rate_hz=args.rate,
+        filter=build_filter(args),
+    )
+    publisher.start()
+    print(f"Publishing at {args.rate} Hz. Filter: {args.filter}.")
+
+    try:
+        deadline = time.monotonic() + args.duration if args.duration > 0 else None
+        while True:
+            time.sleep(0.5)
+            if deadline is not None and time.monotonic() >= deadline:
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        publisher.stop()
+        sensor.close()
+        connection.close()
+        print("Stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/nectar/nectar/examples/sensors/rangefinder_example.py
+++ b/nectar/nectar/examples/sensors/rangefinder_example.py
@@ -10,7 +10,7 @@ Usage::
 
     python rangefinder_example.py --port /dev/ttyUSB0 \\
         --mavlink udp:127.0.0.1:14551 \\
-        --filter obstacle_mask --obstacle-height 1.7
+        --filter obstacle_mask
 """
 
 import argparse
@@ -42,10 +42,14 @@ def parse_args() -> argparse.Namespace:
         help="Filter to apply before publishing (default: none)",
     )
     parser.add_argument(
-        "--obstacle-height", type=float, default=1.7, help="Obstacle height in meters"
+        "--obstacle-height",
+        type=float,
+        default=0.0,
+        help="Obstacle height in meters. <= 0 enables auto-estimation.",
     )
     parser.add_argument("--max-change", type=float, default=0.30)
     parser.add_argument("--avg-window", type=int, default=10)
+    parser.add_argument("--estimate-lock-s", type=float, default=0.2)
     parser.add_argument("--timeout-s", type=float, default=5.0)
     parser.add_argument("--rate", type=float, default=50.0, help="Publish rate (Hz)")
     parser.add_argument(
@@ -61,10 +65,12 @@ def build_filter(args: argparse.Namespace):
     if args.filter == "none":
         return None
     timeout = args.timeout_s if args.timeout_s > 0 else None
+    height = args.obstacle_height if args.obstacle_height > 0 else None
     return ObstacleMaskFilter(
-        obstacle_height_m=args.obstacle_height,
+        obstacle_height_m=height,
         max_change_m=args.max_change,
         avg_window=args.avg_window,
+        estimate_lock_s=args.estimate_lock_s,
         timeout_s=timeout,
     )
 

--- a/nectar/nectar/interface/README.md
+++ b/nectar/nectar/interface/README.md
@@ -235,12 +235,12 @@ worker_thread.start()
 
 ### Service Calls
 
-ROS2 services use async pattern to avoid deadlocks:
+ROS2 services use async pattern to avoid deadlocks. The SDK's `BaseDrone._wait` is the cooperative tick — it spins when the SDK owns ROS, sleeps when the user's executor (e.g. `ROSExecutor`) is already running. Either way, `node.executor` is preserved so later subscriptions still wake the right executor:
 
 ```python
 future = service.call_async(request)
 while not future.done():
-    rclpy.spin_once(node, timeout_sec=0.05)
+    self._wait(0.05)  # spin (SDK-owned) or sleep (user-owned executor)
 result = future.result()
 ```
 

--- a/nectar/nectar/interface/tabs/control_tab.py
+++ b/nectar/nectar/interface/tabs/control_tab.py
@@ -1709,10 +1709,8 @@ class ControlTab(QWidget):
             self._clear_telemetry()
             return
 
-        import rclpy
-
         if self._node:
-            rclpy.spin_once(self._node, timeout_sec=0)
+            self._drone._wait(0)
 
         try:
             if self._drone_type == "mavros":

--- a/nectar/nectar/sensors/README.md
+++ b/nectar/nectar/sensors/README.md
@@ -36,14 +36,18 @@ classDiagram
     }
 
     class ObstacleMaskFilter {
-        -_obstacle_height_m float
+        -_fixed_height Optional~float~
         -_max_change_m float
+        -_estimate_lock_s float
         -_timeout_s Optional~float~
         -_window deque
         -_over_obstacle bool
         -_entry_raw Optional~float~
         -_entry_time Optional~float~
+        -_pre_baseline Optional~float~
+        -_locked bool
         +is_masking bool
+        +estimated_height_m Optional~float~
         +process(raw) Optional~float~
         +reset()
     }
@@ -139,29 +143,65 @@ distance_m = sensor.read()  # float | None
 sensor.close()
 ```
 
-Hardware reference: [TF-Luna product page](https://en.benewake.com/TFLuna/index.html).
+Hardware reference: [TF-Luna product page](https://en.benewake.com/TFLuna/index.html) and [Data Download](https://en.benewake.com/DataDownload/index.aspx?pid=20&lcid=21) (datasheet, user manual, Pixhawk application notes).
+
+> Spec range is 0.20 - 8.00 m. In practice the sensor returns valid readings down to roughly 0.05 - 0.08 m, which is why `min_distance_m` defaults to `0.05`. Keep `RNGFND1_MIN_CM = 20` on the FCU per manufacturer spec — the SDK's reported `DISTANCE_SENSOR.min_distance` and ArduPilot's gating are independent on purpose.
 
 ### `ObstacleMaskFilter`
 
-Stateful rangefinder filter in [`filters/obstacle_mask.py`](filters/obstacle_mask.py). Detects a sudden drop, masks readings for the duration of the obstacle, recovers when the reading returns to the pre-entry baseline.
+Stateful rangefinder filter in [`filters/obstacle_mask.py`](filters/obstacle_mask.py). Detects a sudden drop, masks readings for the duration of the obstacle, recovers when the reading returns to the pre-entry baseline. The obstacle height is **auto-estimated by default** from the entry drop magnitude (`pre_baseline - entry_raw`), so missions don't need to know obstacle dimensions in advance. Pass `obstacle_height_m` explicitly to lock the estimate to a fixed value.
+
+#### State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Passthrough
+    Passthrough --> Passthrough: "raw >= baseline - max_change"
+    Passthrough --> Refining: "drop detected: snapshot pre_baseline, entry_raw = raw"
+    Refining --> Refining: "t < estimate_lock_s, refine entry_raw if raw smaller"
+    Refining --> Locked: "t >= estimate_lock_s, freeze height"
+    Refining --> Passthrough: "raw > entry_raw + max_change OR t > timeout_s"
+    Locked --> Locked: "return raw + height"
+    Locked --> Passthrough: "raw > entry_raw + max_change OR t > timeout_s"
+```
 
 Algorithm:
 - Maintain a rolling average over the last `avg_window` readings while not masking.
-- Enter the masked state when `raw < baseline - max_change_m`. Save `entry_raw`.
-- While masking, return `raw + obstacle_height_m`.
+- Enter the masked state when `raw < baseline - max_change_m`. Snapshot `pre_baseline` and `entry_raw`.
+- For the first `estimate_lock_s` after entry (default 0.2 s): refine `entry_raw` whenever a smaller raw arrives, so the deepest beam reading is captured as the obstacle is fully crossed. After this window, the height is frozen.
+- While masking: return `raw + (pre_baseline - entry_raw)` (or the fixed override).
 - Exit when `raw > entry_raw + max_change_m`, or after `timeout_s` (safety reset).
+
+#### Hook walkthrough (auto-detect)
+
+```
+t=0.0s   hover at 3.40 m AGL    raw=3.40  masked=3.40  state=Passthrough
+t=1.0s   enter sphere column    raw=1.70  masked=3.40  state=Refining (h=1.70)
+t=1.05s  beam settles on top    raw=1.65  masked=3.40  state=Refining (h=1.75)
+t=1.20s  estimate locks         h=1.75 frozen          state=Locked
+t=2..5s  descend over sphere    raw=0.30  masked=2.05  state=Locked
+t=5.1s   exit sphere column     raw=3.20  masked=3.20  state=Passthrough
+```
+
+While refining at constant altitude the masked output stays at `pre_baseline` because `raw + (pre_baseline - entry_raw)` collapses to `pre_baseline` whenever `entry_raw` is updated to the current raw. Once the height locks, the masked stream tracks any drone descent linearly, so the FCU's `EK3_SRC1_POSZ=Rangefinder` setup behaves correctly throughout the mission without any prior knowledge of obstacle dimensions.
 
 ```python
 from nectar.sensors import ObstacleMaskFilter
 
+# Auto-detect (recommended): height learned from each crossing.
 f = ObstacleMaskFilter(
-    obstacle_height_m=1.7,   # known obstacle thickness (e.g. SAE 2026 sphere)
-    max_change_m=0.30,       # entry/exit hysteresis
+    max_change_m=0.30,       # entry/exit hysteresis (also caps physically reachable descent rate)
     avg_window=10,           # samples for the entry baseline
+    estimate_lock_s=0.2,     # how long to refine the height after entry
     timeout_s=5.0,           # force-reset if stuck masked too long
 )
 
+# Fixed height override (e.g. for SITL or known fixtures).
+f_fixed = ObstacleMaskFilter(obstacle_height_m=1.7)
+
 filtered = f.process(raw)    # float (current sample masked or passed through)
+f.is_masking                 # bool
+f.estimated_height_m         # float | None (current estimate while masking)
 f.reset()                    # clear all state (e.g. on mode change)
 ```
 
@@ -191,7 +231,7 @@ publisher = RangefinderPublisher(
     min_distance_m=0.05,
     max_distance_m=8.0,
     rate_hz=50.0,
-    filter=ObstacleMaskFilter(obstacle_height_m=1.7),
+    filter=ObstacleMaskFilter(),  # auto-detect; pass obstacle_height_m=X to lock
 )
 
 publisher.start()
@@ -213,15 +253,18 @@ ros2 run nectar rangefinder_node.py --ros-args \
     -p serial_port:=/dev/ttyUSB0 \
     -p mavlink_url:=udp:127.0.0.1:14551
 
-# Hook mission: mask the 1.7m sphere
+# Auto-detect (Hook mission and similar): no obstacle_height_m needed
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551 \
+    -p filter:=obstacle_mask
+
+# Fixed-height override (SITL, known fixtures)
 ros2 run nectar rangefinder_node.py --ros-args \
     -p serial_port:=/dev/ttyUSB0 \
     -p mavlink_url:=udp:127.0.0.1:14551 \
     -p filter:=obstacle_mask \
-    -p obstacle_height_m:=1.7 \
-    -p max_change_m:=0.30 \
-    -p avg_window:=10 \
-    -p timeout_s:=5.0
+    -p obstacle_height_m:=1.7
 ```
 
 #### Parameters
@@ -239,14 +282,15 @@ ros2 run nectar rangefinder_node.py --ros-args \
 - `covariance_cm` (int 0-254, default `0`) — `0` means "use FCU defaults".
 - `rate_hz` (float, default `50.0`) — Publish rate.
 - `filter` (string, default `none`) — `none` or `obstacle_mask`.
-- `obstacle_height_m`, `max_change_m`, `avg_window`, `timeout_s` — Forwarded to `ObstacleMaskFilter` when `filter=obstacle_mask`. Use `timeout_s <= 0` to disable the safety reset.
+- `obstacle_height_m` (float, default `0.0`) — Obstacle height override in meters. `<= 0` enables auto-detection (the recommended default). Forwarded to `ObstacleMaskFilter` only when `filter=obstacle_mask`.
+- `max_change_m`, `avg_window`, `estimate_lock_s`, `timeout_s` — Forwarded to `ObstacleMaskFilter` when `filter=obstacle_mask`. Use `timeout_s <= 0` to disable the safety reset; `estimate_lock_s` is ignored in fixed-height mode.
 
 ## ArduPilot setup (one-time)
 
 Set on the FCU via Mission Planner / parameter editor:
 
 - `RNGFND1_TYPE = 10` (MAVLink)
-- `RNGFND1_MIN_CM = 20`, `RNGFND1_MAX_CM = 800` ([TF-Luna](https://en.benewake.com/TFLuna/index.html) effective range)
+- `RNGFND1_MIN_CM = 20`, `RNGFND1_MAX_CM = 800` (TF-Luna manufacturer spec; see [datasheet](https://en.benewake.com/DataDownload/index.aspx?pid=20&lcid=21))
 - `RNGFND1_ORIENT = 25` (Down)
 - Physically disconnect the TF-Luna's UART from the Pixhawk so the only rangefinder source is the filtered MAVLink stream.
 - Keep `EK3_SRC1_POSZ = Rangefinder` and `EK3_RNG_USE_HGT = -1` if that is your current configuration; the masking filter is what makes that combination safe across known obstacles.
@@ -275,17 +319,26 @@ Drop a known-height object under the sensor while echoing the topic. The reading
 
 Standalone (no ROS): see [`examples/sensors/rangefinder_example.py`](../examples/sensors/rangefinder_example.py).
 
+## Known limitations of the auto-detect mode
+
+- **Inverse case (sudden rise) is not masked.** The filter only triggers on drops. Flying off a table or cliff makes raw spike up; this filter does nothing about it.
+- **Powering on directly above an obstacle contaminates the baseline.** The rolling average needs at least a few flat-ground samples before the first crossing. Workaround: take off, fly to clear ground for at least `avg_window` samples, then proceed.
+- **Stacked or back-to-back obstacles**: the filter exits and re-enters per obstacle, which is the correct behavior. Each entry re-estimates the height from the new drop.
+- **Wide, gradually-rising obstacle (slope > `max_change_m / sample_period`)**: not detected as an obstacle because there is no step drop. This is intentional — slow elevation changes look like terrain, not an obstacle.
+
 ## Troubleshooting
 
 - **`No FCU heartbeat received within 30s`**: pymavlink can't reach the FCU. Check `mavlink_url`, that mavlink-router is running, and that the UDP port matches. Verify with `mavproxy.py --master=udp:127.0.0.1:14551`.
 - **MAVROS still shows the raw reading**: confirm `RNGFND1_TYPE = 10` on the FCU and that the direct UART is physically disconnected. The FCU prefers the directly wired sensor when both are present.
 - **Filter masks during a legitimate descent**: `max_change_m` is too tight. Increase it, or shrink `avg_window` so the baseline tracks the descent faster.
-- **Stuck masked**: lower `timeout_s` (default 5.0s) or set it to a value just larger than the longest obstacle traversal expected for the mission.
+- **Auto-estimated height is too small** (drone still climbs slightly when crossing the obstacle): the lock window expired before the beam reached the deepest point. Increase `estimate_lock_s` (e.g. 0.4 s), or lock the height with `obstacle_height_m`.
+- **Auto-estimated height is too large** (drone dips when entering the masked region): noisy entry sample. Increase `avg_window` so the pre-baseline is more stable, or lock the height with `obstacle_height_m`.
+- **Stuck masked**: lower `timeout_s` (default 5.0 s) or set it to a value just larger than the longest obstacle traversal expected for the mission.
 - **TF-Luna returns `None` constantly**: check baud (default 115200), wiring, and that no other process is holding the serial port. Increase `min_strength` if you suspect the sensor is reading through low-confidence reflections.
 
 ## References
 
-- [Benewake TF-Luna product page](https://en.benewake.com/TFLuna/index.html)
+- [Benewake TF-Luna product page](https://en.benewake.com/TFLuna/index.html) and [Data Download](https://en.benewake.com/DataDownload/index.aspx?pid=20&lcid=21) (datasheet, user manual, Pixhawk app notes)
 - [ArduPilot rangefinder landing page](https://ardupilot.org/copter/docs/common-rangefinder-landingpage.html)
 - [ArduPilot terrain following](https://ardupilot.org/copter/docs/terrain-following.html)
 - [ArduPilot Benewake setup](https://ardupilot.org/copter/docs/common-benewake-tf02-lidar.html)

--- a/nectar/nectar/sensors/README.md
+++ b/nectar/nectar/sensors/README.md
@@ -1,0 +1,294 @@
+# Sensors Module
+
+Companion-side sensor drivers and value filters, plus a ready-made ROS2 node that bridges a serial rangefinder to MAVLink `DISTANCE_SENSOR` so an ArduPilot/PX4 FCU can consume it as its primary rangefinder.
+
+The module is composition-first: a `DistanceSensor` (driver) and an optional `DistanceFilter` are wired into a `RangefinderPublisher` that pushes filtered samples into a `MavlinkConnection`. Each piece is independently usable.
+
+## Why this exists
+
+When a downward-facing LiDAR is the EKF altitude source (`EK3_SRC1_POSZ = Rangefinder`), flying over a fixed obstacle (e.g. a sphere on a hose) causes a step drop in the rangefinder reading that ArduPilot interprets as the vehicle descending. The position controller climbs to compensate, lifting the drone above its target altitude. Connecting the LiDAR to the companion computer instead of the FCU lets us mask those step drops before the EKF ever sees them.
+
+ArduPilot has no native parameter to reject step changes in the rangefinder — the filter must live upstream of the FCU. See [ArduPilot terrain following docs](https://ardupilot.org/copter/docs/terrain-following.html) and [`AP_RangeFinder_Benewake_CAN.h`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h).
+
+## Architecture
+
+```mermaid
+classDiagram
+    class DistanceSensor {
+        <<protocol>>
+        +read() Optional~float~
+        +close()
+    }
+
+    class DistanceFilter {
+        <<protocol>>
+        +process(raw) Optional~float~
+        +reset()
+    }
+
+    class TFLuna {
+        -_ser Serial
+        -_buffer bytearray
+        -_min_strength int
+        +read() Optional~float~
+        +close()
+        -_parse_one_frame() Optional~float~
+    }
+
+    class ObstacleMaskFilter {
+        -_obstacle_height_m float
+        -_max_change_m float
+        -_timeout_s Optional~float~
+        -_window deque
+        -_over_obstacle bool
+        -_entry_raw Optional~float~
+        -_entry_time Optional~float~
+        +is_masking bool
+        +process(raw) Optional~float~
+        +reset()
+    }
+
+    class RangefinderPublisher {
+        -_sensor DistanceSensor
+        -_connection MavlinkConnection
+        -_filter Optional~DistanceFilter~
+        -_sensor_id int
+        -_sensor_type int
+        -_orientation int
+        -_min_cm int
+        -_max_cm int
+        -_covariance int
+        -_period float
+        -_stop_event Event
+        -_thread Optional~Thread~
+        +is_running bool
+        +start()
+        +stop(timeout)
+        -_loop()
+        -_send(distance_m)
+    }
+
+    class MavlinkConnection {
+        -_source_system int
+        -_source_component int
+        -_heartbeat_timeout float
+        +master Optional~mavfile~
+        +is_connected bool
+        +connect(device, baud)
+        +close()
+        -_await_heartbeat()
+    }
+
+    class RangefinderNode {
+        -_sensor TFLuna
+        -_connection MavlinkConnection
+        -_publisher RangefinderPublisher
+        +__init__()
+        +destroy_node()
+        -_build_pipeline()
+        -_build_filter()
+    }
+
+    DistanceSensor <|.. TFLuna
+    DistanceFilter <|.. ObstacleMaskFilter
+    RangefinderPublisher o-- DistanceSensor
+    RangefinderPublisher o-- DistanceFilter
+    RangefinderPublisher o-- MavlinkConnection
+    RangefinderNode *-- RangefinderPublisher
+```
+
+## Data flow
+
+```mermaid
+flowchart LR
+    HW["TF-Luna UART"] --> TFLuna
+    TFLuna -->|"raw m"| Filter["ObstacleMaskFilter (optional)"]
+    Filter -->|"masked m"| Pub["RangefinderPublisher"]
+    Pub -->|"DISTANCE_SENSOR (132)"| Conn["MavlinkConnection"]
+    Conn -->|"MAVLink UDP/Serial"| FCU["Pixhawk RNGFND1_TYPE=10"]
+    FCU -->|"EKF Z fusion"| Ctrl["AC_PosControl"]
+    FCU -->|"RANGEFINDER (173)"| MAVROS
+    MAVROS -->|"/mavros/rangefinder/rangefinder"| Mission["MavrosDrone + missions (unchanged)"]
+```
+
+## Components
+
+### `DistanceSensor` and `DistanceFilter` (Protocols)
+
+Lightweight structural interfaces in [`base.py`](base.py). Implementations only need to match the shape; no inheritance is required (matches the `Drone` and `ObstacleDetector` convention in `nectar/control`).
+
+```python
+class DistanceSensor(Protocol):
+    def read(self) -> Optional[float]: ...
+    def close(self) -> None: ...
+
+class DistanceFilter(Protocol):
+    def process(self, raw_distance: float) -> Optional[float]: ...
+    def reset(self) -> None: ...
+```
+
+### `TFLuna`
+
+Benewake TF-Luna serial driver in [`benewake/tfluna.py`](benewake/tfluna.py). Parses the standard 9-byte UART frame (`0x59 0x59 ...`), validates checksum and signal strength, and returns the latest valid reading on each `read()`. Non-blocking: small serial timeout, drains `in_waiting` per call, returns `None` when no fresh frame is ready.
+
+```python
+from nectar.sensors import TFLuna
+
+sensor = TFLuna(port="/dev/ttyUSB0", baudrate=115200)
+distance_m = sensor.read()  # float | None
+sensor.close()
+```
+
+Hardware reference: [TF-Luna product page](https://en.benewake.com/TFLuna/index.html).
+
+### `ObstacleMaskFilter`
+
+Stateful rangefinder filter in [`filters/obstacle_mask.py`](filters/obstacle_mask.py). Detects a sudden drop, masks readings for the duration of the obstacle, recovers when the reading returns to the pre-entry baseline.
+
+Algorithm:
+- Maintain a rolling average over the last `avg_window` readings while not masking.
+- Enter the masked state when `raw < baseline - max_change_m`. Save `entry_raw`.
+- While masking, return `raw + obstacle_height_m`.
+- Exit when `raw > entry_raw + max_change_m`, or after `timeout_s` (safety reset).
+
+```python
+from nectar.sensors import ObstacleMaskFilter
+
+f = ObstacleMaskFilter(
+    obstacle_height_m=1.7,   # known obstacle thickness (e.g. SAE 2026 sphere)
+    max_change_m=0.30,       # entry/exit hysteresis
+    avg_window=10,           # samples for the entry baseline
+    timeout_s=5.0,           # force-reset if stuck masked too long
+)
+
+filtered = f.process(raw)    # float (current sample masked or passed through)
+f.reset()                    # clear all state (e.g. on mode change)
+```
+
+### `RangefinderPublisher`
+
+Composition piece in [`rangefinder_publisher.py`](rangefinder_publisher.py). Owns a background thread that reads the sensor at a configurable rate, applies the optional filter, and sends MAVLink `DISTANCE_SENSOR` (id 132) over the connection.
+
+```python
+from nectar.control import MavlinkConnection
+from nectar.sensors import (
+    ObstacleMaskFilter,
+    RangefinderPublisher,
+    TFLuna,
+)
+from pymavlink import mavutil
+
+sensor = TFLuna(port="/dev/ttyUSB0")
+conn = MavlinkConnection()
+conn.connect("udp:127.0.0.1:14551")
+
+publisher = RangefinderPublisher(
+    sensor=sensor,
+    connection=conn,
+    sensor_id=0,
+    sensor_type=mavutil.mavlink.MAV_DISTANCE_SENSOR_LASER,
+    orientation=mavutil.mavlink.MAV_SENSOR_ROTATION_PITCH_270,  # downward
+    min_distance_m=0.05,
+    max_distance_m=8.0,
+    rate_hz=50.0,
+    filter=ObstacleMaskFilter(obstacle_height_m=1.7),
+)
+
+publisher.start()
+# ... mission runs ...
+publisher.stop()
+sensor.close()
+conn.close()
+```
+
+`filter=None` publishes raw readings.
+
+### `RangefinderNode`
+
+ROS2 entry point in [`nodes/rangefinder_node.py`](nodes/rangefinder_node.py). Declares every knob as a ROS parameter so per-mission tuning lives in the launch file rather than in mission code.
+
+```bash
+# Raw passthrough (no filter)
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551
+
+# Hook mission: mask the 1.7m sphere
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551 \
+    -p filter:=obstacle_mask \
+    -p obstacle_height_m:=1.7 \
+    -p max_change_m:=0.30 \
+    -p avg_window:=10 \
+    -p timeout_s:=5.0
+```
+
+#### Parameters
+
+- `serial_port` (string, default `/dev/ttyUSB0`) — TF-Luna device path.
+- `baudrate` (int, default `115200`) — TF-Luna baud rate.
+- `mavlink_url` (string, default `udp:127.0.0.1:14551`) — pymavlink endpoint to the FCU. Use a UDP fan-out (e.g. mavlink-router) if MAVROS already owns the FCU's serial line.
+- `mavlink_baud` (int, default `921600`) — Used only for serial endpoints.
+- `source_system` (int, default `1`) — MAVLink system ID this companion presents.
+- `source_component` (int, default `191`) — `MAV_COMP_ID_ONBOARD_COMPUTER`.
+- `heartbeat_timeout_s` (float, default `30.0`) — Max wait for the first FCU heartbeat.
+- `sensor_id` (int 0-7, default `0`) — Maps to ArduPilot `RNGFND<id+1>_*` slot.
+- `orientation` (int, default `25`) — `MAV_SENSOR_ORIENTATION` enum (`25` = `PITCH_270`, downward).
+- `min_distance_m` / `max_distance_m` (float, default `0.05` / `8.0`) — Sensor range, sent as part of `DISTANCE_SENSOR`.
+- `covariance_cm` (int 0-254, default `0`) — `0` means "use FCU defaults".
+- `rate_hz` (float, default `50.0`) — Publish rate.
+- `filter` (string, default `none`) — `none` or `obstacle_mask`.
+- `obstacle_height_m`, `max_change_m`, `avg_window`, `timeout_s` — Forwarded to `ObstacleMaskFilter` when `filter=obstacle_mask`. Use `timeout_s <= 0` to disable the safety reset.
+
+## ArduPilot setup (one-time)
+
+Set on the FCU via Mission Planner / parameter editor:
+
+- `RNGFND1_TYPE = 10` (MAVLink)
+- `RNGFND1_MIN_CM = 20`, `RNGFND1_MAX_CM = 800` ([TF-Luna](https://en.benewake.com/TFLuna/index.html) effective range)
+- `RNGFND1_ORIENT = 25` (Down)
+- Physically disconnect the TF-Luna's UART from the Pixhawk so the only rangefinder source is the filtered MAVLink stream.
+- Keep `EK3_SRC1_POSZ = Rangefinder` and `EK3_RNG_USE_HGT = -1` if that is your current configuration; the masking filter is what makes that combination safe across known obstacles.
+
+The Jetson and MAVROS both need access to the FCU MAVLink stream. The standard pattern is to run [mavlink-router](https://github.com/mavlink-router/mavlink-router) (or equivalent) on the Jetson to fan out the FCU's serial link to both MAVROS and this node's UDP endpoint.
+
+## DISTANCE_SENSOR vs RANGEFINDER
+
+These are two different MAVLink messages with opposite directions:
+
+- [`DISTANCE_SENSOR` (id 132)](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR): companion-to-FCU. What this node sends. Carries sensor metadata (id, type, orientation, min/max).
+- [`RANGEFINDER` (id 173, ardupilotmega)](https://github.com/mavlink/c_library_v1/blob/master/ardupilotmega/mavlink_msg_rangefinder.h): FCU-to-GCS telemetry. What MAVROS reads to publish `/mavros/rangefinder/rangefinder`.
+
+This node only emits `DISTANCE_SENSOR`. The `RANGEFINDER` flow is handled by ArduPilot and MAVROS without any code from this module.
+
+## Validation
+
+Bench (no flight):
+
+```bash
+ros2 run nectar rangefinder_node.py --ros-args -p mavlink_url:=udp:127.0.0.1:14551
+ros2 topic echo /mavros/rangefinder/rangefinder
+```
+
+Drop a known-height object under the sensor while echoing the topic. The reading should jump by the masked offset and recover when the object is removed.
+
+Standalone (no ROS): see [`examples/sensors/rangefinder_example.py`](../examples/sensors/rangefinder_example.py).
+
+## Troubleshooting
+
+- **`No FCU heartbeat received within 30s`**: pymavlink can't reach the FCU. Check `mavlink_url`, that mavlink-router is running, and that the UDP port matches. Verify with `mavproxy.py --master=udp:127.0.0.1:14551`.
+- **MAVROS still shows the raw reading**: confirm `RNGFND1_TYPE = 10` on the FCU and that the direct UART is physically disconnected. The FCU prefers the directly wired sensor when both are present.
+- **Filter masks during a legitimate descent**: `max_change_m` is too tight. Increase it, or shrink `avg_window` so the baseline tracks the descent faster.
+- **Stuck masked**: lower `timeout_s` (default 5.0s) or set it to a value just larger than the longest obstacle traversal expected for the mission.
+- **TF-Luna returns `None` constantly**: check baud (default 115200), wiring, and that no other process is holding the serial port. Increase `min_strength` if you suspect the sensor is reading through low-confidence reflections.
+
+## References
+
+- [Benewake TF-Luna product page](https://en.benewake.com/TFLuna/index.html)
+- [ArduPilot rangefinder landing page](https://ardupilot.org/copter/docs/common-rangefinder-landingpage.html)
+- [ArduPilot terrain following](https://ardupilot.org/copter/docs/terrain-following.html)
+- [ArduPilot Benewake setup](https://ardupilot.org/copter/docs/common-benewake-tf02-lidar.html)
+- [`AP_RangeFinder.h`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RangeFinder/AP_RangeFinder.h)
+- [`DISTANCE_SENSOR` MAVLink message](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR)
+- [pymavlink documentation](https://mavlink.io/en/mavgen_python/)

--- a/nectar/nectar/sensors/__init__.py
+++ b/nectar/nectar/sensors/__init__.py
@@ -1,0 +1,40 @@
+"""Nectar SDK - Sensors module."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+from nectar.sensors.base import DistanceFilter, DistanceSensor
+
+_LAZY_ATTRS = {
+    "TFLuna": "nectar.sensors.benewake.tfluna",
+    "ObstacleMaskFilter": "nectar.sensors.filters.obstacle_mask",
+    "RangefinderPublisher": "nectar.sensors.rangefinder_publisher",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.sensors.benewake.tfluna import TFLuna
+    from nectar.sensors.filters.obstacle_mask import ObstacleMaskFilter
+    from nectar.sensors.rangefinder_publisher import RangefinderPublisher
+
+
+__all__ = [
+    "DistanceSensor",
+    "DistanceFilter",
+    "TFLuna",
+    "ObstacleMaskFilter",
+    "RangefinderPublisher",
+]

--- a/nectar/nectar/sensors/base.py
+++ b/nectar/nectar/sensors/base.py
@@ -1,0 +1,37 @@
+"""Sensor protocols."""
+
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DistanceSensor(Protocol):
+    """One-shot distance sensor.
+
+    Implementations should be non-blocking: ``read`` returns the latest
+    valid measurement available right now, or ``None`` if no fresh valid
+    reading is ready (e.g. partial frame, bad checksum, low signal).
+    """
+
+    def read(self) -> Optional[float]:
+        """Return the latest distance in meters, or ``None`` if unavailable."""
+        ...
+
+    def close(self) -> None:
+        """Release any underlying resources (serial port, file handle, etc.)."""
+        ...
+
+
+@runtime_checkable
+class DistanceFilter(Protocol):
+    """Stateful filter mapping a raw distance reading to a processed value.
+
+    A filter may suppress a reading entirely by returning ``None``.
+    """
+
+    def process(self, raw_distance: float) -> Optional[float]:
+        """Process one raw reading and return the filtered distance."""
+        ...
+
+    def reset(self) -> None:
+        """Clear internal state."""
+        ...

--- a/nectar/nectar/sensors/benewake/__init__.py
+++ b/nectar/nectar/sensors/benewake/__init__.py
@@ -1,0 +1,28 @@
+"""Benewake LiDAR drivers."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "TFLuna": "nectar.sensors.benewake.tfluna",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.sensors.benewake.tfluna import TFLuna
+
+
+__all__ = ["TFLuna"]

--- a/nectar/nectar/sensors/benewake/tfluna.py
+++ b/nectar/nectar/sensors/benewake/tfluna.py
@@ -1,0 +1,95 @@
+"""Benewake TF-Luna single-point LiDAR driver.
+
+Reads the standard 9-byte UART frame format documented at
+https://en.benewake.com/TFLuna/. The driver is non-blocking: each
+:meth:`read` drains whatever bytes are available, parses every full
+frame found, and returns the most recent valid distance. Bad-checksum
+and low-signal frames are dropped per the Benewake spec.
+"""
+
+from typing import Optional
+
+import serial
+
+
+class TFLuna:
+    """
+    Benewake TF-Luna serial driver.
+
+    Parameters
+    ----------
+    port : str
+        Serial device path (e.g. ``"/dev/ttyUSB0"``).
+    baudrate : int, optional
+        Default 115200 (TF-Luna factory setting).
+    timeout : float, optional
+        Serial read timeout in seconds. Small non-zero value avoids
+        busy-polling while still keeping :meth:`read` snappy. Default 0.02.
+    min_strength : int, optional
+        Minimum signal strength to accept a frame. Frames below this or
+        equal to ``0xFFFF`` are discarded per Benewake's data sheet.
+        Default 100.
+    """
+
+    HEADER = b"\x59\x59"
+    FRAME_SIZE = 9
+    BAD_STRENGTH = 0xFFFF
+
+    def __init__(
+        self,
+        port: str,
+        baudrate: int = 115200,
+        timeout: float = 0.02,
+        min_strength: int = 100,
+    ) -> None:
+        self._ser = serial.Serial(port, baudrate, timeout=timeout)
+        self._buffer = bytearray()
+        self._min_strength = min_strength
+
+    def read(self) -> Optional[float]:
+        """
+        Drain the serial buffer and return the latest valid distance in meters.
+
+        Returns ``None`` when no full valid frame is currently buffered
+        """
+        pending = self._ser.in_waiting
+        if pending:
+            self._buffer.extend(self._ser.read(pending))
+
+        latest: Optional[float] = None
+        while True:
+            value = self._parse_one_frame()
+            if value is None:
+                break
+            latest = value
+        return latest
+
+    def close(self) -> None:
+        """Close the underlying serial port."""
+        if self._ser.is_open:
+            self._ser.close()
+
+    def _parse_one_frame(self) -> Optional[float]:
+        """Find and consume the next valid frame in the buffer."""
+        idx = self._buffer.find(self.HEADER)
+        if idx < 0:
+            self._buffer.clear()
+            return None
+
+        if len(self._buffer) - idx < self.FRAME_SIZE:
+            if idx > 0:
+                del self._buffer[:idx]
+            return None
+
+        frame = bytes(self._buffer[idx : idx + self.FRAME_SIZE])
+        del self._buffer[: idx + self.FRAME_SIZE]
+
+        if (sum(frame[:8]) & 0xFF) != frame[8]:
+            return None
+
+        strength = frame[4] | (frame[5] << 8)
+        if strength < self._min_strength or strength == self.BAD_STRENGTH:
+            return None
+
+        dist_cm = frame[2] | (frame[3] << 8)
+        return dist_cm / 100.0

--- a/nectar/nectar/sensors/filters/__init__.py
+++ b/nectar/nectar/sensors/filters/__init__.py
@@ -1,0 +1,28 @@
+"""Distance-sensor value filters."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+_LAZY_ATTRS = {
+    "ObstacleMaskFilter": "nectar.sensors.filters.obstacle_mask",
+}
+
+
+def __getattr__(name: str):
+    target = _LAZY_ATTRS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(target), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
+
+if TYPE_CHECKING:
+    from nectar.sensors.filters.obstacle_mask import ObstacleMaskFilter
+
+
+__all__ = ["ObstacleMaskFilter"]

--- a/nectar/nectar/sensors/filters/obstacle_mask.py
+++ b/nectar/nectar/sensors/filters/obstacle_mask.py
@@ -1,0 +1,126 @@
+"""Rangefinder filter that masks readings while crossing a known-height obstacle.
+
+When a downward-facing rangefinder is the EKF altitude source, flying over
+a fixed obstacle (e.g. a sphere on a hose) causes a step drop in the
+reading that ArduPilot interprets as the vehicle descending. The position
+controller then climbs to compensate, lifting the drone above its target
+altitude. This filter detects the step drop, masks the affected samples,
+and reports a stable altitude until the obstacle is cleared.
+
+Algorithm
+---------
+While not over an obstacle, the filter maintains a rolling average of
+recent raw readings. A drop greater than ``max_change_m`` below that
+average flags entry; the raw value at entry is saved as ``entry_raw``.
+While over an obstacle the filter returns ``raw + obstacle_height_m``,
+which keeps the masked output close to the pre-entry baseline. Exit is
+declared when the raw reading climbs back above ``entry_raw + max_change_m``,
+or after ``timeout_s`` has elapsed (safety reset).
+"""
+
+import time
+from collections import deque
+from typing import Optional
+
+
+class ObstacleMaskFilter:
+    """
+    Mask rangefinder samples while the beam is over a known-height obstacle.
+
+    Parameters
+    ----------
+    obstacle_height_m : float
+        Vertical thickness of the expected obstacle, in meters. The masked
+        output adds this to each raw reading while in the masked state.
+    max_change_m : float, optional
+        Magnitude of sample-to-baseline drop that triggers entry, and the
+        magnitude of recovery above ``entry_raw`` that triggers exit.
+        Default 0.30.
+    avg_window : int, optional
+        Number of recent samples averaged for the entry baseline. Default 10.
+    timeout_s : float, optional
+        Maximum time to remain in the masked state before forcing a reset.
+        ``None`` disables the safety. Default 5.0.
+
+    Notes
+    -----
+    The entry baseline is only updated outside the masked state, so a long
+    masked period does not corrupt the average. While masked, raw samples
+    are not pushed into the rolling window.
+    """
+
+    def __init__(
+        self,
+        obstacle_height_m: float,
+        *,
+        max_change_m: float = 0.30,
+        avg_window: int = 10,
+        timeout_s: Optional[float] = 5.0,
+    ) -> None:
+        if obstacle_height_m <= 0:
+            raise ValueError("obstacle_height_m must be positive")
+        if max_change_m <= 0:
+            raise ValueError("max_change_m must be positive")
+        if avg_window < 1:
+            raise ValueError("avg_window must be >= 1")
+
+        self._obstacle_height_m = obstacle_height_m
+        self._max_change_m = max_change_m
+        self._timeout_s = timeout_s
+        self._window: deque[float] = deque(maxlen=avg_window)
+        self._over_obstacle = False
+        self._entry_raw: Optional[float] = None
+        self._entry_time: Optional[float] = None
+
+    @property
+    def is_masking(self) -> bool:
+        """Whether the filter is currently masking readings."""
+        return self._over_obstacle
+
+    def process(self, raw_distance: float) -> Optional[float]:
+        """
+        Apply the mask to a raw reading.
+
+        Parameters
+        ----------
+        raw_distance : float
+            Raw rangefinder reading in meters. ``None`` is not accepted;
+            callers should skip invalid samples upstream.
+
+        Returns
+        -------
+        float
+            The filtered distance in meters.
+        """
+        if self._over_obstacle:
+            if self._timed_out() or raw_distance > self._entry_raw + self._max_change_m:
+                self._exit_masked_state()
+                return raw_distance
+            return raw_distance + self._obstacle_height_m
+
+        self._window.append(raw_distance)
+        baseline = sum(self._window) / len(self._window)
+        if raw_distance < baseline - self._max_change_m:
+            self._enter_masked_state(raw_distance)
+            return raw_distance + self._obstacle_height_m
+        return raw_distance
+
+    def reset(self) -> None:
+        """Clear all internal state."""
+        self._window.clear()
+        self._exit_masked_state()
+
+    def _enter_masked_state(self, raw_distance: float) -> None:
+        self._over_obstacle = True
+        self._entry_raw = raw_distance
+        self._entry_time = time.monotonic()
+
+    def _exit_masked_state(self) -> None:
+        self._over_obstacle = False
+        self._entry_raw = None
+        self._entry_time = None
+
+    def _timed_out(self) -> bool:
+        if self._timeout_s is None or self._entry_time is None:
+            return False
+        return (time.monotonic() - self._entry_time) >= self._timeout_s

--- a/nectar/nectar/sensors/filters/obstacle_mask.py
+++ b/nectar/nectar/sensors/filters/obstacle_mask.py
@@ -1,21 +1,23 @@
-"""Rangefinder filter that masks readings while crossing a known-height obstacle.
-
-When a downward-facing rangefinder is the EKF altitude source, flying over
-a fixed obstacle (e.g. a sphere on a hose) causes a step drop in the
-reading that ArduPilot interprets as the vehicle descending. The position
-controller then climbs to compensate, lifting the drone above its target
-altitude. This filter detects the step drop, masks the affected samples,
-and reports a stable altitude until the obstacle is cleared.
+"""Rangefinder filter that masks readings while crossing an obstacle.
 
 Algorithm
 ---------
-While not over an obstacle, the filter maintains a rolling average of
-recent raw readings. A drop greater than ``max_change_m`` below that
-average flags entry; the raw value at entry is saved as ``entry_raw``.
-While over an obstacle the filter returns ``raw + obstacle_height_m``,
-which keeps the masked output close to the pre-entry baseline. Exit is
-declared when the raw reading climbs back above ``entry_raw + max_change_m``,
-or after ``timeout_s`` has elapsed (safety reset).
+While not masking, the filter maintains a rolling average of recent raw
+readings. A drop greater than ``max_change_m`` below that average flags
+entry; the pre-entry baseline and the entry sample are snapshotted.
+
+The obstacle height is by default **auto-estimated** as
+``pre_baseline - entry_raw``. For the first ``estimate_lock_s`` after
+entry, ``entry_raw`` is refined downward whenever a deeper sample arrives
+(captures the deepest beam reading as the obstacle is fully crossed).
+After the lock window the height is frozen, so subsequent drone descent
+over the obstacle does not inflate the estimate.
+
+Pass ``obstacle_height_m`` explicitly to override the estimate with a
+fixed value (useful for SITL or known fixtures).
+
+Exit is declared when the raw reading climbs back above
+``entry_raw + max_change_m``, or after ``timeout_s`` elapses.
 """
 
 import time
@@ -25,22 +27,28 @@ from typing import Optional
 
 class ObstacleMaskFilter:
     """
-    Mask rangefinder samples while the beam is over a known-height obstacle.
+    Mask rangefinder samples while the beam is over an obstacle.
 
     Parameters
     ----------
-    obstacle_height_m : float
-        Vertical thickness of the expected obstacle, in meters. The masked
-        output adds this to each raw reading while in the masked state.
+    obstacle_height_m : float, optional
+        Vertical thickness of the obstacle in meters. ``None`` (default)
+        enables auto-estimation from the entry drop magnitude. A positive
+        value locks the height to that constant.
     max_change_m : float, optional
         Magnitude of sample-to-baseline drop that triggers entry, and the
         magnitude of recovery above ``entry_raw`` that triggers exit.
-        Default 0.30.
+        Default 0.30 m (at 50 Hz this excludes any physically achievable
+        descent rate).
     avg_window : int, optional
         Number of recent samples averaged for the entry baseline. Default 10.
+    estimate_lock_s : float, optional
+        Refinement window after entry during which ``entry_raw`` may be
+        updated downward. After this elapses the height is frozen until
+        exit. Ignored when ``obstacle_height_m`` is set. Default 0.2 s.
     timeout_s : float, optional
         Maximum time to remain in the masked state before forcing a reset.
-        ``None`` disables the safety. Default 5.0.
+        ``None`` disables the safety. Default 5.0 s.
 
     Notes
     -----
@@ -51,31 +59,43 @@ class ObstacleMaskFilter:
 
     def __init__(
         self,
-        obstacle_height_m: float,
+        obstacle_height_m: Optional[float] = None,
         *,
         max_change_m: float = 0.30,
         avg_window: int = 10,
+        estimate_lock_s: float = 0.2,
         timeout_s: Optional[float] = 5.0,
     ) -> None:
-        if obstacle_height_m <= 0:
-            raise ValueError("obstacle_height_m must be positive")
+        if obstacle_height_m is not None and obstacle_height_m <= 0:
+            raise ValueError("obstacle_height_m, when set, must be positive")
         if max_change_m <= 0:
             raise ValueError("max_change_m must be positive")
         if avg_window < 1:
             raise ValueError("avg_window must be >= 1")
+        if estimate_lock_s < 0:
+            raise ValueError("estimate_lock_s must be >= 0")
 
-        self._obstacle_height_m = obstacle_height_m
+        self._fixed_height: Optional[float] = obstacle_height_m
         self._max_change_m = max_change_m
+        self._estimate_lock_s = estimate_lock_s
         self._timeout_s = timeout_s
         self._window: deque[float] = deque(maxlen=avg_window)
+
         self._over_obstacle = False
         self._entry_raw: Optional[float] = None
         self._entry_time: Optional[float] = None
+        self._pre_baseline: Optional[float] = None
+        self._locked = False
 
     @property
     def is_masking(self) -> bool:
         """Whether the filter is currently masking readings."""
         return self._over_obstacle
+
+    @property
+    def estimated_height_m(self) -> Optional[float]:
+        """Current obstacle-height estimate, or ``None`` outside the masked state."""
+        return self._height() if self._over_obstacle else None
 
     def process(self, raw_distance: float) -> Optional[float]:
         """
@@ -96,13 +116,25 @@ class ObstacleMaskFilter:
             if self._timed_out() or raw_distance > self._entry_raw + self._max_change_m:
                 self._exit_masked_state()
                 return raw_distance
-            return raw_distance + self._obstacle_height_m
 
-        self._window.append(raw_distance)
+            if not self._locked:
+                if raw_distance < self._entry_raw:
+                    self._entry_raw = raw_distance
+                if (time.monotonic() - self._entry_time) >= self._estimate_lock_s:
+                    self._locked = True
+
+            return raw_distance + self._height()
+
+        if not self._window:
+            self._window.append(raw_distance)
+            return raw_distance
+
         baseline = sum(self._window) / len(self._window)
         if raw_distance < baseline - self._max_change_m:
-            self._enter_masked_state(raw_distance)
-            return raw_distance + self._obstacle_height_m
+            self._enter_masked_state(raw_distance, baseline)
+            return raw_distance + self._height()
+
+        self._window.append(raw_distance)
         return raw_distance
 
     def reset(self) -> None:
@@ -110,15 +142,24 @@ class ObstacleMaskFilter:
         self._window.clear()
         self._exit_masked_state()
 
-    def _enter_masked_state(self, raw_distance: float) -> None:
+    def _height(self) -> float:
+        if self._fixed_height is not None:
+            return self._fixed_height
+        return self._pre_baseline - self._entry_raw
+
+    def _enter_masked_state(self, raw_distance: float, pre_baseline: float) -> None:
         self._over_obstacle = True
         self._entry_raw = raw_distance
         self._entry_time = time.monotonic()
+        self._pre_baseline = pre_baseline
+        self._locked = self._estimate_lock_s == 0
 
     def _exit_masked_state(self) -> None:
         self._over_obstacle = False
         self._entry_raw = None
         self._entry_time = None
+        self._pre_baseline = None
+        self._locked = False
 
     def _timed_out(self) -> bool:
         if self._timeout_s is None or self._entry_time is None:

--- a/nectar/nectar/sensors/nodes/__init__.py
+++ b/nectar/nectar/sensors/nodes/__init__.py
@@ -1,0 +1,1 @@
+"""Pre-built ROS2 nodes for sensor pipelines."""

--- a/nectar/nectar/sensors/nodes/rangefinder_node.py
+++ b/nectar/nectar/sensors/nodes/rangefinder_node.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""ROS2 node that bridges a serial rangefinder to MAVLink DISTANCE_SENSOR.
+
+Designed to run in parallel with MAVROS so that missions stay unchanged:
+the FCU is configured with ``RNGFND1_TYPE = 10`` (MAVLink) and consumes
+the ``DISTANCE_SENSOR`` stream this node emits. ArduPilot then re-emits
+``RANGEFINDER`` (id 173) telemetry that MAVROS publishes on
+``/mavros/rangefinder/rangefinder``, which any
+``nectar.control.MavrosDrone``-based mission is already subscribed to.
+
+Run::
+
+    ros2 run nectar rangefinder_node.py --ros-args \\
+        -p serial_port:=/dev/ttyUSB0 \\
+        -p mavlink_url:=udp:127.0.0.1:14551 \\
+        -p filter:=obstacle_mask \\
+        -p obstacle_height_m:=1.7
+"""
+
+import rclpy
+from rclpy.node import Node
+
+from nectar.control.mavlink import MavlinkConnection
+from nectar.sensors import ObstacleMaskFilter, RangefinderPublisher, TFLuna
+
+
+class RangefinderNode(Node):
+    """
+    ROS2 entry point that wires TF-Luna + filter + MAVLink publisher.
+
+    All knobs are exposed as ROS parameters so per-mission tuning lives in
+    the launch file. The node owns a background thread (the publisher),
+    not a ROS timer, so it is independent of the ROS executor's load.
+    """
+
+    FILTER_NONE = "none"
+    FILTER_OBSTACLE_MASK = "obstacle_mask"
+
+    def __init__(self) -> None:
+        super().__init__("rangefinder_node")
+
+        self.declare_parameter("serial_port", "/dev/ttyUSB0")
+        self.declare_parameter("baudrate", 115200)
+        self.declare_parameter("mavlink_url", "udp:127.0.0.1:14551")
+        self.declare_parameter("mavlink_baud", 921600)
+        self.declare_parameter("source_system", 1)
+        self.declare_parameter("source_component", 191)
+        self.declare_parameter("heartbeat_timeout_s", 30.0)
+
+        self.declare_parameter("sensor_id", 0)
+        self.declare_parameter("orientation", 25)
+        self.declare_parameter("min_distance_m", 0.05)
+        self.declare_parameter("max_distance_m", 8.0)
+        self.declare_parameter("covariance_cm", 0)
+        self.declare_parameter("rate_hz", 50.0)
+
+        self.declare_parameter("filter", self.FILTER_NONE)
+        self.declare_parameter("obstacle_height_m", 0.0)
+        self.declare_parameter("max_change_m", 0.30)
+        self.declare_parameter("avg_window", 10)
+        self.declare_parameter("timeout_s", 5.0)
+
+        self._sensor: TFLuna | None = None
+        self._connection: MavlinkConnection | None = None
+        self._publisher: RangefinderPublisher | None = None
+
+        self._build_pipeline()
+        self._publisher.start()
+        self.get_logger().info("Rangefinder publisher started")
+
+    def _build_pipeline(self) -> None:
+        port = self.get_parameter("serial_port").value
+        baudrate = int(self.get_parameter("baudrate").value)
+        mavlink_url = self.get_parameter("mavlink_url").value
+        mavlink_baud = int(self.get_parameter("mavlink_baud").value)
+        heartbeat_timeout = float(self.get_parameter("heartbeat_timeout_s").value)
+        source_system = int(self.get_parameter("source_system").value)
+        source_component = int(self.get_parameter("source_component").value)
+
+        self.get_logger().info(f"Opening TF-Luna on {port} @ {baudrate} bps")
+        self._sensor = TFLuna(port=port, baudrate=baudrate)
+
+        self.get_logger().info(f"Connecting MAVLink to {mavlink_url}")
+        self._connection = MavlinkConnection(
+            source_system=source_system,
+            source_component=source_component,
+            heartbeat_timeout=heartbeat_timeout,
+        )
+        self._connection.connect(mavlink_url, baud=mavlink_baud)
+        self.get_logger().info(
+            f"FCU heartbeat received "
+            f"(sys={self._connection.master.target_system}, "
+            f"comp={self._connection.master.target_component})"
+        )
+
+        self._publisher = RangefinderPublisher(
+            sensor=self._sensor,
+            connection=self._connection,
+            sensor_id=int(self.get_parameter("sensor_id").value),
+            orientation=int(self.get_parameter("orientation").value),
+            min_distance_m=float(self.get_parameter("min_distance_m").value),
+            max_distance_m=float(self.get_parameter("max_distance_m").value),
+            covariance_cm=int(self.get_parameter("covariance_cm").value),
+            rate_hz=float(self.get_parameter("rate_hz").value),
+            filter=self._build_filter(),
+        )
+
+    def _build_filter(self):
+        kind = self.get_parameter("filter").value
+        if kind == self.FILTER_NONE:
+            self.get_logger().info("Filter disabled (raw passthrough)")
+            return None
+
+        if kind == self.FILTER_OBSTACLE_MASK:
+            obstacle_height = float(self.get_parameter("obstacle_height_m").value)
+            max_change = float(self.get_parameter("max_change_m").value)
+            avg_window = int(self.get_parameter("avg_window").value)
+            timeout_raw = float(self.get_parameter("timeout_s").value)
+            timeout = timeout_raw if timeout_raw > 0 else None
+            self.get_logger().info(
+                f"Filter: obstacle_mask "
+                f"(height={obstacle_height:.2f}m, max_change={max_change:.2f}m, "
+                f"window={avg_window}, timeout={timeout})"
+            )
+            return ObstacleMaskFilter(
+                obstacle_height_m=obstacle_height,
+                max_change_m=max_change,
+                avg_window=avg_window,
+                timeout_s=timeout,
+            )
+
+        raise ValueError(
+            f"Unknown filter '{kind}'. Valid: {self.FILTER_NONE}, {self.FILTER_OBSTACLE_MASK}"
+        )
+
+    def destroy_node(self) -> bool:
+        if self._publisher is not None:
+            self._publisher.stop()
+        if self._sensor is not None:
+            self._sensor.close()
+        if self._connection is not None:
+            self._connection.close()
+        return super().destroy_node()
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = RangefinderNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/nectar/nectar/sensors/nodes/rangefinder_node.py
+++ b/nectar/nectar/sensors/nodes/rangefinder_node.py
@@ -13,8 +13,7 @@ Run::
     ros2 run nectar rangefinder_node.py --ros-args \\
         -p serial_port:=/dev/ttyUSB0 \\
         -p mavlink_url:=udp:127.0.0.1:14551 \\
-        -p filter:=obstacle_mask \\
-        -p obstacle_height_m:=1.7
+        -p filter:=obstacle_mask
 """
 
 import rclpy
@@ -58,6 +57,7 @@ class RangefinderNode(Node):
         self.declare_parameter("obstacle_height_m", 0.0)
         self.declare_parameter("max_change_m", 0.30)
         self.declare_parameter("avg_window", 10)
+        self.declare_parameter("estimate_lock_s", 0.2)
         self.declare_parameter("timeout_s", 5.0)
 
         self._sensor: TFLuna | None = None
@@ -112,20 +112,28 @@ class RangefinderNode(Node):
             return None
 
         if kind == self.FILTER_OBSTACLE_MASK:
-            obstacle_height = float(self.get_parameter("obstacle_height_m").value)
+            obstacle_height_raw = float(self.get_parameter("obstacle_height_m").value)
+            obstacle_height = obstacle_height_raw if obstacle_height_raw > 0 else None
             max_change = float(self.get_parameter("max_change_m").value)
             avg_window = int(self.get_parameter("avg_window").value)
+            estimate_lock = float(self.get_parameter("estimate_lock_s").value)
             timeout_raw = float(self.get_parameter("timeout_s").value)
             timeout = timeout_raw if timeout_raw > 0 else None
+            height_label = (
+                f"fixed={obstacle_height:.2f}m"
+                if obstacle_height is not None
+                else f"auto-estimated (lock={estimate_lock:.2f}s)"
+            )
             self.get_logger().info(
                 f"Filter: obstacle_mask "
-                f"(height={obstacle_height:.2f}m, max_change={max_change:.2f}m, "
+                f"(height={height_label}, max_change={max_change:.2f}m, "
                 f"window={avg_window}, timeout={timeout})"
             )
             return ObstacleMaskFilter(
                 obstacle_height_m=obstacle_height,
                 max_change_m=max_change,
                 avg_window=avg_window,
+                estimate_lock_s=estimate_lock,
                 timeout_s=timeout,
             )
 

--- a/nectar/nectar/sensors/rangefinder_publisher.py
+++ b/nectar/nectar/sensors/rangefinder_publisher.py
@@ -1,0 +1,147 @@
+"""Rangefinder-to-MAVLink publisher.
+
+Composes a :class:`DistanceSensor`, an optional :class:`DistanceFilter`,
+and a :class:`MavlinkConnection`. Runs a background thread that reads
+the sensor, applies the filter, and sends MAVLink ``DISTANCE_SENSOR``
+(message id 132) to the FCU at a configurable rate.
+
+When the FCU has ``RNGFND1_TYPE = 10`` (MAVLink) it consumes these
+messages as its primary rangefinder source and re-emits ``RANGEFINDER``
+(id 173) telemetry that MAVROS publishes on
+``/mavros/rangefinder/rangefinder``. See
+https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR.
+"""
+
+import threading
+import time
+from typing import Optional
+
+from pymavlink import mavutil
+
+from nectar.control.mavlink.connection import MavlinkConnection
+from nectar.sensors.base import DistanceFilter, DistanceSensor
+
+
+class RangefinderPublisher:
+    """
+    Bridge a :class:`DistanceSensor` to MAVLink ``DISTANCE_SENSOR``.
+
+    Parameters
+    ----------
+    sensor : DistanceSensor
+        Source of raw distance readings in meters.
+    connection : MavlinkConnection
+        Open MAVLink endpoint to the FCU.
+    sensor_id : int, optional
+        MAVLink sensor id (0-7). ArduPilot maps this to ``RNGFND<id+1>_*``.
+        Default 0.
+    sensor_type : int, optional
+        MAVLink ``MAV_DISTANCE_SENSOR`` enum. Default ``LASER``.
+    orientation : int, optional
+        MAVLink ``MAV_SENSOR_ORIENTATION`` enum. Default ``PITCH_270``
+        (downward).
+    min_distance_m : float, optional
+        Minimum range the sensor can report, in meters. Default 0.05.
+    max_distance_m : float, optional
+        Maximum range the sensor can report, in meters. Default 8.0.
+    covariance_cm : int, optional
+        Measurement covariance hint in centimeters (0-254). 0 means
+        "unknown / use ArduPilot defaults". Default 0.
+    rate_hz : float, optional
+        Publishing rate. Default 50.
+    filter : DistanceFilter, optional
+        Pre-publish filter. ``None`` means publish raw readings.
+
+    Notes
+    -----
+    A background thread is created on :meth:`start`. The thread sleeps on
+    a :class:`threading.Event`, so :meth:`stop` is responsive.
+    """
+
+    def __init__(
+        self,
+        sensor: DistanceSensor,
+        connection: MavlinkConnection,
+        *,
+        sensor_id: int = 0,
+        sensor_type: int = mavutil.mavlink.MAV_DISTANCE_SENSOR_LASER,
+        orientation: int = mavutil.mavlink.MAV_SENSOR_ROTATION_PITCH_270,
+        min_distance_m: float = 0.05,
+        max_distance_m: float = 8.0,
+        covariance_cm: int = 0,
+        rate_hz: float = 50.0,
+        filter: Optional[DistanceFilter] = None,
+    ) -> None:
+        if rate_hz <= 0:
+            raise ValueError("rate_hz must be positive")
+        if not (0 <= sensor_id <= 7):
+            raise ValueError("sensor_id must be in [0, 7]")
+        if min_distance_m < 0 or max_distance_m <= min_distance_m:
+            raise ValueError("require 0 <= min_distance_m < max_distance_m")
+
+        self._sensor = sensor
+        self._connection = connection
+        self._filter = filter
+
+        self._sensor_id = sensor_id
+        self._sensor_type = sensor_type
+        self._orientation = orientation
+        self._min_cm = int(round(min_distance_m * 100))
+        self._max_cm = int(round(max_distance_m * 100))
+        self._covariance = max(0, min(254, int(covariance_cm)))
+        self._period = 1.0 / rate_hz
+
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the background loop is active."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> None:
+        """Start the background read/filter/publish loop."""
+        if self.is_running:
+            return
+        if not self._connection.is_connected:
+            raise RuntimeError("MavlinkConnection is not connected")
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._loop, name="rangefinder-publisher", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        """Signal the loop to exit and join the thread."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+
+    def _loop(self) -> None:
+        while not self._stop_event.is_set():
+            cycle_start = time.monotonic()
+
+            raw = self._sensor.read()
+            if raw is not None:
+                value = raw if self._filter is None else self._filter.process(raw)
+                if value is not None:
+                    self._send(value)
+
+            elapsed = time.monotonic() - cycle_start
+            self._stop_event.wait(timeout=max(0.0, self._period - elapsed))
+
+    def _send(self, distance_m: float) -> None:
+        distance_cm = max(0, min(0xFFFF, int(round(distance_m * 100))))
+        time_boot_ms = int(time.monotonic() * 1000) & 0xFFFFFFFF
+        self._connection.master.mav.distance_sensor_send(
+            time_boot_ms,
+            self._min_cm,
+            self._max_cm,
+            distance_cm,
+            self._sensor_type,
+            self._sensor_id,
+            self._orientation,
+            self._covariance,
+        )

--- a/nectar/pyproject.toml
+++ b/nectar/pyproject.toml
@@ -66,8 +66,13 @@ oakd = [
     "depthai==2.32.0.0",
 ]
 
+sensors = [
+    "pyserial>=3.5,<4.0",
+    "pymavlink>=2.4.40,<3.0",
+]
+
 all = [
-    "nectar-sdk[control,vision,interface,realsense,oakd]",
+    "nectar-sdk[control,vision,interface,realsense,oakd,sensors]",
 ]
 
 full = [


### PR DESCRIPTION
This pull request introduces a new direct MAVLink control path via `pymavlink`, adds a minimal `MavlinkConnection` wrapper, and refactors the drone control SDK to support both SDK-owned and user-owned ROS spinning patterns. 

**Direct MAVLink support:**

* Added a new `nectar.control.mavlink` module providing a minimal `MavlinkConnection` wrapper for direct MAVLink communication using `pymavlink`. This enables sensor publishers and custom message senders to connect directly to the flight controller without MAVROS. A future `MavlinkDrone` is planned. [[1]](diffhunk://#diff-b022f25d53573a24c548826603cd3bea23e013130ca21fd3698debfc5714ec33R1-R28) [[2]](diffhunk://#diff-c73434c3ff70351fcdf2fe666d65481a57e387ec2dc3650a76a207f22259e1e3R1-R121) [[3]](diffhunk://#diff-e2ebb921652f9325ec5f2d696e1759fa1b074b84e679370dd2e7632dce39946dR1-R48)
* Updated `nectar.control.__init__` to expose `MavlinkConnection` for import and type checking. [[1]](diffhunk://#diff-4cae39862364cf9564602ba7e483ed071d95ee49c11cd737c92d6d075ea3660cR64-R65) [[2]](diffhunk://#diff-4cae39862364cf9564602ba7e483ed071d95ee49c11cd737c92d6d075ea3660cR85) [[3]](diffhunk://#diff-4cae39862364cf9564602ba7e483ed071d95ee49c11cd737c92d6d075ea3660cR126)
* Add TFLuna lidar communication via serial and publish to distance sensor mavlink

**ROS 2 spinning and wait loop improvements:**

* Refactored the SDK to transparently support both SDK-owned and user-owned ROS spinning: added a `_wait` helper in `BaseDrone` that either spins the executor or sleeps, depending on ownership. Updated all synchronous wait loops to use this helper, improving compatibility with custom executors and GUIs. [[1]](diffhunk://#diff-51891d3ce05b38a02346fe63a837b5686ada3dd706c3348144f0e6102036a68dR1-L7) [[2]](diffhunk://#diff-51891d3ce05b38a02346fe63a837b5686ada3dd706c3348144f0e6102036a68dR53) [[3]](diffhunk://#diff-51891d3ce05b38a02346fe63a837b5686ada3dd706c3348144f0e6102036a68dL777-R785) [[4]](diffhunk://#diff-51891d3ce05b38a02346fe63a837b5686ada3dd706c3348144f0e6102036a68dL823-R858) [[5]](diffhunk://#diff-1700e41946b77b54da4fba3d2c426afa3d95bd64a0c68e27a9ea08c6a8c8aa03L283-R283) [[6]](diffhunk://#diff-1700e41946b77b54da4fba3d2c426afa3d95bd64a0c68e27a9ea08c6a8c8aa03L406-R406) [[7]](diffhunk://#diff-1700e41946b77b54da4fba3d2c426afa3d95bd64a0c68e27a9ea08c6a8c8aa03L472-R472) [[8]](diffhunk://#diff-1700e41946b77b54da4fba3d2c426afa3d95bd64a0c68e27a9ea08c6a8c8aa03L879-R879) [[9]](diffhunk://#diff-1700e41946b77b54da4fba3d2c426afa3d95bd64a0c68e27a9ea08c6a8c8aa03L979-R979) [[10]](diffhunk://#diff-1700e41946b77b54da4fba3d2c426afa3d95bd64a0c68e27a9ea08c6a8c8aa03L1059-R1062) [[11]](diffhunk://#diff-06eabf43bde85203c725ebf74251450538f734583008cad516dd8f6aa71abeddR1-L5)

**Documentation updates:**

* Added a "Spinning Model" section to the control SDK README to explain the dual executor ownership patterns.
* Updated the MAVROS README to clarify the new cooperative wait logic in service calls.
* Added a README for the new MAVLink module, including usage examples and future plans.

**Build and install system:**

* Added new sensor and MAVLink example scripts and nodes to the install list in `CMakeLists.txt`.
* Updated the `Makefile` to add a `python-sensors` target and include it in the PHONY list. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L4-R4) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R38)