### PR TITLE
docs: add full portuguese (pt-BR) documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,16 +6,20 @@ on:
     paths:
       - "website/**"
       - "docs/**"
+      - "i18n/**"
       - "scripts/docs/**"
       - "mkdocs.yml"
+      - "mkdocs.pt.yml"
       - "**/README.md"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "website/**"
       - "docs/**"
+      - "i18n/**"
       - "scripts/docs/**"
       - "mkdocs.yml"
+      - "mkdocs.pt.yml"
       - "**/README.md"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
@@ -39,10 +43,15 @@ jobs:
           python-version: "3.12"
       - name: Install toolchain
         run: pip install -r scripts/docs/requirements.txt
-      - name: Generate reference pages from READMEs
-        run: python scripts/docs/sync_readmes.py
-      - name: Build site
-        run: zensical build --clean
+      - name: Assemble English and Portuguese docs
+        run: |
+          python scripts/docs/sync_readmes.py
+          python scripts/docs/sync_i18n.py
+      - name: Build bilingual site
+        run: |
+          zensical build --clean -f mkdocs.yml
+          zensical build --clean -f mkdocs.pt.yml
+          rm -rf build/site/pt && mkdir -p build/site/pt && cp -a build/site-pt/. build/site/pt/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build/site

--- a/Makefile
+++ b/Makefile
@@ -153,16 +153,34 @@ driver-stop:      ; @$(SETUP) driver-stop
 # Full setup from zero
 full-install:       ; @$(SETUP) full-install
 
-# Documentation site (Zensical). Edit website/ (authored pages), the module
-# READMEs, and docs/*.md; everything generated is assembled under build/.
-# Mermaid diagrams are rendered natively by Zensical (client-side, theme-aware).
+# Documentation site (Zensical). Edit website/ (authored EN pages), i18n/pt/
+# (Portuguese), the module READMEs, and docs/*.md; everything generated is
+# under build/. Mermaid is rendered client-side by Zensical.
 #   make docs-install   create .venv-docs and install the Python doc toolchain
-#   make docs-sync      assemble build/docs/ from website/ + READMEs + docs/*.md
-#   make docs           sync, then compile the HTML into build/site/
-#   make docs-serve     sync, then live preview at http://localhost:8000
-.PHONY: docs-install docs-sync docs docs-serve
+#   make docs-sync      assemble build/docs/ (EN) and build/docs-pt/ (PT)
+#   make docs           sync, build EN + PT, merge PT into build/site/pt/
+#   make docs-serve     full bilingual build, then serve at
+#                       http://localhost:8000/nectar-sdk/  (and .../pt/)
+#   make docs-serve-en  English-only live reload (language switcher 404s for PT)
+.PHONY: docs-install docs-sync docs docs-serve docs-serve-en
 DOCS_VENV := .venv-docs
-docs-install: ; @[ -d $(DOCS_VENV) ] || uv venv $(DOCS_VENV); uv pip install --python $(DOCS_VENV)/bin/python -r scripts/docs/requirements.txt
-docs-sync:    ; @$(DOCS_VENV)/bin/python scripts/docs/sync_readmes.py
-docs:         ; @$(MAKE) docs-sync && $(DOCS_VENV)/bin/zensical build --clean
-docs-serve:   ; @$(MAKE) docs-sync && $(DOCS_VENV)/bin/zensical serve
+# Absolute paths: docs-serve cds into build/serve/, so relative .venv-docs breaks.
+DOCS_PYTHON := $(CURDIR)/$(DOCS_VENV)/bin/python
+DOCS_ZENSICAL := $(CURDIR)/$(DOCS_VENV)/bin/zensical
+docs-install:
+	@[ -d $(DOCS_VENV) ] || uv venv $(DOCS_VENV)
+	@uv pip install --python $(DOCS_PYTHON) -r scripts/docs/requirements.txt
+docs-sync:
+	@$(DOCS_PYTHON) scripts/docs/sync_readmes.py
+	@$(DOCS_PYTHON) scripts/docs/sync_i18n.py
+docs: docs-sync
+	@$(DOCS_ZENSICAL) build --clean -f mkdocs.yml
+	@$(DOCS_ZENSICAL) build --clean -f mkdocs.pt.yml
+	@rm -rf build/site/pt && mkdir -p build/site/pt && cp -a build/site-pt/. build/site/pt/
+docs-serve: docs
+	@rm -rf build/serve && mkdir -p build/serve/nectar-sdk
+	@cp -a build/site/. build/serve/nectar-sdk/
+	@echo "Bilingual docs: http://localhost:8000/nectar-sdk/  and  http://localhost:8000/nectar-sdk/pt/"
+	@cd $(CURDIR)/build/serve && $(DOCS_PYTHON) -m http.server 8000
+docs-serve-en: docs-sync
+	@$(DOCS_ZENSICAL) serve -f mkdocs.yml

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ROS 2 software development kit for autonomous aerial systems. Unified interfaces
 
 ## Documentation
 
-Please visit the **[Nectar SDK documentation](https://black-bee-drones.github.io/nectar-sdk/)** for installation, tutorials, module reference, Python API, simulation, and Docker.
+Please visit the **Nectar SDK documentation** ([en](https://black-bee-drones.github.io/nectar-sdk/) | [pt-BR](https://black-bee-drones.github.io/nectar-sdk/pt/)) for installation, tutorials, module reference, Python API, simulation, and Docker.
 
 ## Features
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -10,7 +10,7 @@ cells advance as more setups are exercised
 
 ## Legend
 
-Each cell's symbol reflects the deepest verification tier reached (see [How it's verified](#how-its-verified)). Rows with a footnote marker carry a caveat at the bottom of the page.
+Each cell's symbol reflects the deepest verification tier reached (see [How it's verified](#how-its-verified)).
 
 | Symbol | Meaning |
 |:---:|---|
@@ -51,7 +51,7 @@ Install: `make python-vision` (algorithms) / camera extras as needed.
 |---|:---:|:---:|:---:|:---:|
 | ArUco / color / line / distance (algorithms) | ● | ● | ● | ● |
 | ROS-topic camera (`CameraFactory`) | ● | ● | ● | ● |
-| USB / OpenCV camera[^usb] | ● | ● | ● | ● |
+| USB / OpenCV camera | ● | ● | ● | ● |
 | RealSense D4xx (librealsense from source)[^realsense] | ● | ● | ◐ | ● |
 | OAK-D (`depthai`)[^oakd] | ● | ● | ◐ | ● |
 | MediaPipe hand / face[^mediapipe] | ● | ● | ● | ◐ |
@@ -64,7 +64,7 @@ Install: `make python-control`; backends are opt-in (`make drone-<x>`).
 |---|:---:|:---:|:---:|:---:|
 | Vehicle core (PID, navigator, frame transforms) | ● | ● | ● | ● |
 | Direct MAVLink (`pymavlink`) transport[^mavlink] | ● | ● | ● | ● |
-| MAVROS backend (ArduPilot / PX4)[^mavros] | ◐ | ● | ● | ◐ |
+| MAVROS backend (ArduPilot / PX4) | ◐ | ● | ● | ◐ |
 | PX4 native uXRCE-DDS[^px4dds] | ● | ● | ● | ◐ |
 | Crazyflie / Crazyswarm2[^crazyflie] | ● | ● | ● | ○ |
 | Bebop driver[^bebop] | ● | ◐ | ◐ | — |

--- a/docs/development/commands.md
+++ b/docs/development/commands.md
@@ -118,9 +118,10 @@ See [Docker](../../docker/README.md).
 | Command | Does |
 |---|---|
 | `make docs-install` | Create `.venv-docs` and install the doc toolchain |
-| `make docs-sync` | Assemble `build/docs/` from `website/` + READMEs + `docs/*.md` |
-| `make docs` | Sync, then build the HTML into `build/site/` |
-| `make docs-serve` | Sync, then live-preview at `http://localhost:8000` |
+| `make docs-sync` | Assemble `build/docs/` (EN) and `build/docs-pt/` (PT) |
+| `make docs` | Sync, build EN + PT, merge into `build/site/` (+ `build/site/pt/`) |
+| `make docs-serve` | Bilingual preview at `http://localhost:8000/nectar-sdk/` and `.../pt/` |
+| `make docs-serve-en` | English-only live reload (PT language links 404) |
 
 Edit the authored pages under `website/`, the module READMEs, and `docs/*.md`; everything under
 `build/` is generated. Conventions are in [Contributing](../CONTRIBUTING.md).

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -110,7 +110,7 @@ deactivate                 # leave it (shell built-in)
 uv pip install <package>   # add a package (fast); plain `pip install` also works
 ```
 
-Prefer it always active? Add one line to `~/.bashrc`:
+To activate the env in every new shell, add one line to `~/.bashrc`:
 
 ```bash
 source ~/ros2_ws/.venv/bin/activate

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,0 +1,204 @@
+# Documentation translations (i18n)
+
+Portuguese (Brazil) pages for the [Nectar SDK docs site](https://black-bee-drones.github.io/nectar-sdk/).
+English remains the source of truth for module `README.md` files in the package tree.
+Python API pages stay English-only; from PT, link to `/api/…` with “(em inglês)”.
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `i18n/pt/` | Author Portuguese Markdown (edit these) |
+| `build/docs-pt/` | Assembled PT docs dir (generated — do not edit) |
+| `build/site/pt/` | Built PT HTML under the English site (generated) |
+
+English authored pages stay in `website/` and `docs/`; module reference pages are synced from package READMEs by `scripts/docs/sync_readmes.py`.
+
+## Workflow
+
+1. Edit or add files under `i18n/pt/`, mirroring the site path (e.g. `i18n/pt/setup/index.md` → `/pt/setup/`).
+2. Keep meaning, structure, code fences, Mermaid, and identifiers identical to the English source. Follow the glossary below.
+3. Run `make docs-sync` (or `make docs`) — never hand-edit `build/`.
+4. Preview bilingual site (same URL layout as GitHub Pages):
+
+   ```bash
+   make docs-serve
+   ```
+
+   Open [http://localhost:8000/nectar-sdk/](http://localhost:8000/nectar-sdk/) and [http://localhost:8000/nectar-sdk/pt/](http://localhost:8000/nectar-sdk/pt/).
+   The header language selector switches between them. English-only live reload:
+   `make docs-serve-en` (Portuguese URLs 404 in that mode).
+
+5. Add the page to `nav` in `mkdocs.pt.yml` when publishing.
+6. Flip the checklist status below (`todo` → `draft` → `reviewed`).
+
+## Quality
+
+- Natural pt-BR; no calque “atrás de” for architectural *behind*.
+- Code comments in fences stay English.
+- Untranslated targets (API only): escape `/pt/` and mark “(em inglês)”.
+
+## Glossary (pt-BR)
+
+Preferred wording for Portuguese documentation. Do not translate code identifiers, CLI flags, package names, topic names, or API symbols.
+
+| English | Portuguese (docs) | Notes |
+|---------|-------------------|--------|
+| autonomous | autônomo / autônoma | |
+| companion computer | computador de bordo | |
+| drone / vehicle | drone / veículo | Prefer “drone” in tutorials |
+| flight controller / FCU | controlador de voo / FCU | Keep `FCU` |
+| firmware | firmware | Keep as-is |
+| mission | missão | |
+| takeoff | decolagem / `takeoff` | Verb in prose: “decolar”; method name unchanged |
+| land / landing | pousar / pouso | Method `land` unchanged |
+| return to launch / RTL | retorno ao ponto de lançamento / RTL | Keep `RTL` next to APIs; spell out once in prose |
+| pose | pose | Keep as-is |
+| setpoint | setpoint | Keep as-is |
+| waypoint | waypoint | Keep as-is |
+| transport | transporte | MAVROS/MAVLink “transport” in control docs |
+| pose source | fonte de pose | |
+| rangefinder | rangefinder / medidor de distância | Prefer “rangefinder” next to APIs |
+| obstacle avoidance / obstacle handling | desvio de obstáculos | Never “tratamento de obstáculos” |
+| localization | localização | |
+| odometry | odometria | |
+| frame (TF / image) | frame | Keep in technical context |
+| overlay | overlay | Keep as-is |
+| handler | handler | Keep class role name; explain in prose if needed |
+| factory | factory | Keep pattern name and English word order (“camera factory”); “fábrica” only in plain explanation |
+| runtime | runtime | Keep as-is |
+| workspace | workspace | |
+| driver | driver | |
+| simulation / SITL | simulação / SITL | |
+| SITL run | execução SITL / sessão SITL | Not “corrida SITL” |
+| annotated run | execução anotada | |
+| wire format | formato on-wire / formato de transmissão | Not “formato do fio” |
+| behind (architecture) | por meio de / em uma interface unificada | Never calque “atrás de” for “behind one interface” |
+| indoor / outdoor | indoor / outdoor | Keep as-is next to competition/mission context; “interno/externo” only in plain explanation |
+| installation | instalação | |
+| setup | configuração / instalação | Prefer “instalação” for install guides; “configuração” for config |
+| computer vision | visão computacional | |
+| detection | detecção | |
+| segmentation | segmentação | |
+| classification | classificação | |
+| model | modelo | |
+| inference | inferência | |
+| training | treinamento | |
+| ground truth | ground truth | Keep as-is |
+| zoom / watch larger | ampliar | Carousel/figcaption UI |
+| Get started | Começar | Nav label |
+| Setup | Instalação | Nav section for install/setup guides |
+| Concepts | Conceitos | |
+| Architecture | Arquitetura | |
+| Modules | Módulos | |
+| Examples | Exemplos | |
+| Development | Desenvolvimento | |
+| Community | Comunidade | |
+| Home | Início | Nav label |
+| With / without | Com / sem | Nav / button |
+
+### Code and comments
+
+- Identifiers, CLI flags, topics, package names, API symbols: always English.
+- Comments inside fenced code blocks: keep English (same as identifiers).
+- Shell prompt hints such as `# pick: control` stay English when they mirror the installer UI.
+
+### Always keep in English
+
+ArduPilot, PX4, MAVROS, MAVLink, Crazyflie, Bebop, ROS 2, Humble, Jazzy, Kilted, Gazebo, Docker, RealSense, T265, Ultralytics, YOLO, DETR, RF-DETR, MediaPipe, Qt6, Black Bee Drones, IMAV, CBR, SAE Eletroquad, Nectar SDK, and all code/API names.
+
+If another language is added later, either extend this README with a locale section or split a per-locale glossary back out (e.g. `glossary.es.md`).
+
+## Phase checklist
+
+Statuses: `todo` | `draft` | `reviewed`.
+
+### Phase 0 — Standards + Phase 1 polish
+
+| Page | Status |
+|------|--------|
+| Glossary (this README) | reviewed |
+| `pt/index.md` | reviewed |
+| `pt/get-started/index.md` | reviewed |
+| `pt/get-started/control.md` | reviewed |
+| `pt/get-started/vision.md` | reviewed |
+| `pt/get-started/ai.md` | reviewed |
+| `pt/concepts/architecture.md` | reviewed |
+| `pt/setup/index.md` | reviewed |
+| `pt/setup/drivers.md` | reviewed |
+| `pt/setup/simulation.md` | reviewed |
+| `pt/setup/realsense.md` | reviewed |
+| `pt/setup/configuration.md` | reviewed |
+| `pt/setup/compatibility.md` | reviewed |
+
+### Phase 1b — Onboarding gaps
+
+| Page | Status |
+|------|--------|
+| `pt/get-started/with-without.md` | reviewed |
+| `pt/setup/docker.md` | reviewed |
+
+### Phase 2 — Module overviews
+
+| Page | Status |
+|------|--------|
+| `pt/modules/control/index.md` | reviewed |
+| `pt/modules/vision/index.md` | reviewed |
+| `pt/modules/ai/index.md` | reviewed |
+| `pt/modules/sensors.md` | reviewed |
+| `pt/modules/interface.md` | reviewed |
+| `pt/modules/simulation.md` | reviewed |
+| `pt/modules/interfaces.md` | reviewed |
+| `pt/modules/utils.md` | reviewed |
+
+### Phase 3 — Control deep reference
+
+| Page | Status |
+|------|--------|
+| `pt/modules/control/vehicle.md` | reviewed |
+| `pt/modules/control/mavros.md` | reviewed |
+| `pt/modules/control/mavlink.md` | reviewed |
+| `pt/modules/control/ardupilot.md` | reviewed |
+| `pt/modules/control/px4.md` | reviewed |
+| `pt/modules/control/localization/index.md` | reviewed |
+| `pt/modules/control/localization/concepts.md` | reviewed |
+| `pt/modules/control/localization/legacy.md` | reviewed |
+| `pt/modules/control/obstacles.md` | reviewed |
+| `pt/modules/control/pid.md` | reviewed |
+| `pt/modules/control/bebop.md` | reviewed |
+| `pt/modules/control/crazyflie.md` | reviewed |
+
+### Phase 4 — Vision + AI deep reference
+
+| Page | Status |
+|------|--------|
+| `pt/modules/vision/camera.md` | reviewed |
+| `pt/modules/vision/algorithms.md` | reviewed |
+| `pt/modules/vision/nodes.md` | reviewed |
+| `pt/modules/ai/detection.md` | reviewed |
+| `pt/modules/ai/segmentation.md` | reviewed |
+| `pt/modules/ai/classification.md` | reviewed |
+
+### Phase 5 — Examples, projects, community, development
+
+| Page | Status |
+|------|--------|
+| `pt/modules/examples/index.md` | reviewed |
+| `pt/modules/examples/control.md` | reviewed |
+| `pt/modules/examples/vision.md` | reviewed |
+| `pt/modules/examples/ai.md` | reviewed |
+| `pt/modules/examples/sensors.md` | reviewed |
+| `pt/projects/index.md` | reviewed |
+| `pt/community/index.md` | reviewed |
+| `pt/development/commands.md` | reviewed |
+| `pt/project/contributing.md` | reviewed |
+| `pt/project/releasing.md` | reviewed |
+| `pt/project/code-of-conduct.md` | reviewed |
+| `pt/project/security.md` | reviewed |
+| API (`website/api/*`) | skipped (EN only) |
+
+### Phase 6 — Consistency
+
+| Item | Status |
+|------|--------|
+| Glossary grep / link / switcher pass | reviewed |

--- a/i18n/pt/community/index.md
+++ b/i18n/pt/community/index.md
@@ -1,0 +1,41 @@
+# Comunidade
+
+O Nectar SDK é construído e usado pela [Black Bee Drones](https://github.com/Black-Bee-Drones),
+uma equipe de competição de drones autônomos. Contribuições, perguntas e relatos de bugs são
+bem-vindos.
+
+## Participe
+
+<div class="grid cards" markdown>
+
+-   **Pergunte ou discuta**
+
+    Perguntas gerais, ideias e discussão de design.
+
+    [GitHub Discussions](https://github.com/Black-Bee-Drones/nectar-sdk/discussions)
+
+-   **Relate um bug ou peça uma funcionalidade**
+
+    Uma issue por relato, com passos para reproduzir e sua versão/SO/hardware.
+
+    [GitHub Issues](https://github.com/Black-Bee-Drones/nectar-sdk/issues)
+
+-   **Contribua com código ou documentação**
+
+    Instalação, convenções de estilo, testes e o processo de pull request.
+
+    [Contribuindo](../project/contributing.md)
+
+-   **Veja em ação**
+
+    As missões de competição construídas sobre o SDK.
+
+    [Projetos](../projects/index.md)
+
+</div>
+
+## Políticas
+
+- [Código de Conduta](../project/code-of-conduct.md) — comportamento esperado e como relatar problemas.
+- [Segurança](../project/security.md) — como relatar uma vulnerabilidade.
+- [Processo de release](../project/releasing.md) — como os mantenedores versionam e publicam releases.

--- a/i18n/pt/concepts/architecture.md
+++ b/i18n/pt/concepts/architecture.md
@@ -1,0 +1,206 @@
+# Arquitetura
+
+O código de missão, as máquinas de estados e a GUI acionam os módulos do SDK, que chegam
+aos controladores de voo, câmeras e modelos de detecção via ROS 2. Cada página de módulo
+tem seu próprio diagrama de classes detalhado; esta página é a visão ponta a ponta e os
+padrões compartilhados entre todos os módulos.
+
+## Ponta a ponta
+
+Leia da esquerda para a direita como quatro camadas:
+
+1. **Application** — seu código de missão, máquinas de estados
+   [Yasmin](https://github.com/uleroboticsgroup/yasmin) ou a GUI Qt6.
+2. **Nectar SDK** — os módulos `control`, `vision`, `ai` e `sensors`, cada um acessado por
+   uma factory ou protocol e apoiado pelos `utils` compartilhados.
+3. **ROS 2 middleware** — os tópicos, serviços, actions e TF2 que carregam tudo, mais as
+   mensagens `nectar_interfaces`.
+4. **External systems** — controladores de voo, câmeras, VSLAM e modelos.
+
+Cada módulo é colorido por camada. Setas sólidas são os caminhos principais de dados/comando;
+a seta pontilhada marca um vínculo opcional (frames de profundidade alimentando detecção de
+obstáculos). Clique no diagrama para zoom e pan.
+
+```mermaid
+---
+config:
+  layout: elk
+  elk:
+    nodePlacementStrategy: NETWORK_SIMPLEX
+    mergeEdges: true
+---
+flowchart LR
+  subgraph APP["Application"]
+    direction TB
+    Mission["Mission code / examples"]
+    FSM["State machines · Yasmin"]
+    GUI["Qt6 GUI · NectarApp"]
+  end
+
+  subgraph SDK["Nectar SDK"]
+    direction TB
+
+    subgraph CTRL["control"]
+      direction TB
+      DroneFactory(["DroneFactory"])
+      DroneProto{{"Drone protocol"}}
+      VehicleDrone["VehicleDrone<br/>ArduPilot · PX4 core"]
+      Transports["Transports<br/>MAVROS · MAVLink · uXRCE-DDS"]
+      OtherDrones["BebopDrone · CrazyflieDrone"]
+      Nav["Navigator · PID · Sequencer"]
+      Obstacles["ObstacleManager<br/>detector + strategy"]
+      Loc["Localization<br/>vision-pose bridge"]
+    end
+
+    subgraph VIS["vision"]
+      direction TB
+      CameraFactory(["CameraFactory"])
+      ImageHandler["ImageHandler"]
+      VisAlgos["ArUco · Color · Line<br/>Distance · MediaPipe"]
+    end
+
+    subgraph AIM["ai"]
+      direction TB
+      DetSeg(["Detector / Segmentor"])
+      AIExtras["Slicing · Training · Evaluation"]
+    end
+
+    subgraph SENS["sensors"]
+      direction TB
+      Rangefinder["Rangefinder → MAVLink<br/>TF-Luna + filters"]
+    end
+
+    subgraph UTIL["utils"]
+      direction TB
+      Utils["GPSCalculate · PositionUtils<br/>ProcessUtils"]
+    end
+  end
+
+  subgraph ROS["ROS 2 middleware"]
+    direction TB
+    Topics["Topics · Services<br/>Actions · TF2"]
+    Msgs["nectar_interfaces<br/>ArucoTransforms · LineInfo · PhotoInfo"]
+  end
+
+  subgraph EXT["Vehicles · sensors · models"]
+    direction TB
+    FCU["Flight controller<br/>ArduPilot · PX4 · Bebop · Crazyflie"]
+    Cameras["Cameras<br/>USB · RealSense · OAK-D · Pi"]
+    Models["Models<br/>YOLO · DETR · RF-DETR"]
+    VSLAM["Isaac ROS Visual SLAM"]
+  end
+
+  Mission --> DroneFactory
+  Mission --> CameraFactory
+  Mission --> DetSeg
+  FSM --> DroneFactory
+  GUI --> DroneFactory
+  GUI --> CameraFactory
+
+  DroneFactory --> DroneProto
+  DroneProto --> VehicleDrone
+  DroneProto --> OtherDrones
+  VehicleDrone --> Transports
+  VehicleDrone --> Nav
+  VehicleDrone --> Obstacles
+  Nav --> Utils
+
+  CameraFactory --> ImageHandler
+  ImageHandler --> VisAlgos
+  Obstacles -. depth .-> ImageHandler
+  DetSeg --> AIExtras
+  DetSeg --> Models
+  VisAlgos --> Msgs
+
+  Transports <--> Topics
+  Transports <--> FCU
+  Topics <--> FCU
+  ImageHandler <--> Topics
+  ImageHandler --> Cameras
+  VSLAM --> Loc
+  Loc --> FCU
+  Rangefinder --> FCU
+
+  classDef app fill:#3b82f6,stroke:#1d4ed8,color:#ffffff;
+  classDef ctl fill:#f5a623,stroke:#b8770a,color:#1a1a1a;
+  classDef vis fill:#22c55e,stroke:#15803d,color:#052e16;
+  classDef aim fill:#a855f7,stroke:#7c3aed,color:#ffffff;
+  classDef sen fill:#ef4444,stroke:#b91c1c,color:#ffffff;
+  classDef utl fill:#94a3b8,stroke:#475569,color:#0b1220;
+  classDef ros fill:#14b8a6,stroke:#0f766e,color:#04231f;
+  classDef ext fill:#64748b,stroke:#334155,color:#ffffff;
+
+  class Mission,FSM,GUI app;
+  class DroneFactory,DroneProto,VehicleDrone,Transports,OtherDrones,Nav,Obstacles,Loc ctl;
+  class CameraFactory,ImageHandler,VisAlgos vis;
+  class DetSeg,AIExtras aim;
+  class Rangefinder sen;
+  class Utils utl;
+  class Topics,Msgs ros;
+  class FCU,Cameras,Models,VSLAM ext;
+```
+
+## Padrões de projeto
+
+O código usa os mesmos padrões em todos os módulos, o que torna a navegação e a extensão
+previsíveis:
+
+| Padrão | Onde | O que faz |
+|--------|------|-----------|
+| **Factory + Registry** | `DroneFactory`, `CameraFactory`, `Detector` | Desacopla criação do uso. Novos tipos são registrados em runtime e instanciados por chave. |
+| **Protocol** | `Drone`, `ObstacleDetector` | Define interfaces por tipagem estrutural (duck typing). Qualquer classe que corresponda à assinatura é aceita. |
+| **Strategy** | `AvoidanceStrategy`, `ILineEstimationMethod`, `EstimationModel`, `BaseMergingStrategy` | Encapsula algoritmos intercambiáveis por meio de uma interface comum. |
+| **Abstract Base Class** | `BaseDrone`, `AbstractCam`, `DepthCam`, `BaseDetectionModel` | Compartilha lógica comum e impõe contratos de método nas implementações concretas. |
+| **Dataclass Config** | `MavrosConfig`, `OpenCVConfig`, `TrainingConfig`, `EvaluationConfig` | Configuração tipada com defaults, validação e serialização YAML. |
+
+Toda factory permite registro em runtime, então adicionar um novo tipo de drone, driver de
+câmera ou framework de detecção segue a mesma receita:
+
+```python
+DroneFactory.register("custom", lambda cfg, executor: MyDrone(cfg, executor))
+drone = DroneFactory.create("custom", config)
+
+CameraFactory.register("thermal", ThermalCamera)
+camera = CameraFactory.from_source("thermal")
+
+Detector.register("custom", lambda name, **kw: CustomModel(name, **kw))
+detector = Detector("model.bin", framework="custom")
+```
+
+Assinaturas completas de classes e métodos são geradas a partir das docstrings do código na
+[referência da API Python](../../api/) (em inglês): [control](../../api/control/),
+[vision](../../api/vision/), [ai](../../api/ai/), [sensors](../../api/sensors/) e
+[utils](../../api/utils/).
+
+## Modelo de runtime
+
+Cada drone possui seu próprio `Node` ROS 2. Todos os nós de subsistema do SDK entram em um
+`MultiThreadedExecutor` compartilhado gerenciado por `nectar.runtime`, que gira em uma
+thread de fundo. Chamadas bloqueantes (`takeoff`, `land`, `move_to`) dormem na thread do
+chamador enquanto o executor continua disparando callbacks de telemetria. Três padrões de
+uso compartilham as mesmas primitivas:
+
+| Padrão | Chamada de setup | O que acontece |
+|--------|------------------|----------------|
+| Script standalone | `nectar.init()` | Cria o executor compartilhado e a thread de spin; `DroneFactory.create(...)` registra o nó do drone; `nectar.shutdown()` na saída. |
+| Missão Yasmin | `nectar.use_executor(...)` | Chamado uma vez no início para que os subsistemas do SDK se registrem no executor da missão em vez de criar uma segunda thread de spin. |
+| GUI | `ROSExecutor` registra em `nectar.runtime` | Drones e handlers de câmera criados nas abas compartilham o executor do app automaticamente. |
+
+## Transportes: um núcleo, links intercambiáveis
+
+Toda a lógica de voo e navegação vive uma vez no `VehicleDrone` agnóstico a firmware.
+Especializações de firmware (`ArduPilotDrone`, `Px4Drone`) acrescentam só a semântica do
+firmware e leem telemetria / emitem comandos por um `VehicleTransport` plugável:
+
+| Transporte | Classe | Como funciona | Backends |
+|------------|--------|---------------|----------|
+| MAVROS | `MavrosTransport` | Subscriptions → telemetria, clients de serviço → comandos, publishers → setpoints (exige um `mavros_node` em execução). | `mavros`, `px4` |
+| MAVLink direto | `PymavlinkTransport` | Possui o link do FCU diretamente; um `MavlinkModeCodec` isola a única diferença de firmware (encode/decode de modo de voo), então ArduPilot e PX4 o compartilham. | `mavlink`, `px4_mavlink` |
+| uXRCE-DDS | `Px4DdsTransport` | uORB nativo do PX4 pela ponte uXRCE-DDS (`px4_msgs`). | `px4_dds` |
+
+Assim o PX4 oferece três backends (`px4`, `px4_mavlink`, `px4_dds`) e o ArduPilot dois
+(`mavros`, `mavlink`), todos compartilhando a mesma lógica de voo — as missões são
+agnósticas ao backend. O núcleo trabalha em tipos simples, sem ROS (ENU/FLU, radianos);
+cada transporte converte de e para o formato on-wire. Detalhe completo:
+[Vehicle core](../modules/control/vehicle.md) e o
+[módulo Control](../modules/control/index.md).

--- a/i18n/pt/development/commands.md
+++ b/i18n/pt/development/commands.md
@@ -1,0 +1,130 @@
+# Comandos e Makefile
+
+O [`Makefile`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/Makefile) é um
+wrapper fino sobre o [`scripts/setup.sh`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/setup.sh):
+todo `make <target>` roda `./scripts/setup.sh <command>`. Liste tudo a qualquer momento com:
+
+```bash
+make help          # or: ./scripts/setup.sh help
+```
+
+## Instalação e sistema
+
+| Comando | Faz |
+|---|---|
+| `make setup` | Menu de instalação interativo (nada é instalado até você escolher) |
+| `make system` | Instala pacotes apt do sistema |
+| `make ros2` | Instala ROS 2 + MAVROS |
+| `make geographiclib` | Instala os datasets de geoide do GeographicLib |
+| `make ros2-env` | Configura o `~/.bashrc` (adiciona `nectar-activate`) |
+| `make rosdep-init` | Inicializa o rosdep |
+| `make full-install` | Instalação completa a partir do zero (usado pelo bootstrap) |
+| `make update` | Atualiza os pacotes do sistema (apt upgrade) |
+
+## Módulos Python
+
+| Comando | Instala |
+|---|---|
+| `make python` | Somente o core (numpy, opencv, scipy) |
+| `make python-control` | + GPS, PID, navegação MAVROS |
+| `make python-vision` | + drivers de câmera, ArUco, cor, linha |
+| `make python-ai` | + YOLO, DETR, RF-DETR (precisa de PyTorch) |
+| `make python-interface` | + GUI Qt6 / PySide6 |
+| `make python-sensors` | + pyserial / pymavlink |
+| `make python-all` | Todos os módulos |
+| `make python-full` | Todos + drivers de hardware de câmera |
+| `make python-dev` | Ferramental de teste/dev (pytest) |
+| `make pytorch` | PyTorch (detecta CUDA/CPU automaticamente) |
+
+Veja [Instalação](../setup/index.md) para mais detalhes.
+
+## Drivers de drone
+
+| Comando | Instala |
+|---|---|
+| `make drone-mavros` | MAVROS (ArduPilot) + GeographicLib |
+| `make drone-px4` | PX4 sobre MAVROS |
+| `make drone-px4-dds` | PX4 sobre uXRCE-DDS |
+| `make drone-crazyflie` | Crazyswarm2 |
+| `make drone-bebop` | Parrot Bebop 2 |
+| `make drone-all` | Todos os anteriores |
+
+Inicie um driver/bridge para hardware real com `make driver DRONE=<type> ...`; veja
+[Drivers de drone](../setup/drivers.md).
+
+## Build, verificação e qualidade
+
+| Comando | Faz |
+|---|---|
+| `make build` | Builda o workspace inteiro |
+| `make build-pkg` | Builda somente os pacotes do SDK |
+| `make clean` | Remove os artefatos de build |
+| `make verify` | Verifica a instalação (presença/imports) |
+| `make verify-functional` | Suíte funcional pytest (`MODULE="vision control"` para um subconjunto) |
+| `make verify-hardware` | Testes condicionados a dispositivo (câmeras, rangefinder) |
+| `make verify-sitl` | Testes de voo SITL/integração (`FIRMWARE=`, `PROTOCOL=`) |
+| `make doctor` | Relatório somente leitura do ambiente (ROS, módulos, dispositivos, CUDA) |
+| `make test` | colcon test (suíte funcional + lint cmake/xml) |
+| `make ci-local` | CI cross-distro em Docker (`DISTROS=`, `FULL=`) |
+| `make check` | Todos os checks de pre-commit (lint/format, igual ao CI) |
+| `make lint` / `make lint-fix` / `make format` | ruff check / fix / format do Python |
+
+## Simulação
+
+Escolha `FIRMWARE` (`ardupilot`/`px4`), `ENV` (`outdoor`/`indoor`), `PROTOCOL`
+(`mavros`/`mavlink`/`dds`).
+
+| Comando | Faz |
+|---|---|
+| `make sim-install FIRMWARE=..` | Instala SITL + Gazebo (também `all`) |
+| `make sim-start FIRMWARE=.. ENV=..` | Terminal 1: o simulador |
+| `make sim-bridge FIRMWARE=.. ENV=.. PROTOCOL=..` | Terminal 2: a stack ROS |
+| `make sim-stop` | Para tudo |
+
+Veja [Simulação](../setup/simulation.md).
+
+## Drivers para hardware real
+
+| Comando | Faz |
+|---|---|
+| `make driver DRONE=.. ENV=.. FCU_URL=..` | Inicia o driver/bridge ao qual a missão se conecta |
+| `make driver-mavros` / `driver-px4` / `driver-px4-dds` / `driver-bebop` / `driver-crazyflie` | Atalhos por tipo |
+| `make driver-stop` | Para todos os drivers/bridges |
+
+Sobrescritas de conexão via variáveis de ambiente: `FCU_URL` / `DEV` / `BAUD` / `PORT` / `IP`.
+
+## RealSense e Isaac VSLAM
+
+| Comando | Faz |
+|---|---|
+| `make realsense` | Builda o librealsense + realsense-ros |
+| `make realsense-verify` | Verifica a instalação do RealSense |
+| `make isaac-run` | Inicia o container Isaac ROS Visual SLAM (Jetson) |
+| `make isaac-stop` | Desmonta os containers do Isaac |
+| `make vslam-viz` | Check VSLAM no RViz (`VSLAM_PROFILE=light` ou `full`) |
+
+## Docker
+
+| Comando | Faz |
+|---|---|
+| `make docker-build` | Imagem do SDK (sem AI) |
+| `make docker-build-full` | Imagem completa (+ PyTorch/AI) |
+| `make docker-build-t265` | Imagem com suporte a T265 |
+| `make docker-run` | Roda com X11, câmeras, USB |
+| `make docker-exec` | Terminal extra em um container em execução |
+| `make docker-publish-jetson` | Builda + faz push da imagem Jetson (rode no Jetson) |
+
+Veja [Docker](../setup/docker.md).
+
+## Site de documentação
+
+| Comando | Faz |
+|---|---|
+| `make docs-install` | Cria o `.venv-docs` e instala o toolchain de documentação |
+| `make docs-sync` | Monta `build/docs/` (EN) e `build/docs-pt/` (PT) |
+| `make docs` | Sincroniza, builda EN + PT, faz merge em `build/site/` (+ `build/site/pt/`) |
+| `make docs-serve` | Preview bilíngue em `http://localhost:8000/nectar-sdk/` e `.../pt/` |
+| `make docs-serve-en` | Live reload somente em inglês (os links da versão PT dão 404) |
+
+Edite as páginas autorais em `website/`, os READMEs dos módulos e `docs/*.md`; tudo sob
+`build/` é gerado. As convenções estão em [Contribuindo](../project/contributing.md).

--- a/i18n/pt/get-started/ai.md
+++ b/i18n/pt/get-started/ai.md
@@ -1,0 +1,157 @@
+# Detectar, segmentar e classificar
+
+Rode detecção de objetos, segmentação de instâncias ou classificação de imagens com
+Ultralytics YOLO, HuggingFace Transformers e RF-DETR (só detect/seg) por meio de um
+`Detector` / `Segmentor` / `Classifier`. O framework é detectado automaticamente pelo nome
+do modelo; só a string do modelo muda.
+
+Precisa da instalação completa primeiro? Veja [Instalação](../setup/index.md).
+
+## 1. Instale o módulo de IA
+
+O módulo de IA precisa do PyTorch:
+
+```bash
+make setup            # pick: control ai   (installs PyTorch)
+
+# or: make python-ai && make pytorch
+
+```
+
+Os pesos do modelo baixam automaticamente no primeiro carregamento.
+
+## 2. Detecte objetos
+
+Escolha um framework — o nome do modelo o seleciona. `detect()` devolve resultados tipados
+com `class_name`, `confidence` e `xyxy`:
+
+=== "YOLO"
+
+    ```python
+    from nectar.ai.detection import Detector
+    detector = Detector("yolov8n.pt")                      # ultralytics, auto-detected
+    ```
+
+=== "DETR"
+
+    ```python
+    from nectar.ai.core import Framework
+    from nectar.ai.detection import Detector
+    detector = Detector("facebook/detr-resnet-50", framework=Framework.TRANSFORMERS)
+    ```
+
+=== "RF-DETR"
+
+    ```python
+    from nectar.ai.core import Framework
+    from nectar.ai.detection import Detector
+    detector = Detector("rfdetr-medium", framework=Framework.RFDETR)
+    ```
+
+Depois carregue uma vez e detecte por frame:
+
+```python
+detector.load()
+result = detector.detect(image, conf=0.5)
+
+for det in result:
+    print(f"{det.class_name}: {det.confidence:.2f} at {det.xyxy}")
+
+annotated = detector.draw_detections(image, result)
+```
+
+Para rodar ao vivo em uma câmera, coloque `detector.detect` em um callback de
+`ImageHandler` (veja [Ver com uma câmera](vision.md)).
+
+## 3. Segmente objetos
+
+`Segmentor` espelha `Detector` com máscaras por instância; `segment()` devolve máscaras
+mais os mesmos campos de classe/score:
+
+=== "YOLO-seg"
+
+    ```python
+    from nectar.ai.segmentation import Segmentor
+    segmentor = Segmentor("yolov8n-seg.pt")
+    ```
+
+=== "MaskFormer (DETR)"
+
+    ```python
+    from nectar.ai.segmentation import Segmentor
+    from nectar.ai.core import Framework
+    segmentor = Segmentor("facebook/maskformer-swin-tiny-coco", framework=Framework.TRANSFORMERS)
+    ```
+
+=== "RF-DETR-seg"
+
+    ```python
+    from nectar.ai.segmentation import Segmentor
+    from nectar.ai.core import Framework
+    segmentor = Segmentor("rfdetr-seg-medium", framework=Framework.RFDETR)
+    ```
+
+```python
+segmentor.load()
+result = segmentor.segment(image, conf=0.5)
+```
+
+!!! success "Resultado esperado"
+    Uma lista de detecções/segmentos por frame, cada um com rótulo de classe, confiança e
+    uma caixa (detecção) ou máscara (segmentação).
+
+## 4. Classifique imagens
+
+`classify()` devolve resultados tipados top-k com `top1_name` e `top1_confidence`:
+
+=== "YOLO-cls"
+
+    ```python
+    from nectar.ai.classification import Classifier
+    classifier = Classifier("yolo26n-cls.pt")
+    classifier.load()
+    result = classifier.classify(image)
+    print(result.top1_name, result.top1_confidence)
+    ```
+
+=== "ViT"
+
+    ```python
+    from nectar.ai.classification import Classifier
+    from nectar.ai.core import Framework
+    classifier = Classifier(
+        "google/vit-base-patch16-224",
+        framework=Framework.TRANSFORMERS,
+    )
+    classifier.load()
+    result = classifier.classify(image, topk=5)
+    ```
+
+## 5. Além da inferência
+
+O mesmo `Detector` / `Segmentor` / `Classifier` cobre o fluxo completo — apontadores na
+referência:
+
+- **Slicing inference** para objetos pequenos em frames de alta resolução, com pós-processamento
+  NMS / Soft-NMS / WBF / NMM —
+  [Detection](../modules/ai/detection/).
+- **Treinamento** com dataclasses de config por framework, logging TensorBoard e push no
+  HuggingFace Hub; **avaliação** e ferramentas de **dataset** —
+  [visão geral de AI](../modules/ai/).
+- **CLI `nectar-ai`** para predict / train / evaluate sem escrever um script.
+
+## 6. Tutoriais em notebook (Colab)
+
+Fluxos ponta a ponta no Google Colab:
+
+- **Detecção:** [Abrir no Colab](https://colab.research.google.com/drive/1mQmbWwnwn-nzMdBlzvkuBmYPMHUrCm_Z?usp=sharing)
+- **Classificação:** [Abrir no Colab](https://colab.research.google.com/drive/1mEo05wfYJRsuxKodxbFwBuxRSRh43f-X?usp=sharing)
+- **Segmentação:** [Abrir no Colab](https://colab.research.google.com/drive/1qZzAF_iD2sZyuWPin48XpxaY6dtak_gV?usp=sharing)
+
+## Ver também
+
+- [Visão geral de AI](../modules/ai/) · [Detection](../modules/ai/detection/) ·
+  [Segmentation](../modules/ai/segmentation/) ·
+  [Classification](../modules/ai/classification.md).
+- [Exemplos de AI](../modules/examples/ai.md) — scripts de detector, classificador
+  e batch-detector.

--- a/i18n/pt/get-started/control.md
+++ b/i18n/pt/get-started/control.md
@@ -1,16 +1,16 @@
-# Fly a drone
+# Voar um drone
 
-Take off, fly a square, and land with the same code on any supported platform. You pick a
-**backend** (a firmware plus a transport), start its **driver** (or a simulator), set a **pose
-source**, and run a mission. Only the factory key and its config change between platforms; the
-flight calls stay identical.
+Decole, voe um quadrado e pouse com o mesmo código em qualquer plataforma suportada. Você
+escolhe um **backend** (firmware mais um transporte), inicia o **driver** (ou um simulador),
+define uma **fonte de pose** e roda uma missão. Só a chave da factory e o config mudam entre
+plataformas; as chamadas de voo permanecem idênticas.
 
-Pick your backend in the tab below and it stays selected through install, driver, and mission
-code. New to the workspace? Do the [Installation](../setup/index.md) first.
+Escolha o backend na aba abaixo; a seleção vale para instalação, driver e código da missão.
+Novo no workspace? Faça a [Instalação](../setup/index.md) primeiro.
 
-## 1. Install the backend
+## 1. Instale o backend
 
-Install `control`, then add the driver your vehicle uses:
+Instale `control` e depois o driver que o veículo usa:
 
 ```bash
 make setup           # pick: control
@@ -24,8 +24,8 @@ make setup           # pick: control
 
 === "ArduPilot · MAVLink"
 
-    No extra install: `pymavlink` ships with the core SDK. `make drone-mavros` adds the
-    geoid data used for GPS altitude.
+    Sem instalação extra: `pymavlink` já vem com o SDK core. `make drone-mavros` adiciona os
+    dados geoid usados na altitude GPS.
 
 === "PX4 · MAVROS"
 
@@ -35,8 +35,8 @@ make setup           # pick: control
 
 === "PX4 · MAVLink"
 
-    No extra install: `pymavlink` ships with the core SDK. `make drone-mavros` adds the
-    geoid data used for GPS altitude.
+    Sem instalação extra: `pymavlink` já vem com o SDK core. `make drone-mavros` adiciona os
+    dados geoid usados na altitude GPS.
 
 === "PX4 · uXRCE-DDS"
 
@@ -56,26 +56,26 @@ make setup           # pick: control
     make drone-bebop
     ```
 
-## 2. Set the pose source
+## 2. Defina a fonte de pose
 
-For ArduPilot and PX4 the **environment** selects the pose source on the config:
+Para ArduPilot e PX4 o **ambiente** seleciona a fonte de pose no config:
 
-| Environment | Pose source | Config argument |
-|-------------|-------------|-----------------|
+| Ambiente | Fonte de pose | Argumento no config |
+|----------|---------------|---------------------|
 | Outdoor | GPS | `pose_source=PoseSource.GPS` |
-| Indoor (GPS-denied) | Vision (VSLAM) | `pose_source=PoseSource.VISION` |
+| Indoor (sem GPS) | Visão (VSLAM) | `pose_source=PoseSource.VISION` |
 
-!!! note "Indoor flight"
-    A vision-pose feed into the FCU's EKF is required indoors; see
-    [Localization](../modules/control/localization/) (architecture, Run,
-    EKF origin, indoor procedure). Bebop and Crazyflie fly indoors without GPS
-    and ignore this setting.
+!!! note "Voo indoor"
+    Indoor exige um feed de vision-pose no EKF do FCU; veja
+    [Localização](../modules/control/localization/) (arquitetura, Run,
+    origem EKF, procedimento indoor). Bebop e Crazyflie voam indoor sem GPS e ignoram
+    essa configuração.
 
-## 3. Start the driver
+## 3. Inicie o driver
 
-Start the driver or bridge your mission connects to **before** running it (examples default
-to `start_driver=False`). Connection overrides go through env vars (`FCU_URL`, `DEV`, `BAUD`,
-`IP`).
+Inicie o driver ou a ponte a que a missão se conecta **antes** de rodá-la (os exemplos usam
+`start_driver=False` por padrão). Overrides de conexão passam por variáveis de ambiente
+(`FCU_URL`, `DEV`, `BAUD`, `IP`).
 
 === "ArduPilot · MAVROS"
 
@@ -85,8 +85,8 @@ to `start_driver=False`). Connection overrides go through env vars (`FCU_URL`, `
 
 === "ArduPilot · MAVLink"
 
-    Outdoor needs no bridge; the mission opens the link itself. Indoor starts the
-    vision-pose bridge:
+    Outdoor não precisa de ponte; a missão abre o link. Indoor inicia a ponte de
+    vision-pose:
 
     ```bash
     make driver DRONE=mavlink ENV=indoor
@@ -100,8 +100,8 @@ to `start_driver=False`). Connection overrides go through env vars (`FCU_URL`, `
 
 === "PX4 · MAVLink"
 
-    Outdoor needs no bridge; the mission opens the link itself. Indoor starts the
-    vision-pose bridge:
+    Outdoor não precisa de ponte; a missão abre o link. Indoor inicia a ponte de
+    vision-pose:
 
     ```bash
     make driver DRONE=px4_mavlink ENV=indoor
@@ -125,19 +125,19 @@ to `start_driver=False`). Connection overrides go through env vars (`FCU_URL`, `
     make driver-bebop IP=192.168.42.1
     ```
 
-!!! tip "No hardware yet? Fly in simulation"
+!!! tip "Sem hardware ainda? Voe em simulação"
     ```bash
     make sim-install FIRMWARE=ardupilot   # one-time (use FIRMWARE=px4 for PX4)
     make sim-start                        # terminal 1
     make sim-bridge                       # terminal 2
     ```
-    For direct MAVLink or uXRCE-DDS add `PROTOCOL=mavlink` / `PROTOCOL=dds` on `sim-bridge`. Full
-    matrix: [Simulation](../setup/simulation.md).
+    Para MAVLink direto ou uXRCE-DDS, acrescente `PROTOCOL=mavlink` / `PROTOCOL=dds` em
+    `sim-bridge`. Matriz completa: [Simulação](../setup/simulation.md).
 
-## 4. Write the mission
+## 4. Escreva a missão
 
-Build the drone with your backend's factory key and config. The flight calls after it are the
-same for every backend.
+Monte o drone com a chave e o config do backend. As chamadas de voo depois disso são as
+mesmas para todos os backends.
 
 === "ArduPilot · MAVROS"
 
@@ -209,7 +209,7 @@ same for every backend.
     drone = DroneFactory.create("bebop", BebopConfig())
     ```
 
-Fly a 2 m square, then land:
+Voe um quadrado de 2 m e depois pouse:
 
 ```python
 drone.takeoff(altitude=2.0)
@@ -221,10 +221,10 @@ drone.land()
 nectar.shutdown()
 ```
 
-The bundled examples fly the same box on any backend, flown by the PID navigator where the
-backend supports it. Each tab is the exact command for that platform (outdoor GPS shown; for
-indoor flight swap `--mode indoor` on `navigation.py` or `--env indoor` on `basic.py` to the
-vision pose source):
+Os exemplos do repositório voam o mesmo box em qualquer backend, com o navegador PID quando
+o backend permite. Cada aba é o comando exato da plataforma (GPS outdoor; para indoor use
+`--mode indoor` em `navigation.py` ou `--env indoor` em `basic.py` para a fonte de pose de
+visão):
 
 === "ArduPilot · MAVROS"
 
@@ -245,7 +245,7 @@ vision pose source):
         --test rectangle --altitude 2.0 --distance 2.0 --precision 0.15
     ```
 
-    On hardware, pass your serial link instead, e.g. `--connection /dev/ttyUSB0`.
+    No hardware, passe o link serial, por exemplo `--connection /dev/ttyUSB0`.
 
 === "PX4 · MAVROS"
 
@@ -258,7 +258,7 @@ vision pose source):
 
 === "PX4 · MAVLink"
 
-    `navigation.py` does not cover this backend; the position box in `basic.py` does:
+    `navigation.py` não cobre este backend; o box em posição de `basic.py` cobre:
 
     ```bash
     nectar-activate
@@ -287,16 +287,16 @@ vision pose source):
 
 === "Bebop"
 
-    Bebop has no onboard position control, so it flies the velocity box:
+    Bebop não tem controle de posição a bordo, então voa o box em velocidade:
 
     ```bash
     nectar-activate
     python3 nectar/nectar/examples/control/basic.py --drone bebop --mode velocity
     ```
 
-!!! success "Expected result"
-    The drone arms, climbs to the target altitude, flies a 2 m box (0.6 m for Crazyflie) with
-    0.15 m arrival precision, then lands and disarms.
+!!! success "Resultado esperado"
+    O drone arma, sobe até a altitude alvo, voa um box de 2 m (0,6 m no Crazyflie) com
+    precisão de chegada de 0,15 m, depois pousa e desarma.
 
 <figure class="nectar-shot">
   <div class="nectar-shot__media" data-src="../assets/media/basic-square.mp4">
@@ -304,15 +304,15 @@ vision pose source):
       <source src="../assets/media/basic-square.mp4" type="video/mp4">
     </video>
   </div>
-  <figcaption>Our drone flying the square example on real hardware. Click to enlarge.</figcaption>
+  <figcaption>Nosso drone voando o exemplo do quadrado em hardware real. Clique para ampliar.</figcaption>
 </figure>
 
-## See also
+## Ver também
 
-- [Control reference](../modules/control/index.md): the factory, the `Drone` protocol,
-  capabilities, and the full backend matrix.
-- [Vehicle core](../modules/control/vehicle.md) · [Transports](../modules/control/mavlink.md) ·
-  [PID tuning](../modules/control/pid.md) · [Obstacles](../modules/control/obstacles.md) ·
-  [Localization](../modules/control/localization/).
-- [Control examples](../modules/examples/control.md): navigation suite, interactive REPL,
-  servo test.
+- [Referência de Control](../modules/control/index.md): a factory, o protocolo
+  `Drone`, capacidades e a matriz completa de backends.
+- [Vehicle core](../modules/control/vehicle/) · [Transports](../modules/control/mavlink/) ·
+  [PID](../modules/control/pid/) · [Obstacles](../modules/control/obstacles/) ·
+  [Localization](../modules/control/localization/index.md).
+- [Exemplos de Control](../modules/examples/control.md): suíte de navegação,
+  REPL interativo, teste de servo.

--- a/i18n/pt/get-started/index.md
+++ b/i18n/pt/get-started/index.md
@@ -1,0 +1,69 @@
+# Começar
+
+Nectar SDK oferece uma interface Python para **controle de voo**, **visão computacional** e
+**IA**, todas compartilhando um único runtime ROS 2. Escolha um tópico abaixo, siga os
+passos para sua plataforma, câmera ou modelo, e use os links quando quiser a referência
+completa.
+
+## O modelo mental
+
+Todo módulo segue a mesma forma, então ao conhecer um você conhece todos:
+
+```python
+import nectar
+
+nectar.init()                      # start the shared runtime (one background executor)
+obj = SomeFactory.create(...)      # build a drone / camera / detector by key + config
+obj.do_something(...)              # call the same API regardless of backend
+nectar.shutdown()                  # stop the runtime
+```
+
+- **Factories** montam o backend concreto a partir de uma chave em string e de um config
+  tipado (`DroneFactory`, `CameraFactory`, `Detector`) — troque a chave, mantenha o código.
+- **Um runtime** (`nectar.init` / `nectar.spin` / `nectar.shutdown`) possui um executor
+  compartilhado, para que controle, visão e IA se componham em uma única missão. Veja
+  [Arquitetura](../concepts/architecture.md).
+
+## Pré-requisitos
+
+Um workspace Nectar SDK já configurado. Se ainda não tiver, faça a
+[Instalação](../setup/index.md) primeiro (instala só os módulos que você escolher). Cada
+tópico abaixo lista a instalação do módulo de que precisa.
+
+## Escolha seu caminho
+
+<div class="grid cards" markdown>
+
+-   **Voar um drone**
+
+    Escolha uma plataforma e um transporte, inicie o driver ou um simulador, configure uma
+    fonte de pose e voe um quadrado — as mesmas chamadas em ArduPilot, PX4, Crazyflie ou Bebop.
+
+    [Voar um drone](control.md)
+
+-   **Ver com uma câmera**
+
+    Abra qualquer câmera por meio de uma factory, transmita frames por um `ImageHandler` e rode
+    um algoritmo (ArUco, cor, linha, distância, MediaPipe).
+
+    [Ver com uma câmera](vision.md)
+
+-   **Detectar, segmentar e classificar**
+
+    Carregue um modelo de detecção, segmentação ou classificação com Ultralytics YOLO,
+    HuggingFace DETR ou RF-DETR por meio de um `Detector` / `Segmentor` / `Classifier`, e
+    rode em um frame.
+
+    [Detectar, segmentar e classificar](ai.md)
+
+-   **Com e sem Nectar**
+
+    Os mesmos comportamentos de missão com o SDK e com scripts completos da stack
+    subjacente.
+
+    [Com e sem Nectar](with-without.md)
+
+</div>
+
+Cada página é independente e compartilha o runtime, então você pode combinar controle,
+visão e IA em uma única missão.

--- a/i18n/pt/get-started/vision.md
+++ b/i18n/pt/get-started/vision.md
@@ -1,23 +1,26 @@
-# See with a camera
+# Ver com uma câmera
 
-Open any camera behind one factory, turn it into a callback-driven stream with an
-`ImageHandler`, and run an algorithm on each frame. Only the source changes between cameras;
-the pipeline stays the same.
+Abra qualquer câmera por meio de uma factory, transforme-a em um stream orientado a callback
+com um `ImageHandler` e rode um algoritmo em cada frame. Só a fonte muda entre câmeras; o
+pipeline permanece o mesmo.
 
-Pick your camera in the tab below and it stays selected through every step. New to the
-workspace? Do the [Installation](../setup/index.md) first; depth cameras also need the
-[RealSense setup](../setup/realsense.md).
+Escolha a câmera na aba abaixo; a seleção vale para todos os passos. Novo no workspace?
+Faça a [Instalação](../setup/index.md) primeiro; câmeras de profundidade também precisam da
+[configuração RealSense](../setup/realsense.md).
 
-## 1. Install the vision module
+## 1. Instale o módulo de visão
 
 ```bash
 make setup            # pick: vision
+
 # or: make python-vision
+
 ```
 
-## 2. Open the camera
+## 2. Abra a câmera
 
-`CameraFactory.from_source(...)` returns the matching driver for any key it understands:
+`CameraFactory.from_source(...)` devolve o driver correspondente a qualquer chave que
+entenda:
 
 === "Webcam"
 
@@ -47,31 +50,32 @@ make setup            # pick: vision
     camera = CameraFactory.from_source("/camera/image_raw")
     ```
 
-A one-off frame is `camera.get_frame()`; depth cameras add `get_depth_frame()` and
-`get_distance()`.
+Um frame avulso é `camera.get_frame()`; câmeras de profundidade acrescentam
+`get_depth_frame()` e `get_distance()`.
 
-The tabs above cover the common four. `from_source` accepts every key below; see the
-[Cameras reference](../modules/vision/camera.md) for each driver's config dataclass:
+As abas acima cobrem as quatro mais comuns. `from_source` aceita todas as chaves abaixo;
+veja a [referência de Cameras](../modules/vision/camera.md) para o dataclass
+de config de cada driver:
 
-| Key | Camera | Notes |
-|-----|--------|-------|
-| `webcam` / `opencv` | Generic USB webcam | `OpenCVConfig` (resolution, fps, focus) |
-| `realsense` | Intel RealSense D4xx | Color + depth |
-| `t265` | Intel RealSense T265 | Fisheye + host stereo depth + 6DOF pose |
-| `oakd` | Luxonis OAK-D | Color + depth |
-| `c920` | Logitech C920/C920e | Profile-based `OpenCVCam` |
+| Chave | Câmera | Notas |
+|-------|--------|-------|
+| `webcam` / `opencv` | Webcam USB genérica | `OpenCVConfig` (resolução, fps, foco) |
+| `realsense` | Intel RealSense D4xx | Cor + profundidade |
+| `t265` | Intel RealSense T265 | Fisheye + profundidade estéreo no host + pose 6DOF |
+| `oakd` | Luxonis OAK-D | Cor + profundidade |
+| `c920` | Logitech C920/C920e | `OpenCVCam` por perfil |
 | `imx219` | Raspberry Pi Camera v2 | Jetson (GStreamer) |
-| `ros` | ROS 2 image topic | Any `sensor_msgs/Image` topic |
-| `ros_depth` | ROS 2 color + depth topics | Depth-capable |
-| `file` | Static image file | A path resolves to this automatically |
+| `ros` | Tópico de imagem ROS 2 | Qualquer tópico `sensor_msgs/Image` |
+| `ros_depth` | Tópicos ROS 2 cor + profundidade | Com profundidade |
+| `file` | Arquivo de imagem estático | Um caminho resolve para isto automaticamente |
 
-A file path resolves to `file` and a source starting with `/` to `ros`, so those two need no
-explicit key.
+Um caminho de arquivo resolve para `file` e uma fonte que começa com `/` para `ros`, então
+essas duas não precisam de chave explícita.
 
-## 3. Stream frames through an ImageHandler
+## 3. Transmita frames por um ImageHandler
 
-`ImageHandler` wraps the source in a timer-driven ROS 2 node and calls your callback on every
-frame:
+`ImageHandler` envolve a fonte em um nó ROS 2 acionado por timer e chama seu callback a
+cada frame:
 
 === "Webcam"
 
@@ -137,21 +141,21 @@ frame:
     nectar.shutdown()
     ```
 
-## 4. Run an algorithm
+## 4. Rode um algoritmo
 
-Construct an algorithm and call it inside the callback. Each one follows the same shape:
+Construa um algoritmo e chame-o dentro do callback. Todos seguem a mesma forma:
 
-| Algorithm | Class | Use it for |
-|-----------|-------|------------|
-| ArUco markers | `Aruco` | Fiducial detection and 6-DoF pose (`detect`, `pose_estimate`) |
-| Color | `ColorDetector` | HSV/LAB color filtering (calibrate, then `mode="preset"`) |
-| Line | `LineDetector` | Line following with Hough / RANSAC / ellipse methods |
-| Distance | `DistanceEstimator` | Pixel-size to distance regression |
-| Hand / face | `HandTracker`, `FaceMeshTracker` | MediaPipe landmark tracking |
-| Optical flow | `OpticalFlowEstimator` | Frame-to-frame motion |
+| Algoritmo | Classe | Use para |
+|-----------|--------|----------|
+| Marcadores ArUco | `Aruco` | Detecção fiducial e pose 6-DoF (`detect`, `pose_estimate`) |
+| Cor | `ColorDetector` | Filtro de cor HSV/LAB (calibre e depois `mode="preset"`) |
+| Linha | `LineDetector` | Seguimento de linha com Hough / RANSAC / elipse |
+| Distância | `DistanceEstimator` | Regressão de tamanho em pixels para distância |
+| Mão / face | `HandTracker`, `FaceMeshTracker` | Tracking de landmarks MediaPipe |
+| Optical flow | `OpticalFlowEstimator` | Movimento frame a frame |
 
-ArUco pose estimation returns the marker id, translation, and yaw and draws the axes on the
-frame. Swap `Aruco` for any class above; the source stays whatever you picked in step 2:
+A estimativa de pose ArUco devolve o id do marcador, a translação e o yaw, e desenha os eixos
+no frame. Troque `Aruco` por qualquer classe acima; a fonte continua a escolhida no passo 2:
 
 === "Webcam"
 
@@ -225,22 +229,23 @@ frame. Swap `Aruco` for any class above; the source stays whatever you picked in
     nectar.shutdown()
     ```
 
-Exact constructor arguments and return types are in the [Vision reference](../modules/vision/index.md).
+Argumentos exatos do construtor e tipos de retorno estão na
+[referência de Vision](../modules/vision/index.md).
 
-!!! success "Expected result"
-    The preview window shows the live stream with the algorithm's overlay (for ArUco, the
-    marker axes and id).
+!!! success "Resultado esperado"
+    A janela de preview mostra o stream ao vivo com o overlay do algoritmo (no ArUco, os
+    eixos e o id do marcador).
 
 <figure class="nectar-shot">
   <div class="nectar-shot__media">
-    <img src="../assets/media/aruco-ex.jpg" alt="ArUco detection overlaying axes and ids on 15 markers in one frame">
+    <img src="../assets/media/aruco-ex.jpg" alt="Overlay ArUco com eixos e ids em 15 marcadores em um frame">
   </div>
-  <figcaption>ArUco pose estimation detecting 15 markers in a single frame, each with its id and axes.</figcaption>
+  <figcaption>Estimativa de pose ArUco detectando 15 marcadores em um único frame, cada um com id e eixos.</figcaption>
 </figure>
 
-## See also
+## Ver também
 
-- [Vision reference](../modules/vision/index.md): camera drivers, algorithm APIs, ROS 2 nodes,
-  and camera/color calibration.
-- [Vision examples](../modules/examples/vision.md): camera capture and depth examples.
-- [Detect, segment & classify](ai.md).
+- [Referência de Vision](../modules/vision/index.md): drivers de câmera, APIs dos
+  algoritmos, nós ROS 2 e calibração de câmera/cor.
+- [Exemplos de Vision](../modules/examples/vision.md): captura e profundidade.
+- [Detectar, segmentar e classificar](ai.md).

--- a/i18n/pt/get-started/with-without.md
+++ b/i18n/pt/get-started/with-without.md
@@ -1,0 +1,1956 @@
+# Com e sem o Nectar SDK
+
+Os mesmos comportamentos com as APIs públicas do Nectar e com scripts completos usando as
+stacks subjacentes. Expanda cada bloco **Sem o Nectar** para ver o script completo.
+
+| Área | Código da missão permanece | O que muda |
+|------|--------------------|--------------|
+| [Control](#control) | `takeoff` / `move_to` / `land` | Factory key + config (transporte, pose) |
+| [Vision](#vision) | Acesso a frames / callback do handler | String `source` da câmera (+ config) |
+| [AI](#ai) | Formato do resultado de `detect` / `segment` / `classify` | ID do modelo + `framework` opcional |
+| [Composition](#composition) | Loop de centralização + PID | Transporte, pose, câmera, backend de percepção |
+
+Referência dos módulos: [Control](../modules/control/index.md),
+[Vision](../modules/vision/index.md),
+[Cameras](../modules/vision/camera.md),
+[AI](../modules/ai/index.md).
+Composition monta uma missão curta com os três.
+
+!!! note "Contagem de esforço"
+    Fixtures marcadas reportam SLOC de Boilerplate / Core / Total do lado da aplicação e
+    o custo de edição da troca de stack para fragmentos de missão mais longos:
+
+    - [scripts/effort/](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/scripts/effort)
+      ([regras de contagem](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/effort/README.md))
+    - [Tabela de LoC](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/effort/results/loc_table.md)
+    - [Deltas de troca](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/effort/results/swap_delta.md)
+
+---
+
+## [Control](../modules/control/index.md)
+
+Decolar, mover e pousar. A factory key e a config selecionam o transporte; as chamadas
+da missão permanecem as mesmas.
+
+### Controle de posição
+
+Decolar até 2 m → mover 5 m para frente no frame do corpo → pousar. Com o Nectar apenas
+a factory key e a config mudam entre transportes.
+
+!!! note "Método de navegação"
+    Estes pares usam `NavigationMethod.POSITION` (o FCU mantém o setpoint local) para que
+    os scripts sem o Nectar sejam uma contrapartida justa. Missões de campo costumam
+    controlar velocidade com um [`PIDController`](../modules/control/pid.md)
+    auxiliar (veja [Composition](#composition)). O padrão do SDK para `move_to` é
+    `PID_EKF` — [Vehicle core](../modules/control/vehicle.md).
+
+#### ArduPilot · MAVROS
+
+!!! tip "Pré-requisitos"
+    FCU acessível via MAVROS. Com o Nectar e `start_driver=False`, inicie o driver em
+    outro terminal: `make driver DRONE=mavros` (veja
+    [Drivers de drone](../setup/drivers.md)). Sem o Nectar, rode `mavros_node`
+    (ou o mesmo `make driver`) você mesmo antes do script.
+
+```python
+import nectar
+from nectar.control import DroneFactory, MavrosConfig, NavigationMethod, PoseSource
+
+nectar.init()
+drone = DroneFactory.create(
+    "mavros", MavrosConfig(pose_source=PoseSource.GPS, start_driver=False)
+)
+drone.takeoff(altitude=2.0)
+drone.move_to(x=5.0, y=0.0, z=0.0, precision=0.3, method=NavigationMethod.POSITION)
+drone.land()
+drone.cleanup()
+nectar.shutdown()
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import math
+import time
+
+import rclpy
+from geometry_msgs.msg import PoseStamped
+from mavros_msgs.msg import PositionTarget, State
+from mavros_msgs.srv import CommandBool, CommandTOL, SetMode
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+_POSITION_MASK = (
+    PositionTarget.IGNORE_VX
+    | PositionTarget.IGNORE_VY
+    | PositionTarget.IGNORE_VZ
+    | PositionTarget.IGNORE_AFX
+    | PositionTarget.IGNORE_AFY
+    | PositionTarget.IGNORE_AFZ
+    | PositionTarget.IGNORE_YAW_RATE
+)
+
+def yaw_from_quat(q) -> float:
+    siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+    cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+    return math.atan2(siny_cosp, cosy_cosp)
+
+class MavrosPilot(Node):
+    def __init__(self) -> None:
+        super().__init__("mavros_position_mission")
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+        self.state = State()
+        self.pose = PoseStamped()
+        self.create_subscription(State, "/mavros/state", lambda m: setattr(self, "state", m), 10)
+        self.create_subscription(
+            PoseStamped, "/mavros/local_position/pose", lambda m: setattr(self, "pose", m), qos
+        )
+        self.setpoint_pub = self.create_publisher(PositionTarget, "/mavros/setpoint_raw/local", 10)
+        self.mode_cli = self.create_client(SetMode, "/mavros/set_mode")
+        self.arm_cli = self.create_client(CommandBool, "/mavros/cmd/arming")
+        self.takeoff_cli = self.create_client(CommandTOL, "/mavros/cmd/takeoff")
+        self.land_cli = self.create_client(CommandTOL, "/mavros/cmd/land")
+
+    def call(self, client, request, timeout: float = 5.0):
+        if not client.wait_for_service(timeout_sec=timeout):
+            raise RuntimeError(f"service unavailable: {client.srv_name}")
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self, future, timeout_sec=timeout)
+        if future.result() is None:
+            raise RuntimeError(f"service call failed: {client.srv_name}")
+        return future.result()
+
+    def wait_connected(self, timeout: float = 30.0) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if self.state.connected:
+                return
+        raise TimeoutError("FCU not connected via MAVROS")
+
+    def set_guided_and_arm(self) -> None:
+        req = SetMode.Request()
+        req.custom_mode = "GUIDED"
+        self.call(self.mode_cli, req)
+        while self.state.mode != "GUIDED":
+            rclpy.spin_once(self, timeout_sec=0.1)
+        arm = CommandBool.Request()
+        arm.value = True
+        self.call(self.arm_cli, arm)
+        while not self.state.armed:
+            rclpy.spin_once(self, timeout_sec=0.1)
+
+    def takeoff(self, altitude: float, timeout: float = 25.0) -> None:
+        req = CommandTOL.Request()
+        req.altitude = float(altitude)
+        self.call(self.takeoff_cli, req)
+        start_z = self.pose.pose.position.z
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if self.pose.pose.position.z >= start_z + altitude - 0.3:
+                return
+        raise TimeoutError("takeoff settle")
+
+    def move_body(self, forward: float, left: float, up: float, precision: float = 0.3) -> None:
+        rclpy.spin_once(self, timeout_sec=0.1)
+        p = self.pose.pose.position
+        yaw = yaw_from_quat(self.pose.pose.orientation)
+        c, s = math.cos(yaw), math.sin(yaw)
+        tx = p.x + forward * c - left * s
+        ty = p.y + forward * s + left * c
+        tz = p.z + up
+        target = PositionTarget()
+        target.coordinate_frame = PositionTarget.FRAME_LOCAL_NED
+        target.type_mask = _POSITION_MASK
+        target.position.x = float(tx)
+        target.position.y = float(ty)
+        target.position.z = float(tz)
+        target.yaw = float(yaw)
+        deadline = time.time() + 60.0
+        while time.time() < deadline:
+            target.header.stamp = self.get_clock().now().to_msg()
+            self.setpoint_pub.publish(target)
+            rclpy.spin_once(self, timeout_sec=0.05)
+            dx = self.pose.pose.position.x - tx
+            dy = self.pose.pose.position.y - ty
+            dz = self.pose.pose.position.z - tz
+            if math.sqrt(dx * dx + dy * dy + dz * dz) <= precision:
+                return
+        raise TimeoutError("position settle")
+
+    def land(self) -> None:
+        req = CommandTOL.Request()
+        req.altitude = 0.0
+        self.call(self.land_cli, req)
+
+def main() -> None:
+    rclpy.init()
+    node = MavrosPilot()
+    try:
+        node.wait_connected()
+        node.set_guided_and_arm()
+        time.sleep(1.0)
+        node.takeoff(2.0)
+        node.move_body(forward=5.0, left=0.0, up=0.0, precision=0.3)
+        node.land()
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+#### ArduPilot · MAVLink
+
+!!! tip "Pré-requisitos"
+    FCU em uma URL pymavlink (SITL ou serial). Com o Nectar, defina a URL em
+    `MavlinkConfig` (os padrões cobrem as portas SITL mais comuns). Sem o Nectar, defina a
+    string de conexão no script (`udp:…`, `tcp:127.0.0.1:5762`,
+    `/dev/ttyUSB0`, …). Nenhum processo MAVROS é necessário.
+
+```python
+import nectar
+from nectar.control import DroneFactory, MavlinkConfig, NavigationMethod, PoseSource
+
+nectar.init()
+drone = DroneFactory.create(
+    "mavlink", MavlinkConfig(pose_source=PoseSource.GPS, start_driver=False)
+)
+drone.takeoff(altitude=2.0)
+drone.move_to(x=5.0, y=0.0, z=0.0, precision=0.3, method=NavigationMethod.POSITION)
+drone.land()
+drone.cleanup()
+nectar.shutdown()
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import math
+import time
+
+from pymavlink import mavutil
+
+_M = mavutil.mavlink
+_POSITION_MASK = (
+    _M.POSITION_TARGET_TYPEMASK_VX_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_VY_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_VZ_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_AX_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_AY_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_AZ_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE
+)
+
+def enu_to_ned(x: float, y: float, z: float):
+    return y, x, -z
+
+def ned_to_enu(n: float, e: float, d: float):
+    return e, n, -d
+
+class MavlinkPilot:
+    def __init__(self, connection_string: str = "udp:127.0.0.1:14550") -> None:
+        self.master = mavutil.mavlink_connection(connection_string, autoreconnect=True)
+        self.master.wait_heartbeat()
+        self._local = None
+        self._yaw_ned = 0.0
+        self._request_streams()
+
+    def _request_streams(self) -> None:
+        for msg_id, hz in (
+            (_M.MAVLINK_MSG_ID_LOCAL_POSITION_NED, 20),
+            (_M.MAVLINK_MSG_ID_ATTITUDE, 20),
+            (_M.MAVLINK_MSG_ID_HEARTBEAT, 1),
+        ):
+            self.master.mav.command_long_send(
+                self.master.target_system,
+                self.master.target_component,
+                _M.MAV_CMD_SET_MESSAGE_INTERVAL,
+                0,
+                msg_id,
+                int(1e6 / hz),
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
+
+    def _spin(self, timeout: float = 0.5):
+        """Drain the link; LOCAL_POSITION_NED has no yaw — attitude carries it."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            msg = self.master.recv_match(
+                blocking=True, timeout=max(0.0, deadline - time.time())
+            )
+            if msg is None:
+                break
+            t = msg.get_type()
+            if t == "LOCAL_POSITION_NED":
+                self._local = msg
+            elif t == "ATTITUDE":
+                self._yaw_ned = float(msg.yaw)
+        return self._local
+
+    def set_mode(self, mode: str) -> None:
+        mapping = self.master.mode_mapping()
+        if mode not in mapping:
+            raise RuntimeError(f"mode {mode!r} not in mode_mapping")
+        self.master.mav.set_mode_send(
+            self.master.target_system,
+            mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+            mapping[mode],
+        )
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            hb = self.master.recv_match(type="HEARTBEAT", blocking=True, timeout=0.5)
+            if hb and mavutil.mode_string_v10(hb) == mode:
+                return
+        raise TimeoutError(f"failed to enter {mode}")
+
+    def arm(self) -> None:
+        self.master.mav.command_long_send(
+            self.master.target_system,
+            self.master.target_component,
+            _M.MAV_CMD_COMPONENT_ARM_DISARM,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        deadline = time.time() + 6.0
+        while time.time() < deadline:
+            hb = self.master.recv_match(type="HEARTBEAT", blocking=True, timeout=0.5)
+            if hb and (hb.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED):
+                return
+        raise TimeoutError("arm failed")
+
+    def takeoff(self, altitude: float, timeout: float = 25.0) -> None:
+        self.master.mav.command_long_send(
+            self.master.target_system,
+            self.master.target_component,
+            _M.MAV_CMD_NAV_TAKEOFF,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            float(altitude),
+        )
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            msg = self._spin()
+            if msg is not None and -msg.z >= altitude - 0.3:
+                return
+        raise TimeoutError("takeoff settle")
+
+    def move_body(self, forward: float, left: float, up: float, precision: float = 0.3) -> None:
+        msg = self._spin(timeout=2.0)
+        if msg is None:
+            raise RuntimeError("no LOCAL_POSITION_NED")
+        x, y, z = ned_to_enu(msg.x, msg.y, msg.z)
+        yaw_enu = math.pi / 2.0 - self._yaw_ned
+        c, s = math.cos(yaw_enu), math.sin(yaw_enu)
+        tx = x + forward * c - left * s
+        ty = y + forward * s + left * c
+        tz = z + up
+        n, e, d = enu_to_ned(tx, ty, tz)
+        yaw_ned = self._yaw_ned
+        deadline = time.time() + 60.0
+        while time.time() < deadline:
+            self.master.mav.set_position_target_local_ned_send(
+                0,
+                self.master.target_system,
+                self.master.target_component,
+                _M.MAV_FRAME_LOCAL_NED,
+                _POSITION_MASK,
+                n,
+                e,
+                d,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                yaw_ned,
+                0,
+            )
+            msg = self._spin(timeout=0.2)
+            if msg is None:
+                continue
+            cx, cy, cz = ned_to_enu(msg.x, msg.y, msg.z)
+            if math.sqrt((cx - tx) ** 2 + (cy - ty) ** 2 + (cz - tz) ** 2) <= precision:
+                return
+        raise TimeoutError("position settle")
+
+    def land(self) -> None:
+        self.set_mode("LAND")
+
+def main() -> None:
+    pilot = MavlinkPilot("udp:127.0.0.1:14550")
+    pilot.set_mode("GUIDED")
+    pilot.arm()
+    time.sleep(1.0)
+    pilot.takeoff(2.0)
+    pilot.move_body(forward=5.0, left=0.0, up=0.0, precision=0.3)
+    pilot.land()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+#### PX4 · uXRCE-DDS
+
+!!! tip "Pré-requisitos"
+    PX4 com cliente uXRCE-DDS e `px4_msgs` no workspace. Com o Nectar e
+    `start_driver=False`, inicie o agente: `make driver-px4-dds`. Sem o Nectar,
+    rode o MicroXRCEAgent (mesmo comando) antes do script.
+
+```python
+import nectar
+from nectar.control import DroneFactory, NavigationMethod, PoseSource, Px4DdsConfig
+
+nectar.init()
+drone = DroneFactory.create(
+    "px4_dds", Px4DdsConfig(pose_source=PoseSource.GPS, start_driver=False)
+)
+drone.takeoff(altitude=2.0)
+drone.move_to(x=5.0, y=0.0, z=0.0, precision=0.3, method=NavigationMethod.POSITION)
+drone.land()
+drone.cleanup()
+nectar.shutdown()
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import math
+import time
+
+import rclpy
+from px4_msgs.msg import (
+    OffboardControlMode,
+    TrajectorySetpoint,
+    VehicleCommand,
+    VehicleLocalPosition,
+    VehicleStatus,
+)
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+
+_ARMING_STATE_ARMED = 2
+_NAV_STATE_OFFBOARD = 14
+
+def enu_to_ned(x: float, y: float, z: float):
+    return y, x, -z
+
+def yaw_enu_to_ned(yaw_enu: float) -> float:
+    return math.pi / 2.0 - yaw_enu
+
+class Px4DdsPilot(Node):
+    def __init__(self) -> None:
+        super().__init__("px4_dds_position_mission")
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=5,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+        self.local = None
+        self.status = None
+        self._sp_n = self._sp_e = self._sp_d = 0.0
+        self._sp_yaw = 0.0
+        self._position_mode = True
+        self.create_subscription(
+            VehicleLocalPosition, "/fmu/out/vehicle_local_position_v1", self._on_local, qos
+        )
+        self.create_subscription(VehicleStatus, "/fmu/out/vehicle_status_v4", self._on_status, qos)
+        self.offboard_pub = self.create_publisher(OffboardControlMode, "/fmu/in/offboard_control_mode", 10)
+        self.setpoint_pub = self.create_publisher(TrajectorySetpoint, "/fmu/in/trajectory_setpoint", 10)
+        self.command_pub = self.create_publisher(VehicleCommand, "/fmu/in/vehicle_command", 10)
+        self.create_timer(0.05, self._pump)
+
+    def _now_us(self) -> int:
+        return int(self.get_clock().now().nanoseconds / 1000)
+
+    def _on_local(self, msg: VehicleLocalPosition) -> None:
+        self.local = msg
+
+    def _on_status(self, msg: VehicleStatus) -> None:
+        self.status = msg
+
+    def _pump(self) -> None:
+        mode = OffboardControlMode()
+        mode.timestamp = self._now_us()
+        mode.position = self._position_mode
+        mode.velocity = not self._position_mode
+        self.offboard_pub.publish(mode)
+        sp = TrajectorySetpoint()
+        sp.timestamp = self._now_us()
+        if self._position_mode:
+            sp.position = [self._sp_n, self._sp_e, self._sp_d]
+            sp.velocity = [math.nan, math.nan, math.nan]
+        else:
+            sp.position = [math.nan, math.nan, math.nan]
+            sp.velocity = [0.0, 0.0, 0.0]
+        sp.yaw = self._sp_yaw
+        sp.yawspeed = math.nan
+        self.setpoint_pub.publish(sp)
+
+    def _command(self, command: int, **params) -> None:
+        msg = VehicleCommand()
+        msg.timestamp = self._now_us()
+        msg.command = int(command)
+        for i in range(1, 8):
+            setattr(msg, f"param{i}", float(params.get(f"param{i}", 0.0)))
+        msg.target_system = 1
+        msg.target_component = 1
+        msg.source_system = 1
+        msg.source_component = 1
+        msg.from_external = True
+        self.command_pub.publish(msg)
+
+    def wait_telemetry(self, timeout: float = 30.0) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if self.local is not None and self.status is not None:
+                return
+        raise TimeoutError("no PX4 telemetry on uXRCE-DDS")
+
+    def hold_current(self) -> None:
+        assert self.local is not None
+        self._position_mode = True
+        self._sp_n = float(self.local.x)
+        self._sp_e = float(self.local.y)
+        self._sp_d = float(self.local.z)
+        self._sp_yaw = yaw_enu_to_ned(math.pi / 2.0 - float(self.local.heading))
+
+    def enter_offboard_and_arm(self) -> None:
+        self.hold_current()
+        for _ in range(20):
+            rclpy.spin_once(self, timeout_sec=0.05)
+        self._command(176, param1=1.0, param2=6.0, param3=0.0)
+        self._command(400, param1=1.0)
+        deadline = time.time() + 6.0
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if (
+                self.status is not None
+                and self.status.arming_state == _ARMING_STATE_ARMED
+                and self.status.nav_state == _NAV_STATE_OFFBOARD
+            ):
+                return
+        raise TimeoutError("OFFBOARD arm failed")
+
+    def takeoff(self, altitude: float, timeout: float = 25.0) -> None:
+        assert self.local is not None
+        self._position_mode = True
+        self._sp_n = float(self.local.x)
+        self._sp_e = float(self.local.y)
+        self._sp_d = float(self.local.z) - float(altitude)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if self.local is not None and -self.local.z >= altitude - 0.3:
+                return
+        raise TimeoutError("takeoff settle")
+
+    def move_body(self, forward: float, left: float, up: float, precision: float = 0.3) -> None:
+        assert self.local is not None
+        ex0 = float(self.local.y)
+        ey0 = float(self.local.x)
+        ez0 = -float(self.local.z)
+        yaw_enu = math.pi / 2.0 - float(self.local.heading)
+        c, s = math.cos(yaw_enu), math.sin(yaw_enu)
+        ex = ex0 + forward * c - left * s
+        ey = ey0 + forward * s + left * c
+        ez = ez0 + up
+        tn, te, td = enu_to_ned(ex, ey, ez)
+        self._sp_n, self._sp_e, self._sp_d = tn, te, td
+        self._sp_yaw = yaw_enu_to_ned(yaw_enu)
+        deadline = time.time() + 60.0
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if self.local is None:
+                continue
+            cx, cy, cz = float(self.local.y), float(self.local.x), -float(self.local.z)
+            if math.sqrt((cx - ex) ** 2 + (cy - ey) ** 2 + (cz - ez) ** 2) <= precision:
+                return
+        raise TimeoutError("position settle")
+
+    def land(self) -> None:
+        self._command(176, param1=1.0, param2=4.0, param3=6.0)
+
+def main() -> None:
+    rclpy.init()
+    node = Px4DdsPilot()
+    try:
+        node.wait_telemetry()
+        node.enter_offboard_and_arm()
+        node.takeoff(2.0)
+        node.move_body(forward=5.0, left=0.0, up=0.0, precision=0.3)
+        node.land()
+        time.sleep(2.0)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+### Fonte de pose
+
+<span id="pose-source"></span>
+
+GPS (outdoor) vs. pose de visão externa (indoor). As chamadas da missão permanecem as
+mesmas; muda o `pose_source`, a factory key e — quando necessário — o tópico de pose.
+Qualquer publisher que emita a mensagem de pose esperada funciona (Isaac ROS VSLAM,
+T265, ground truth do Gazebo, …); o caminho do SDK entrega isso ao FCU como navegação
+externa. Detalhes de conexão:
+[Localization](../modules/control/localization/index.md).
+
+!!! tip "Pré-requisitos"
+    Indoor: um producer de pose no tópico configurado, além do caminho de vision do
+    transporte (`make driver … ENV=indoor`, ou `vision_pose.launch.py` para
+    mavros/mavlink/dds). De qualquer forma, o EKF do FCU precisa aceitar navegação
+    externa.
+
+```python
+import nectar
+from nectar.control import (
+    DroneFactory,
+    MavlinkConfig,
+    MavrosConfig,
+    PoseSource,
+    Px4DdsConfig,
+)
+
+nectar.init()
+
+# Same takeoff / move / land after create. Pick one:
+
+drone = DroneFactory.create(
+    "mavros",
+    MavrosConfig(pose_source=PoseSource.VISION, start_driver=False),
+)
+
+# drone = DroneFactory.create(
+
+#     "mavlink",
+
+#     MavlinkConfig(
+
+#         pose_source=PoseSource.VISION,
+
+#         vision_pose_topic="/visual_slam/tracking/vo_pose_covariance",  # any pose topic
+
+#         start_driver=False,
+
+#     ),
+
+# )
+
+# drone = DroneFactory.create(
+
+#     "px4_dds", Px4DdsConfig(pose_source=PoseSource.VISION, start_driver=False)
+
+# )
+
+drone.takeoff(altitude=2.0)
+drone.land()
+drone.cleanup()
+nectar.shutdown()
+```
+
+<details markdown>
+<summary>Sem o Nectar (exemplo de relay MAVROS)</summary>
+
+```python
+#!/usr/bin/env python3
+"""Relay an external pose topic into MAVROS vision_pose (FCU EKF).
+
+Topic names are parameters — match your producer. MAVLink without Nectar sends
+VISION_POSITION_ESTIMATE instead; PX4 DDS publishes VehicleOdometry. See
+Localization README for those paths.
+"""
+import rclpy
+from geometry_msgs.msg import PoseWithCovarianceStamped
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+
+class VisionPoseRelay(Node):
+    def __init__(
+        self,
+        input_topic: str = "/visual_slam/tracking/vo_pose_covariance",
+        output_topic: str = "/mavros/vision_pose/pose_cov",
+    ) -> None:
+        super().__init__("vision_pose_relay")
+        self.pub = self.create_publisher(
+            PoseWithCovarianceStamped, output_topic, qos_profile_sensor_data
+        )
+        self.create_subscription(
+            PoseWithCovarianceStamped, input_topic, self._on_pose, qos_profile_sensor_data
+        )
+
+    def _on_pose(self, msg: PoseWithCovarianceStamped) -> None:
+        self.pub.publish(msg)
+
+def main() -> None:
+    rclpy.init()
+    node = VisionPoseRelay()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+---
+
+## [Vision](../modules/vision/index.md)
+
+`CameraFactory` / `ImageHandler` abrem qualquer câmera suportada; algoritmos e modelos
+de aprendizado processam os frames. Drivers:
+[Cameras](../modules/vision/camera.md).
+
+Abrir uma única USB já é curto sem o Nectar. A comparação importa quando o mesmo
+handler/callback precisa migrar entre backends —
+[Trocar a fonte da câmera](#change-camera-source), [Tópico de imagem ROS](#ros-image-topic),
+[Profundidade · RealSense](#depth--realsense).
+
+### Webcam
+
+!!! tip "Pré-requisitos"
+    Webcam USB visível para o OpenCV (`/dev/video*`). Nenhum driver extra do Nectar.
+
+```python
+from nectar.vision.camera import CameraFactory
+
+cam = CameraFactory.from_source("webcam")
+cam.start()
+frame = cam.get_frame()
+cam.close()
+if frame is None:
+    raise RuntimeError("failed to read frame")
+print(frame.shape)
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import cv2
+
+def main() -> None:
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        raise RuntimeError("cannot open webcam")
+    ok, frame = cap.read()
+    cap.release()
+    if not ok or frame is None:
+        raise RuntimeError("failed to read frame")
+    print(frame.shape)
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+### Tópico de imagem ROS
+
+<span id="ros-image-topic"></span>
+
+!!! tip "Pré-requisitos"
+    Um node publicando `sensor_msgs/Image` no tópico (driver de câmera ou
+    simulador). Chame `nectar.init()` para que a subscription compartilhe o runtime do
+    SDK. Use `ROSConfig(compressed=True)` / `CompressedImage` se o tópico for
+    comprimido.
+
+```python
+import nectar
+from nectar.vision.camera import CameraFactory
+
+nectar.init()
+cam = CameraFactory.from_source("/camera/color/image_raw")
+cam.start()
+frame = cam.get_frame(wait_for_new=True, timeout=2.0)
+cam.close()
+nectar.shutdown()
+if frame is None:
+    raise RuntimeError("failed to read frame")
+print(frame.shape)
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import rclpy
+from cv_bridge import CvBridge
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import Image
+
+class OneShotCam(Node):
+    def __init__(self, topic: str = "/camera/color/image_raw") -> None:
+        super().__init__("oneshot_cam")
+        self.bridge = CvBridge()
+        self.frame = None
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+        self.create_subscription(Image, topic, self._on_image, qos)
+
+    def _on_image(self, msg: Image) -> None:
+        self.frame = self.bridge.imgmsg_to_cv2(msg, desired_encoding="bgr8")
+
+def main() -> None:
+    rclpy.init()
+    node = OneShotCam()
+    try:
+        while node.frame is None:
+            rclpy.spin_once(node, timeout_sec=0.1)
+        print(node.frame.shape)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+### Profundidade · RealSense
+
+<span id="depth--realsense"></span>
+
+Frame de cor mais uma amostra de profundidade no centro da imagem. O mesmo padrão se
+aplica a outros backends de profundidade (`oakd`, `ros_depth`) via a factory key e a
+config.
+
+!!! tip "Pré-requisitos"
+    Intel RealSense D4xx conectado. Sem o Nectar também é preciso `pyrealsense2`.
+    Veja [Cameras](../modules/vision/camera.md) para a configuração de
+    RealSense / OAK.
+
+```python
+from nectar.vision.camera import CameraFactory
+
+cam = CameraFactory.from_source("realsense")
+cam.start()
+frame = cam.get_frame()
+if frame is None:
+    raise RuntimeError("no color frame")
+h, w = frame.shape[:2]
+distance_m = cam.get_distance(w // 2, h // 2)
+depth = cam.get_depth_frame()
+cam.close()
+print(frame.shape, None if depth is None else depth.shape, distance_m)
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import numpy as np
+import pyrealsense2 as rs
+
+def main() -> None:
+    pipeline = rs.pipeline()
+    config = rs.config()
+    config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)
+    config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
+    profile = pipeline.start(config)
+    align = rs.align(rs.stream.color)
+    try:
+        frames = pipeline.wait_for_frames(timeout_ms=5000)
+        frames = align.process(frames)
+        color = np.asanyarray(frames.get_color_frame().get_data())
+        depth_frame = frames.get_depth_frame()
+        depth = np.asanyarray(depth_frame.get_data())
+        h, w = color.shape[:2]
+        distance_m = depth_frame.get_distance(w // 2, h // 2)
+        print(color.shape, depth.shape, distance_m)
+    finally:
+        pipeline.stop()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+### Pose com ArUco
+
+Um frame → id do marker e a translação no frame da câmera. A mesma chamada
+[`Aruco`](../modules/vision/algorithms.md), seja o frame vindo de uma webcam,
+de um tópico ROS ou de uma câmera de profundidade (veja
+[Trocar a fonte da câmera](#change-camera-source)).
+Loop de voo completo: [Centralização com ArUco](#aruco-center).
+
+!!! tip "Pré-requisitos"
+    Webcam USB. Calibração em disco: o Nectar carrega
+    `camera_matrix.txt` / `camera_distortion.txt` via
+    [`CameraCalibration`](../modules/vision/camera.md)
+    (diretório padrão do pacote, a menos que você passe outro). Sem o Nectar, carregue
+    você mesmo os mesmos intrínsecos (`camera_matrix.npy` / `dist_coeffs.npy` abaixo, ou
+    equivalente). O dicionário de markers e o `tag_size` físico precisam corresponder à
+    tag impressa.
+
+```python
+from nectar.vision import Aruco
+from nectar.vision.camera import CameraFactory
+
+cam = CameraFactory.from_source("webcam")
+cam.start()
+frame = cam.get_frame()
+cam.close()
+if frame is None:
+    raise RuntimeError("failed to read frame")
+
+aruco = Aruco(marker_dict=5, tag_size=0.2)
+marker_id, tvec, yaw = aruco.pose_estimate(frame)
+print(marker_id, None if tvec is None else tvec.tolist(), yaw)
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import cv2
+import cv2.aruco as aruco
+import numpy as np
+
+TAG_SIZE = 0.2
+
+def main() -> None:
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        raise RuntimeError("cannot open webcam")
+    ok, frame = cap.read()
+    cap.release()
+    if not ok or frame is None:
+        raise RuntimeError("failed to read frame")
+
+    camera_matrix = np.load("camera_matrix.npy")
+    dist_coeffs = np.load("dist_coeffs.npy")
+    dictionary = aruco.getPredefinedDictionary(aruco.DICT_5X5_1000)
+    detector = aruco.ArucoDetector(dictionary, aruco.DetectorParameters())
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    corners, ids, _ = detector.detectMarkers(gray)
+    if ids is None:
+        print(None, None, None)
+        return
+    rvecs, tvecs, _ = aruco.estimatePoseSingleMarkers(
+        corners, TAG_SIZE, camera_matrix, dist_coeffs
+    )
+    tvec = tvecs[0][0]
+    # Yaw from top edge of the first marker (same idea as Nectar's helper).
+    tl, tr = corners[0][0][0], corners[0][0][1]
+    yaw = float(np.degrees(np.arctan2(tr[1] - tl[1], tr[0] - tl[0]))) % 360.0
+    print(int(ids[0][0]), tvec.tolist(), yaw)
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+### Trocar a fonte da câmera
+
+<span id="change-camera-source"></span>
+
+O mesmo callback e handler; só a string `source` (e a config opcional) muda.
+Outras chaves registradas: `oakd`, `t265`, `c920`, `imx219`, `file`, `ros_depth` —
+[Cameras](../modules/vision/camera.md).
+`ImageHandler.run()` + `nectar.spin()` é a forma em streaming; o padrão one-shot
+`CameraFactory` / `take_photo` aparece nas seções acima e em
+[Composition](#composition).
+
+!!! tip "Pré-requisitos"
+    Corresponda ao `source` escolhido (webcam, tópico ROS, RealSense, …). Com o Nectar
+    o código da missão não muda; só a string/config muda. Sem o Nectar, cada backend
+    mantém seu próprio caminho de abertura (veja os scripts sem o Nectar acima).
+
+```python
+import nectar
+from nectar.vision.camera import ImageHandler
+
+nectar.init()
+
+def on_frame(frame) -> None:
+    if frame is not None:
+        print(frame.shape)
+
+source = "webcam"  # or "/camera/color/image_raw", "realsense", "oakd", ...
+ImageHandler(source, image_processing_callback=on_frame).run()
+nectar.spin()
+nectar.shutdown()
+```
+
+---
+
+## [AI](../modules/ai/index.md)
+
+[`Detector`](../modules/ai/detection.md),
+[`Segmentor`](../modules/ai/segmentation.md) e
+[`Classifier`](../modules/ai/classification.md). A string do modelo e
+o `framework` opcional selecionam o backend; a chamada da tarefa e os campos do
+resultado permanecem os mesmos.
+
+Uma única detecção YOLO da Ultralytics já é curta sem o Nectar. A comparação
+importa quando você troca o framework ou a tarefa sem reescrever o parsing do
+resultado — [Troca de framework](#framework-swap), [Troca de tarefa](#task-flip).
+
+### YOLO
+
+!!! tip "Pré-requisitos"
+    `ultralytics` instalado; um arquivo de imagem legível (`image.jpg` por
+    padrão, abaixo). Os pesos são baixados no primeiro carregamento.
+
+```python
+from nectar.ai.detection import Detector
+
+detector = Detector("yolov8n.pt")
+detector.load()
+result = detector.detect("image.jpg")
+for det in result:
+    print(f"{det.class_name}: {det.confidence:.2f}")
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import sys
+
+import cv2
+from ultralytics import YOLO
+
+def main(image_path: str) -> None:
+    image = cv2.imread(image_path)
+    if image is None:
+        raise RuntimeError(f"cannot read {image_path}")
+    model = YOLO("yolov8n.pt")
+    out = model.predict(image, conf=0.25, verbose=False)[0]
+    names = out.names
+    for box in out.boxes:
+        cls_id = int(box.cls.item())
+        conf = float(box.conf.item())
+        print(f"{names[cls_id]}: {conf:.2f}")
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "image.jpg")
+```
+
+</details>
+
+### Troca de framework
+
+<span id="framework-swap"></span>
+
+!!! tip "Pré-requisitos"
+    O mesmo arquivo de imagem para cada modelo. Instale o framework em teste
+    (`ultralytics`, `transformers` + `torch`, ou `rfdetr`). Modelos do Hub
+    podem precisar de acesso à rede.
+
+```python
+from nectar.ai.core import Framework
+from nectar.ai.detection import Detector
+
+image_path = "image.jpg"
+for model, framework in (
+    ("yolov8n.pt", None),
+    ("rfdetr-medium", None),
+    ("facebook/detr-resnet-50", Framework.TRANSFORMERS),
+):
+    detector = Detector(model, framework=framework)
+    detector.load()
+    for det in detector.detect(image_path):
+        print(model, det.class_name, det.confidence)
+```
+
+<details markdown>
+<summary>Sem o Nectar (Hugging Face DETR)</summary>
+
+```python
+#!/usr/bin/env python3
+import sys
+
+import cv2
+import torch
+from PIL import Image as PILImage
+from transformers import AutoImageProcessor, AutoModelForObjectDetection
+
+def main(image_path: str) -> None:
+    bgr = cv2.imread(image_path)
+    if bgr is None:
+        raise RuntimeError(f"cannot read {image_path}")
+    pil = PILImage.fromarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB))
+    processor = AutoImageProcessor.from_pretrained("facebook/detr-resnet-50")
+    model = AutoModelForObjectDetection.from_pretrained("facebook/detr-resnet-50")
+    model.eval()
+    inputs = processor(images=pil, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model(**inputs)
+    results = processor.post_process_object_detection(
+        outputs, threshold=0.25, target_sizes=torch.tensor([pil.size[::-1]])
+    )[0]
+    id2label = model.config.id2label
+    for score, label in zip(results["scores"], results["labels"]):
+        print(f"{id2label[label.item()]}: {score.item():.2f}")
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "image.jpg")
+```
+
+</details>
+
+<details markdown>
+<summary>Sem o Nectar (RF-DETR)</summary>
+
+```python
+#!/usr/bin/env python3
+import sys
+
+import cv2
+from PIL import Image as PILImage
+from rfdetr import RFDETRMedium
+
+def main(image_path: str) -> None:
+    bgr = cv2.imread(image_path)
+    if bgr is None:
+        raise RuntimeError(f"cannot read {image_path}")
+    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    model = RFDETRMedium()
+    detections = model.predict(PILImage.fromarray(rgb), threshold=0.25)
+    for i in range(len(detections)):
+        cls_id = int(detections.class_id[i])
+        conf = float(detections.confidence[i])
+        # Raw API returns class_id; map to names yourself (Nectar: det.class_name).
+        print(f"{cls_id}: {conf:.2f}")
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "image.jpg")
+```
+
+</details>
+
+### Troca de tarefa
+
+<span id="task-flip"></span>
+
+A mesma imagem; alterne entre os pontos de entrada de detecção, segmentação e
+classificação.
+
+!!! tip "Pré-requisitos"
+    `ultralytics` com pesos de detecção, segmentação e classificação
+    (`yolov8n.pt`, `yolov8n-seg.pt`, `yolov8n-cls.pt`). Arquivo de imagem
+    `image.jpg` abaixo (o mesmo dos scripts sem o Nectar).
+
+```python
+from nectar.ai.detection import Detector
+from nectar.ai.segmentation import Segmentor
+from nectar.ai.classification import Classifier
+
+image_path = "image.jpg"
+
+detector = Detector("yolov8n.pt")
+detector.load()
+for det in detector.detect(image_path):
+    print(det.class_name, det.confidence)
+
+segmentor = Segmentor("yolov8n-seg.pt")
+segmentor.load()
+for seg in segmentor.segment(image_path):
+    print(seg.class_name, seg.confidence, seg.mask_area)
+
+classifier = Classifier("yolov8n-cls.pt")
+classifier.load()
+cls = classifier.classify(image_path)
+print(cls.top1_name, cls.top1_confidence)
+```
+
+<details markdown>
+<summary>Sem o Nectar (YOLO segment)</summary>
+
+```python
+#!/usr/bin/env python3
+import sys
+
+import cv2
+import numpy as np
+from ultralytics import YOLO
+
+def main(image_path: str) -> None:
+    image = cv2.imread(image_path)
+    if image is None:
+        raise RuntimeError(f"cannot read {image_path}")
+    model = YOLO("yolov8n-seg.pt")
+    out = model.predict(image, conf=0.25, verbose=False)[0]
+    names = out.names
+    if out.masks is None:
+        return
+    for i, box in enumerate(out.boxes):
+        cls_id = int(box.cls.item())
+        conf = float(box.conf.item())
+        mask = out.masks.data[i].cpu().numpy()
+        area = int(np.count_nonzero(mask > 0.5))
+        print(f"{names[cls_id]}: {conf:.2f}, mask_area={area}px")
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "image.jpg")
+```
+
+</details>
+
+<details markdown>
+<summary>Sem o Nectar (YOLO classify)</summary>
+
+```python
+#!/usr/bin/env python3
+import sys
+
+import cv2
+from ultralytics import YOLO
+
+def main(image_path: str) -> None:
+    image = cv2.imread(image_path)
+    if image is None:
+        raise RuntimeError(f"cannot read {image_path}")
+    model = YOLO("yolov8n-cls.pt")
+    out = model.predict(image, verbose=False)[0]
+    names = out.names
+    top1 = int(out.probs.top1)
+    conf = float(out.probs.top1conf)
+    print(f"{names[top1]}: {conf:.2f}")
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "image.jpg")
+```
+
+</details>
+
+---
+
+## Composition
+
+Missões curtas que combinam control, vision e, quando necessário, aprendizado.
+O loop de centralização é o mesmo nos dois pares; apenas a factory key, a
+config de pose e a fonte da câmera mudam para se adequar à stack.
+
+| Par | Firmware / transporte | Pose | Câmera | Percepção |
+|------|----------------------|------|--------|------------|
+| [Detectar e centralizar](#detect-and-center) | ArduPilot · MAVLink | Vision | Webcam | `Detector` |
+| [Centralização com ArUco](#aruco-center) | PX4 · uXRCE-DDS | GPS | Tópico de imagem ROS | `Aruco` |
+
+### Detectar e centralizar
+
+<span id="detect-and-center"></span>
+
+[`ImageHandler`](../modules/vision/camera.md) +
+[`Detector`](../modules/ai/detection.md) +
+[`PIDController`](../modules/control/pid.md) → velocidade do corpo
+até que o alvo esteja centralizado (ArduPilot · MAVLink, pose de visão, webcam).
+
+!!! tip "Pré-requisitos"
+    FCU em uma URL pymavlink; VSLAM/VIO publicando o tópico de pose de visão (o
+    Nectar o reenvia como `VISION_POSITION_ESTIMATE` quando `pose_source=VISION` —
+    [Fonte de pose](#pose-source),
+    [Localization](../modules/control/localization/index.md)); webcam USB;
+    `ultralytics` para o script sem o Nectar. Ganhos e limiares são específicos
+    da missão.
+
+```python
+import nectar
+from nectar.ai.detection import Detector
+from nectar.control import DroneFactory, MavlinkConfig, PIDController, PoseSource
+from nectar.vision.camera import ImageHandler
+
+CENTER_PX = 40.0
+LOST_LIMIT = 30
+TARGET_CLASS = "person"  # class name in the loaded model
+
+nectar.init()
+drone = DroneFactory.create(
+    "mavlink", MavlinkConfig(pose_source=PoseSource.VISION, start_driver=False)
+)
+drone.takeoff(altitude=1.2)
+
+detector = Detector("yolov8n.pt")
+detector.load()
+
+handler = ImageHandler(
+    "webcam",
+    image_processing_callback=lambda frame: detector.detect(frame),
+)
+handler.open()
+
+pid_x = PIDController(kp=-0.002, ki=0.0, kd=0.0, setpoint=0.0, output_limits=(-0.4, 0.4))
+pid_y = PIDController(kp=-0.002, ki=0.0, kd=0.0, setpoint=0.0, output_limits=(-0.4, 0.4))
+pid_x.reset()
+pid_y.reset()
+
+lost = 0
+while True:
+    result = handler.take_photo()
+    targets = result.filter_by_class([TARGET_CLASS]) if result else None
+    if not targets:
+        lost += 1
+        drone.move_velocity(vx=0.0, vy=0.0, vz=0.0, duration=1.0 / 30.0)
+        if lost >= LOST_LIMIT:
+            break
+        continue
+    lost = 0
+    det = max(targets, key=lambda d: d.confidence)
+    h, w = handler.img.shape[:2]
+    cx, cy = det.center
+    err_x = float(cx - w / 2.0)
+    err_y = float(cy - h / 2.0)
+    if err_x * err_x + err_y * err_y <= CENTER_PX * CENTER_PX:
+        drone.move_velocity(vx=0.0, vy=0.0, vz=0.0, duration=0.2)
+        break
+    # Downward camera: image x → body vy, image y → body vx (signs are mission-tuned).
+    drone.move_velocity(
+        vx=pid_y.update(err_y),
+        vy=pid_x.update(-err_x),
+        vz=0.0,
+        duration=1.0 / 30.0,
+    )
+
+drone.land()
+handler.cleanup()
+drone.cleanup()
+nectar.shutdown()
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import time
+
+import cv2
+from pymavlink import mavutil
+from ultralytics import YOLO
+
+CENTER_PX = 40.0
+LOST_LIMIT = 30
+TARGET_CLASS = "person"
+_M = mavutil.mavlink
+_VELOCITY_MASK = (
+    _M.POSITION_TARGET_TYPEMASK_X_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_Y_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_Z_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_AX_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_AY_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_AZ_IGNORE
+    | _M.POSITION_TARGET_TYPEMASK_YAW_IGNORE
+)
+
+class PID:
+    def __init__(self, kp: float, ki: float, kd: float, limits=(-0.4, 0.4)) -> None:
+        self.kp, self.ki, self.kd = kp, ki, kd
+        self.lo, self.hi = limits
+        self.setpoint = 0.0
+        self._i = 0.0
+        self._prev_err = 0.0
+        self._prev_t = None
+
+    def reset(self) -> None:
+        self._i = 0.0
+        self._prev_err = 0.0
+        self._prev_t = None
+
+    def update(self, value: float) -> float:
+        now = time.monotonic()
+        err = self.setpoint - value
+        if self._prev_t is None:
+            self._prev_t = now
+            self._prev_err = err
+            return 0.0
+        dt = max(now - self._prev_t, 1e-3)
+        self._i = max(self.lo, min(self.hi, self._i + err * dt))
+        d = (err - self._prev_err) / dt
+        self._prev_err, self._prev_t = err, now
+        out = self.kp * err + self.ki * self._i + self.kd * d
+        return max(self.lo, min(self.hi, out))
+
+class DetectCenter:
+    """ArduPilot GUIDED over pymavlink + YOLO + webcam.
+
+    Indoor EKF still needs an external VISION_POSITION_ESTIMATE feed (separate
+    VSLAM relay). Nectar starts that bridge when pose_source=VISION.
+    """
+
+    def __init__(self, connection_string: str = "udp:127.0.0.1:14550") -> None:
+        self.master = mavutil.mavlink_connection(connection_string, autoreconnect=True)
+        self.master.wait_heartbeat()
+        self._local = None
+        self._request_streams()
+        self.model = YOLO("yolov8n.pt")
+        self.cap = cv2.VideoCapture(0)
+        if not self.cap.isOpened():
+            raise RuntimeError("cannot open webcam")
+        self.pid_x = PID(kp=-0.002, ki=0.0, kd=0.0)
+        self.pid_y = PID(kp=-0.002, ki=0.0, kd=0.0)
+
+    def _request_streams(self) -> None:
+        for msg_id, hz in (
+            (_M.MAVLINK_MSG_ID_LOCAL_POSITION_NED, 20),
+            (_M.MAVLINK_MSG_ID_ATTITUDE, 20),
+            (_M.MAVLINK_MSG_ID_HEARTBEAT, 1),
+        ):
+            self.master.mav.command_long_send(
+                self.master.target_system,
+                self.master.target_component,
+                _M.MAV_CMD_SET_MESSAGE_INTERVAL,
+                0,
+                msg_id,
+                int(1e6 / hz),
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
+
+    def _spin_local(self, timeout: float = 0.5):
+        msg = self.master.recv_match(type="LOCAL_POSITION_NED", blocking=True, timeout=timeout)
+        if msg is not None:
+            self._local = msg
+        return self._local
+
+    def set_mode(self, mode: str) -> None:
+        mapping = self.master.mode_mapping()
+        if mode not in mapping:
+            raise RuntimeError(f"mode {mode!r} not in mode_mapping")
+        self.master.mav.set_mode_send(
+            self.master.target_system,
+            mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+            mapping[mode],
+        )
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            hb = self.master.recv_match(type="HEARTBEAT", blocking=True, timeout=0.5)
+            if hb and mavutil.mode_string_v10(hb) == mode:
+                return
+        raise TimeoutError(f"failed to enter {mode}")
+
+    def arm(self) -> None:
+        self.master.mav.command_long_send(
+            self.master.target_system,
+            self.master.target_component,
+            _M.MAV_CMD_COMPONENT_ARM_DISARM,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+        deadline = time.time() + 6.0
+        while time.time() < deadline:
+            hb = self.master.recv_match(type="HEARTBEAT", blocking=True, timeout=0.5)
+            if hb and (hb.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED):
+                return
+        raise TimeoutError("arm failed")
+
+    def takeoff(self, altitude: float, timeout: float = 25.0) -> None:
+        self.master.mav.command_long_send(
+            self.master.target_system,
+            self.master.target_component,
+            _M.MAV_CMD_NAV_TAKEOFF,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            float(altitude),
+        )
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            msg = self._spin_local()
+            if msg is not None and -msg.z >= altitude - 0.3:
+                return
+        raise TimeoutError("takeoff settle")
+
+    def publish_velocity(self, vx: float, vy: float, vz: float = 0.0) -> None:
+        # Body FLU → MAV_FRAME_BODY_NED FRD
+        vn, ve, vd = float(vx), -float(vy), -float(vz)
+        self.master.mav.set_position_target_local_ned_send(
+            0,
+            self.master.target_system,
+            self.master.target_component,
+            _M.MAV_FRAME_BODY_NED,
+            _VELOCITY_MASK,
+            0.0,
+            0.0,
+            0.0,
+            vn,
+            ve,
+            vd,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        )
+
+    def land(self) -> None:
+        self.set_mode("LAND")
+
+    def run_center(self) -> None:
+        self.pid_x.reset()
+        self.pid_y.reset()
+        lost = 0
+        rate = 1.0 / 30.0
+        while True:
+            ok, frame = self.cap.read()
+            self._spin_local(timeout=0.0)
+            if not ok or frame is None:
+                continue
+            out = self.model.predict(frame, conf=0.25, verbose=False)[0]
+            names = out.names
+            candidates = []
+            if out.boxes is not None:
+                for box in out.boxes:
+                    cls_id = int(box.cls.item())
+                    if names[cls_id] == TARGET_CLASS:
+                        candidates.append(box)
+            if not candidates:
+                lost += 1
+                self.publish_velocity(0.0, 0.0)
+                time.sleep(rate)
+                if lost >= LOST_LIMIT:
+                    return
+                continue
+            lost = 0
+            box = max(candidates, key=lambda b: float(b.conf.item()))
+            x1, y1, x2, y2 = box.xyxy[0].tolist()
+            cx, cy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+            h, w = frame.shape[:2]
+            err_x = float(cx - w / 2.0)
+            err_y = float(cy - h / 2.0)
+            if err_x * err_x + err_y * err_y <= CENTER_PX * CENTER_PX:
+                self.publish_velocity(0.0, 0.0)
+                return
+            self.publish_velocity(self.pid_y.update(err_y), self.pid_x.update(-err_x))
+            time.sleep(rate)
+
+    def close(self) -> None:
+        self.cap.release()
+
+def main() -> None:
+    pilot = DetectCenter("udp:127.0.0.1:14550")
+    try:
+        pilot.set_mode("GUIDED")
+        pilot.arm()
+        time.sleep(1.0)
+        pilot.takeoff(1.2)
+        pilot.run_center()
+        pilot.land()
+    finally:
+        pilot.close()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+!!! note "Pose de visão sem o Nectar"
+    Sem o Nectar você também precisa manter o relay VSLAM →
+    `VISION_POSITION_ESTIMATE` você mesmo ([Fonte de pose](#pose-source)).
+
+### Centralização com ArUco
+
+<span id="aruco-center"></span>
+
+O mesmo loop de centralização com
+[`Aruco`](../modules/vision/algorithms.md) em vez de um modelo de
+aprendizado (PX4 · uXRCE-DDS, pose GPS, tópico de imagem ROS).
+
+!!! tip "Pré-requisitos"
+    PX4 com cliente uXRCE-DDS e `px4_msgs`; com o Nectar, rode
+    `make driver-px4-dds` quando `start_driver=False`. Um node publicando
+    `sensor_msgs/Image` no tópico. Os dois lados precisam dos intrínsecos da
+    câmera e de um marker correspondente: o Nectar carrega `camera_matrix.txt` /
+    `camera_distortion.txt` via `CameraCalibration` ao construir `Aruco`; o
+    script sem o Nectar carrega `camera_matrix.npy` / `dist_coeffs.npy`. O
+    dicionário `DICT_5X5_1000` e o `tag_size` precisam corresponder à tag
+    impressa.
+
+```python
+import nectar
+from nectar.control import DroneFactory, PIDController, PoseSource, Px4DdsConfig
+from nectar.vision import Aruco
+from nectar.vision.camera import ImageHandler
+
+CENTER_XY = 0.05
+LOST_LIMIT = 30
+
+nectar.init()
+drone = DroneFactory.create(
+    "px4_dds", Px4DdsConfig(pose_source=PoseSource.GPS, start_driver=False)
+)
+drone.takeoff(altitude=1.2)
+
+aruco = Aruco(marker_dict=5, tag_size=0.2)
+handler = ImageHandler(
+    "/camera/color/image_raw",
+    image_processing_callback=lambda frame: aruco.pose_estimate(frame),
+)
+handler.open()
+
+pid_x = PIDController(kp=-0.4, ki=-0.02, kd=0.0, setpoint=0.0, output_limits=(-0.4, 0.4))
+pid_y = PIDController(kp=-0.4, ki=-0.02, kd=0.0, setpoint=0.0, output_limits=(-0.4, 0.4))
+pid_x.reset()
+pid_y.reset()
+
+lost = 0
+while True:
+    out = handler.take_photo()
+    if out is None:
+        continue
+    marker_id, tvec, _yaw = out
+    if marker_id is None or tvec is None:
+        lost += 1
+        drone.move_velocity(vx=0.0, vy=0.0, vz=0.0, duration=1.0 / 30.0)
+        if lost >= LOST_LIMIT:
+            break
+        continue
+    lost = 0
+    err_x, err_y = float(tvec[0]), float(tvec[1])
+    if err_x * err_x + err_y * err_y <= CENTER_XY * CENTER_XY:
+        drone.move_velocity(vx=0.0, vy=0.0, vz=0.0, duration=0.2)
+        break
+    drone.move_velocity(
+        vx=pid_x.update(err_x),
+        vy=pid_y.update(err_y),
+        vz=0.0,
+        duration=1.0 / 30.0,
+    )
+
+drone.land()
+handler.cleanup()
+drone.cleanup()
+nectar.shutdown()
+```
+
+<details markdown>
+<summary>Sem o Nectar</summary>
+
+```python
+#!/usr/bin/env python3
+import math
+import time
+
+import cv2
+import cv2.aruco as aruco
+import numpy as np
+import rclpy
+from cv_bridge import CvBridge
+from px4_msgs.msg import (
+    OffboardControlMode,
+    TrajectorySetpoint,
+    VehicleCommand,
+    VehicleLocalPosition,
+    VehicleStatus,
+)
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import Image
+
+CENTER_XY = 0.05
+LOST_LIMIT = 30
+TAG_SIZE = 0.2
+_ARMING_STATE_ARMED = 2
+_NAV_STATE_OFFBOARD = 14
+
+class PID:
+    def __init__(self, kp: float, ki: float, kd: float, limits=(-0.4, 0.4)) -> None:
+        self.kp, self.ki, self.kd = kp, ki, kd
+        self.lo, self.hi = limits
+        self.setpoint = 0.0
+        self._i = 0.0
+        self._prev_err = 0.0
+        self._prev_t = None
+
+    def reset(self) -> None:
+        self._i = 0.0
+        self._prev_err = 0.0
+        self._prev_t = None
+
+    def update(self, value: float) -> float:
+        now = time.monotonic()
+        err = self.setpoint - value
+        if self._prev_t is None:
+            self._prev_t = now
+            self._prev_err = err
+            return 0.0
+        dt = max(now - self._prev_t, 1e-3)
+        self._i = max(self.lo, min(self.hi, self._i + err * dt))
+        d = (err - self._prev_err) / dt
+        self._prev_err, self._prev_t = err, now
+        out = self.kp * err + self.ki * self._i + self.kd * d
+        return max(self.lo, min(self.hi, out))
+
+def enu_to_ned(x: float, y: float, z: float):
+    return y, x, -z
+
+def yaw_enu_to_ned(yaw_enu: float) -> float:
+    return math.pi / 2.0 - yaw_enu
+
+class ArucoCenter(Node):
+    """PX4 OFFBOARD over uXRCE-DDS + ArUco + ROS Image topic (GPS local pose)."""
+
+    def __init__(self, image_topic: str = "/camera/color/image_raw") -> None:
+        super().__init__("aruco_center_px4")
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=5,
+            durability=DurabilityPolicy.VOLATILE,
+        )
+        self.local = None
+        self.status = None
+        self.frame = None
+        self.bridge = CvBridge()
+        self._sp_n = self._sp_e = self._sp_d = 0.0
+        self._sp_yaw = 0.0
+        self._vn = self._ve = self._vd = 0.0
+        self._velocity_mode = False
+
+        self.create_subscription(
+            VehicleLocalPosition, "/fmu/out/vehicle_local_position_v1", self._on_local, qos
+        )
+        self.create_subscription(VehicleStatus, "/fmu/out/vehicle_status_v4", self._on_status, qos)
+        self.create_subscription(Image, image_topic, self._on_image, qos)
+        self.offboard_pub = self.create_publisher(OffboardControlMode, "/fmu/in/offboard_control_mode", 10)
+        self.setpoint_pub = self.create_publisher(TrajectorySetpoint, "/fmu/in/trajectory_setpoint", 10)
+        self.command_pub = self.create_publisher(VehicleCommand, "/fmu/in/vehicle_command", 10)
+        self.create_timer(0.05, self._pump)
+
+        self.dictionary = aruco.getPredefinedDictionary(aruco.DICT_5X5_1000)
+        self.detector = aruco.ArucoDetector(self.dictionary, aruco.DetectorParameters())
+        self.camera_matrix = np.load("camera_matrix.npy")
+        self.dist_coeffs = np.load("dist_coeffs.npy")
+        self.pid_x = PID(kp=-0.4, ki=-0.02, kd=0.0)
+        self.pid_y = PID(kp=-0.4, ki=-0.02, kd=0.0)
+
+    def _now_us(self) -> int:
+        return int(self.get_clock().now().nanoseconds / 1000)
+
+    def _on_local(self, msg: VehicleLocalPosition) -> None:
+        self.local = msg
+
+    def _on_status(self, msg: VehicleStatus) -> None:
+        self.status = msg
+
+    def _on_image(self, msg: Image) -> None:
+        self.frame = self.bridge.imgmsg_to_cv2(msg, desired_encoding="bgr8")
+
+    def _pump(self) -> None:
+        mode = OffboardControlMode()
+        mode.timestamp = self._now_us()
+        mode.position = not self._velocity_mode
+        mode.velocity = self._velocity_mode
+        self.offboard_pub.publish(mode)
+        sp = TrajectorySetpoint()
+        sp.timestamp = self._now_us()
+        if self._velocity_mode:
+            sp.position = [math.nan, math.nan, math.nan]
+            sp.velocity = [self._vn, self._ve, self._vd]
+            sp.yaw = math.nan
+        else:
+            sp.position = [self._sp_n, self._sp_e, self._sp_d]
+            sp.velocity = [math.nan, math.nan, math.nan]
+            sp.yaw = self._sp_yaw
+        sp.yawspeed = math.nan
+        self.setpoint_pub.publish(sp)
+
+    def _command(self, command: int, **params) -> None:
+        msg = VehicleCommand()
+        msg.timestamp = self._now_us()
+        msg.command = int(command)
+        for i in range(1, 8):
+            setattr(msg, f"param{i}", float(params.get(f"param{i}", 0.0)))
+        msg.target_system = 1
+        msg.target_component = 1
+        msg.source_system = 1
+        msg.source_component = 1
+        msg.from_external = True
+        self.command_pub.publish(msg)
+
+    def wait_telemetry(self, timeout: float = 30.0) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if self.local is not None and self.status is not None:
+                return
+        raise TimeoutError("no PX4 telemetry on uXRCE-DDS")
+
+    def hold_current(self) -> None:
+        assert self.local is not None
+        self._velocity_mode = False
+        self._sp_n = float(self.local.x)
+        self._sp_e = float(self.local.y)
+        self._sp_d = float(self.local.z)
+        self._sp_yaw = yaw_enu_to_ned(math.pi / 2.0 - float(self.local.heading))
+
+    def enter_offboard_and_arm(self) -> None:
+        self.hold_current()
+        for _ in range(20):
+            rclpy.spin_once(self, timeout_sec=0.05)
+        self._command(176, param1=1.0, param2=6.0, param3=0.0)
+        self._command(400, param1=1.0)
+        deadline = time.time() + 6.0
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.1)
+            if (
+                self.status is not None
+                and self.status.arming_state == _ARMING_STATE_ARMED
+                and self.status.nav_state == _NAV_STATE_OFFBOARD
+            ):
+                return
+        raise TimeoutError("OFFBOARD arm failed")
+
+    def takeoff(self, altitude: float, timeout: float = 25.0) -> None:
+        assert self.local is not None
+        self._velocity_mode = False
+        self._sp_n = float(self.local.x)
+        self._sp_e = float(self.local.y)
+        self._sp_d = float(self.local.z) - float(altitude)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+            if self.local is not None and -self.local.z >= altitude - 0.3:
+                return
+        raise TimeoutError("takeoff settle")
+
+    def publish_velocity(self, vx: float, vy: float, vz: float = 0.0) -> None:
+        # Body FLU → world ENU using PX4 heading, then ENU → NED for TrajectorySetpoint.
+        assert self.local is not None
+        yaw_enu = math.pi / 2.0 - float(self.local.heading)
+        c, s = math.cos(yaw_enu), math.sin(yaw_enu)
+        ve = vx * c - vy * s
+        vn = vx * s + vy * c
+        self._vn, self._ve, self._vd = enu_to_ned(ve, vn, vz)
+        self._velocity_mode = True
+
+    def land(self) -> None:
+        self._command(176, param1=1.0, param2=4.0, param3=6.0)
+
+    def estimate_pose(self, frame):
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        corners, ids, _ = self.detector.detectMarkers(gray)
+        if ids is None:
+            return None, None
+        rvecs, tvecs, _ = aruco.estimatePoseSingleMarkers(
+            corners, TAG_SIZE, self.camera_matrix, self.dist_coeffs
+        )
+        return int(ids[0][0]), tvecs[0][0]
+
+    def run_center(self) -> None:
+        self.pid_x.reset()
+        self.pid_y.reset()
+        lost = 0
+        rate = 1.0 / 30.0
+        while True:
+            now = time.time()
+            rclpy.spin_once(self, timeout_sec=0.0)
+            frame = self.frame
+            if frame is None:
+                continue
+            marker_id, tvec = self.estimate_pose(frame)
+            if tvec is None:
+                lost += 1
+                self.publish_velocity(0.0, 0.0)
+                while time.time() - now < rate:
+                    rclpy.spin_once(self, timeout_sec=0.01)
+                if lost >= LOST_LIMIT:
+                    return
+                continue
+            lost = 0
+            err_x, err_y = float(tvec[0]), float(tvec[1])
+            if err_x * err_x + err_y * err_y <= CENTER_XY * CENTER_XY:
+                self.publish_velocity(0.0, 0.0)
+                return
+            self.publish_velocity(self.pid_x.update(err_x), self.pid_y.update(err_y))
+            while time.time() - now < rate:
+                rclpy.spin_once(self, timeout_sec=0.01)
+
+def main() -> None:
+    rclpy.init()
+    node = ArucoCenter()
+    try:
+        node.wait_telemetry()
+        node.enter_offboard_and_arm()
+        node.takeoff(1.2)
+        node.run_center()
+        node.land()
+        time.sleep(2.0)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>
+
+!!! note "O que muda"
+    Sem o Nectar, as stacks divergem (captura via pymavlink + OpenCV vs.
+    offboard PX4 DDS + subscriber de imagem ROS). Com o Nectar, as diferenças
+    ficam restritas à factory key, à config e à string de origem do
+    `ImageHandler`.

--- a/i18n/pt/index.md
+++ b/i18n/pt/index.md
@@ -9,26 +9,27 @@ hide:
 
 - [:simple-github: GitHub](https://github.com/Black-Bee-Drones/nectar-sdk)
 - [:simple-apache: Apache 2.0](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/LICENSE){ .cb style="--b:#D22128" }
-- [:octicons-tag-16: Latest release](https://github.com/Black-Bee-Drones/nectar-sdk/releases/latest)
+- [:octicons-tag-16: Última release](https://github.com/Black-Bee-Drones/nectar-sdk/releases/latest)
 - [:simple-ros: ROS 2 · Humble · Jazzy · Kilted](setup/compatibility.md)
 
 </div>
 
-Nectar SDK is a ROS 2 software development kit for autonomous drones. It unifies flight
-control, computer vision, and AI behind one consistent set of interfaces, so a mission you
-write once runs across different vehicles, sensors, and simulators with little change.
+Nectar SDK é um kit de desenvolvimento ROS 2 para drones autônomos. Ele unifica
+controle de voo, visão computacional e IA por meio de um conjunto consistente de
+interfaces, para que uma missão escrita uma vez rode em veículos, sensores e
+simuladores diferentes com pouca mudança.
 
-[Get started](get-started/index.md){ .md-button .md-button--primary }
-[With / without](get-started/with-without.md){ .md-button }
-[Architecture](concepts/architecture.md){ .md-button }
+[Começar](get-started/index.md){ .md-button .md-button--primary }
+[Com / sem](get-started/with-without.md){ .md-button }
+[Arquitetura](concepts/architecture.md){ .md-button }
 
-## See it in action
+## Veja em ação
 
-Autonomous missions our team flew with the SDK, in competition and in the field. Click any clip
-to watch it larger.
+Missões autônomas que nossa equipe voou com o SDK, em competição e em campo. Clique
+em qualquer clipe para ampliar.
 
 <div class="nectar-carousel nectar-carousel--marquee">
-  <button class="nectar-carousel__btn nectar-carousel__btn--prev" aria-label="Previous">&lsaquo;</button>
+  <button class="nectar-carousel__btn nectar-carousel__btn--prev" aria-label="Anterior">&lsaquo;</button>
   <div class="nectar-carousel__track">
     <div class="nectar-tile nectar-tile--portrait" data-src="assets/media/comp-imav25.mp4" data-poster="assets/media/comp-imav25.jpg">
       <div class="nectar-tile__media">
@@ -36,7 +37,7 @@ to watch it larger.
           <source src="assets/media/comp-imav25.mp4" type="video/mp4">
         </video>
       </div>
-      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/imav-2025">IMAV 2025, indoor</a><span class="cap-sub">Gate entry, obstacles, moving smoke platform · 3rd place</span></div>
+      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/imav-2025">IMAV 2025, indoor</a><span class="cap-sub">Entrada em portão, obstáculos, plataforma de fumaça móvel · 3º lugar</span></div>
     </div>
     <div class="nectar-tile" data-src="assets/media/comp-hook.mp4" data-poster="assets/media/comp-hook.jpg">
       <div class="nectar-tile__media">
@@ -44,7 +45,7 @@ to watch it larger.
           <source src="assets/media/comp-hook.mp4" type="video/mp4">
         </video>
       </div>
-      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/SAE-Eletroquad">SAE Eletroquad 2026</a><span class="cap-sub">Hook and place, annotated run</span></div>
+      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/SAE-Eletroquad">SAE Eletroquad 2026</a><span class="cap-sub">Hook and place, execução anotada</span></div>
     </div>
     <div class="nectar-tile" data-src="assets/media/comp-imav23.mp4" data-poster="assets/media/comp-imav23.jpg">
       <div class="nectar-tile__media">
@@ -52,7 +53,7 @@ to watch it larger.
           <source src="assets/media/comp-imav23.mp4" type="video/mp4">
         </video>
       </div>
-      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/imav2023-indoor">IMAV 2023, indoor</a><span class="cap-sub">Line following and ArUco landing · 3rd place</span></div>
+      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/imav2023-indoor">IMAV 2023, indoor</a><span class="cap-sub">Seguimento de linha e pouso em ArUco · 3º lugar</span></div>
     </div>
     <div class="nectar-tile nectar-tile--portrait" data-src="assets/media/comp-cbr.mp4" data-poster="assets/media/comp-cbr.jpg">
       <div class="nectar-tile__media">
@@ -60,7 +61,7 @@ to watch it larger.
           <source src="assets/media/comp-cbr.mp4" type="video/mp4">
         </video>
       </div>
-      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/cbr-2025">CBR 2025</a><span class="cap-sub">Phase 1: Precision landing on a base</span></div>
+      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/cbr-2025">CBR 2025</a><span class="cap-sub">Fase 1: pouso de precisão em uma base</span></div>
     </div>
     <div class="nectar-tile" data-src="assets/media/comp-slalom.mp4" data-poster="assets/media/comp-slalom.jpg">
       <div class="nectar-tile__media">
@@ -68,13 +69,13 @@ to watch it larger.
           <source src="assets/media/comp-slalom.mp4" type="video/mp4">
         </video>
       </div>
-      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/SAE-Eletroquad">SAE Eletroquad 2025</a><span class="cap-sub">Slalom mission</span></div>
+      <div class="nectar-cap"><a href="https://github.com/Black-Bee-Drones/SAE-Eletroquad">SAE Eletroquad 2025</a><span class="cap-sub">Missão de slalom</span></div>
     </div>
   </div>
-  <button class="nectar-carousel__btn nectar-carousel__btn--next" aria-label="Next">&rsaquo;</button>
+  <button class="nectar-carousel__btn nectar-carousel__btn--next" aria-label="Próximo">&rsaquo;</button>
 </div>
 
-## What you can build
+## O que você pode construir
 
 <div class="nectar-features">
   <div class="nectar-feature">
@@ -84,9 +85,9 @@ to watch it larger.
       </video>
     </div>
     <div class="nectar-feature__body">
-      <h3>Fly any vehicle</h3>
-      <p>ArduPilot and PX4 over MAVROS, direct MAVLink, or native uXRCE-DDS, plus Bebop and Crazyflie, behind one flight interface. Navigation, GPS waypoints, return to launch, PID, and obstacle handling.</p>
-      <a href="get-started/control/">Fly a drone</a>
+      <h3>Voar qualquer veículo</h3>
+      <p>ArduPilot e PX4 via MAVROS, MAVLink direto ou uXRCE-DDS nativo, além de Bebop e Crazyflie, por meio de uma interface de voo. Navegação, waypoints GPS, retorno ao ponto de lançamento (RTL), PID e desvio de obstáculos.</p>
+      <a href="get-started/control/">Voar um drone</a>
     </div>
   </div>
   <div class="nectar-feature">
@@ -96,9 +97,9 @@ to watch it larger.
       </video>
     </div>
     <div class="nectar-feature__body">
-      <h3>See with any camera</h3>
-      <p>USB, RealSense, OAK-D, Pi Camera, or a ROS topic behind one camera factory and a shared image handler. ArUco, color, line, distance estimation, optical flow, and MediaPipe.</p>
-      <a href="get-started/vision/">See with a camera</a>
+      <h3>Ver com qualquer câmera</h3>
+      <p>USB, RealSense, OAK-D, Pi Camera ou um tópico ROS por meio de uma camera factory e um image handler compartilhado. ArUco, cor, linha, estimativa de distância, optical flow e MediaPipe.</p>
+      <a href="get-started/vision/">Ver com uma câmera</a>
     </div>
   </div>
   <div class="nectar-feature">
@@ -108,9 +109,9 @@ to watch it larger.
       </video>
     </div>
     <div class="nectar-feature__body">
-      <h3>Detect, segment, and classify</h3>
-      <p>Object detection, instance segmentation, and classification across Ultralytics YOLO, HuggingFace DETR, and RF-DETR behind one interface built to take on new models and tasks, with training and evaluation.</p>
-      <a href="get-started/ai/">Detect, segment & classify</a>
+      <h3>Detectar, segmentar e classificar</h3>
+      <p>Detecção de objetos, segmentação de instâncias e classificação com Ultralytics YOLO, HuggingFace DETR e RF-DETR por meio de uma interface preparada para novos modelos e tarefas, com treinamento e avaliação.</p>
+      <a href="get-started/ai/">Detectar, segmentar e classificar</a>
     </div>
   </div>
   <div class="nectar-feature">
@@ -120,9 +121,9 @@ to watch it larger.
       </video>
     </div>
     <div class="nectar-feature__body">
-      <h3>Fly indoors without GPS</h3>
-      <p>A companion rangefinder bridge and a RealSense with Isaac VSLAM pipeline feed the flight controller, so the same navigation code and precision work indoors and out.</p>
-      <a href="modules/control/localization/">Localization</a>
+      <h3>Voar indoor sem GPS</h3>
+      <p>Uma ponte de rangefinder no computador de bordo e um RealSense com pipeline Isaac VSLAM alimentam o controlador de voo, para o mesmo código de navegação e a mesma precisão indoor e outdoor.</p>
+      <a href="modules/control/localization/">Localização</a>
     </div>
   </div>
   <div class="nectar-feature">
@@ -132,8 +133,8 @@ to watch it larger.
       </video>
     </div>
     <div class="nectar-feature__body">
-      <h3>Operate without code</h3>
-      <p>A desktop app to arm, take off, fly, stream cameras with live filters, tune PID with live plots, and inspect ROS 2 topics, services, and parameters.</p>
+      <h3>Operar sem código</h3>
+      <p>Um app desktop para armar, decolar, voar, transmitir câmeras com filtros ao vivo, ajustar PID com gráficos e inspecionar tópicos, serviços e parâmetros ROS 2.</p>
       <a href="modules/interface/">Interface</a>
     </div>
   </div>
@@ -144,47 +145,48 @@ to watch it larger.
       </video>
     </div>
     <div class="nectar-feature__body">
-      <h3>Test in simulation</h3>
-      <p>ArduPilot or PX4 SITL with Gazebo, indoor and outdoor, running the same missions you fly on hardware.</p>
-      <a href="setup/simulation/">Simulation</a>
+      <h3>Testar em simulação</h3>
+      <p>ArduPilot ou PX4 SITL com Gazebo, indoor e outdoor, rodando as mesmas missões que você voa no hardware.</p>
+      <a href="setup/simulation/">Simulação</a>
     </div>
   </div>
 </div>
 
-## Who it's for
+## Para quem é
 
-Nectar SDK suits academic labs, research groups, competition teams, and industry prototyping:
-anyone building autonomous flight who wants control, vision, and AI under one consistent set of
-interfaces. It is a good fit when you want to:
+Nectar SDK serve laboratórios acadêmicos, grupos de pesquisa, equipes de competição e
+prototipagem industrial: quem constrói voo autônomo e quer controle, visão e IA sob um
+conjunto consistente de interfaces. É um bom encaixe quando você quer:
 
-- Run one mission across different vehicles and transports, in simulation or on hardware.
-- Combine flight control, computer vision, and AI in a single codebase with typed, consistent APIs.
-- Fly indoors and outdoors with the same navigation code and the same precision.
-- Add a new drone, camera, or model by following one familiar pattern, without forking the core.
+- Rodar uma missão em veículos e transportes diferentes, em simulação ou no hardware.
+- Combinar controle de voo, visão computacional e IA em um único código com APIs tipadas e consistentes.
+- Voar indoor e outdoor com o mesmo código de navegação e a mesma precisão.
+- Adicionar um novo drone, câmera ou modelo seguindo um padrão familiar, sem fork do núcleo.
 
-It is not a flight controller or a replacement for ArduPilot or PX4. It runs on the companion
-computer and drives them through ROS 2.
+Não é um controlador de voo nem um substituto do ArduPilot ou do PX4. Roda no computador
+de bordo e os aciona via ROS 2.
 
-## About
+## Sobre
 
-Nectar SDK is developed by [Black Bee Drones](https://github.com/Black-Bee-Drones), Latin
-America's first academic autonomous drone team, founded in 2014 at the Federal University of
-Itajubá (UNIFEI). The team builds autonomous aircraft for missions that rely on computer vision
-and artificial intelligence, and competes nationally and internationally, including
-[IMAV](https://www.imavs.org/) (3rd place indoor in 2023 and 2025), the
-[CBR RoboCup Flying Robots League](https://cbr.robocup.org.br/), and
+Nectar SDK é desenvolvido pela [Black Bee Drones](https://github.com/Black-Bee-Drones), a
+primeira equipe acadêmica de drones autônomos da América Latina, fundada em 2014 na
+Universidade Federal de Itajubá (UNIFEI). A equipe constrói aeronaves autônomas para
+missões que dependem de visão computacional e inteligência artificial, e compete em nível
+nacional e internacional, incluindo
+[IMAV](https://www.imavs.org/) (3º lugar indoor em 2023 e 2025), a
+[CBR RoboCup Flying Robots League](https://cbr.robocup.org.br/) e
 [SAE Eletroquad](https://saebrasil.org.br/programas-estudantis/eletroquad/).
 
-It started in 2023 as a way to stop rewriting the same camera, PID, and detection code for each
-competition mission, and grew into a ROS 2 package with consistent interfaces across flight
-control, computer vision, and AI. It is open source under Apache 2.0 so other teams and labs
-can build autonomous systems more quickly.
+Começou em 2023 como forma de parar de reescrever o mesmo código de câmera, PID e detecção
+para cada missão de competição, e cresceu até um pacote ROS 2 com interfaces consistentes
+em controle de voo, visão computacional e IA. É open source sob Apache 2.0 para que outras
+equipes e laboratórios construam sistemas autônomos com mais rapidez.
 
-### Built on
+### Construído sobre
 
 <div class="nectar-ack__group" markdown>
 
-<p class="nectar-ack__title">Robotics & flight</p>
+<p class="nectar-ack__title">Robótica e voo</p>
 
 - [:simple-ros: ROS 2](https://docs.ros.org/)
 - <a class="b-logo" href="https://ardupilot.org/" aria-label="ArduPilot"><img class="nectar-logo off-glb" src="assets/logos/ardupilot.svg" alt="ArduPilot"></a>
@@ -197,7 +199,7 @@ can build autonomous systems more quickly.
 
 <div class="nectar-ack__group" markdown>
 
-<p class="nectar-ack__title">Perception & AI</p>
+<p class="nectar-ack__title">Percepção e IA</p>
 
 - [:simple-opencv: OpenCV](https://opencv.org/){ .cb style="--b:#5C3EE8" }
 - [:simple-pytorch: PyTorch](https://pytorch.org/){ .cb style="--b:#EE4C2C" }
@@ -210,7 +212,7 @@ can build autonomous systems more quickly.
 
 <div class="nectar-ack__group" markdown>
 
-<p class="nectar-ack__title">Localization & sensors</p>
+<p class="nectar-ack__title">Localização e sensores</p>
 
 - [:simple-nvidia: NVIDIA Isaac ROS](https://nvidia-isaac-ros.github.io/){ .cb style="--b:#76B900" }
 - [:simple-intel: Intel RealSense](https://github.com/realsenseai/librealsense){ .cb style="--b:#0071C5" }
@@ -218,7 +220,7 @@ can build autonomous systems more quickly.
 
 </div>
 
-### Runs on
+### Roda em
 
 <div class="nectar-supported" markdown>
 

--- a/i18n/pt/modules/ai/classification.md
+++ b/i18n/pt/modules/ai/classification.md
@@ -1,0 +1,203 @@
+# Módulo de Classificação
+
+Classificação de imagens entre Ultralytics YOLO-cls e HuggingFace Transformers por meio de um
+único `Classifier` — carregue um modelo, chame `classify`, e obtenha resultados top-k tipados.
+A mesma API cobre treinamento, avaliação e ferramentas de dataset ImageFolder / HuggingFace,
+via a CLI `nectar-ai classify`.
+
+## Resumo rápido
+
+```python
+from nectar.ai.classification import Classifier
+
+classifier = Classifier("yolo26n-cls.pt")
+classifier.load()
+result = classifier.classify(image)
+print(result.top1_name, result.top1_confidence)
+for pred in result.topk(5):
+    print(pred.class_name, pred.confidence)
+```
+
+## Tutorial (Colab)
+
+Fluxo ponta a ponta de classificação (dataset → train → TensorBoard → eval → Hub):
+
+[Abrir no Google Colab](https://colab.research.google.com/drive/1mEo05wfYJRsuxKodxbFwBuxRSRh43f-X?usp=sharing)
+
+## Arquitetura
+
+```mermaid
+flowchart TB
+    subgraph API["User API"]
+        Classifier["Classifier"]
+    end
+
+    subgraph Core["Core"]
+        BCM["BaseClassificationModel"]
+        Types["Classification / ClassificationResult"]
+        Configs["ClsTrainingConfig / ClsEvaluationConfig"]
+    end
+
+    subgraph Models["Models"]
+        UM["UltralyticsClsModel"]
+        TM["TransformersClsModel"]
+    end
+
+    subgraph Eval["Evaluation"]
+        CE["ClassificationEvaluator"]
+    end
+
+    subgraph External["External"]
+        YOLO["ultralytics *-cls"]
+        HF["transformers AutoModelForImageClassification"]
+    end
+
+    Classifier -->|creates| UM
+    Classifier -->|creates| TM
+    UM --> BCM
+    TM --> BCM
+    BCM --> Types
+    CE --> BCM
+    UM --> YOLO
+    TM --> HF
+```
+
+## Classifier
+
+```python
+from nectar.ai.classification import Classifier
+from nectar.ai.core import Framework
+
+classifier = Classifier("yolo26n-cls.pt")
+classifier = Classifier("google/vit-base-patch16-224-in21k", framework=Framework.TRANSFORMERS)
+classifier.load()
+result = classifier.classify(image, topk=5)
+annotated = classifier.draw_classification(image, result)
+```
+
+Detecção automática de framework: `-cls` → Ultralytics; `vit` / `google/` / `facebook/` →
+Transformers.
+
+## Configs de exemplo
+
+Templates portáveis em `configs/` (só caminhos relativos; sem IDs de Hub específicos de
+organização):
+
+| Config | Backend | Preparo do dataset |
+|--------|---------|--------------|
+| `mnist_yolo26n_cls.yaml` | Ultralytics YOLO-cls | `dataset download --source ultralytics --dataset mnist160` |
+| `mnist_vit_example.yaml` | Transformers ViT | `dataset download --source huggingface --repo ylecun/mnist --max-samples 128` |
+| `cifar10_yolo26n_cls_example.yaml` | Ultralytics + opções de Hub | `dataset download --source ultralytics --dataset cifar10 --max-samples 200` |
+
+Copie um config e altere `dataset_path`, `model`, `epochs`, e opcionalmente habilite o upload
+para o Hub.
+
+## Treinamento
+
+**Layout ImageFolder** (formato de dataset de classificação do Ultralytics):
+
+```
+dataset/
+├── train/<class_name>/*.jpg
+├── val/<class_name>/*.jpg
+└── test/<class_name>/*.jpg
+```
+
+```python
+from nectar.ai.classification import Classifier, ClsTrainingConfig
+
+classifier = Classifier("yolo26n-cls.pt")
+classifier.load()
+result = classifier.train(ClsTrainingConfig(
+    dataset_path="data/mnist160",
+    epochs=50,
+    imgsz=64,
+    tensorboard=True,
+))
+```
+
+```bash
+
+# Ultralytics + TensorBoard
+
+nectar-ai classify train --config configs/mnist_yolo26n_cls.yaml --tensorboard
+
+# Transformers ViT
+
+nectar-ai classify train --config configs/mnist_vit_example.yaml
+
+# Enable Hub upload (requires HF_TOKEN): set in YAML or override
+
+nectar-ai classify train --config configs/cifar10_yolo26n_cls_example.yaml \
+    --push-to-hub --hub-model-id your-org/cifar10-yolo26n-cls
+```
+
+Traga seu próprio ImageFolder da mesma forma: aponte `data.dataset_path` para qualquer árvore
+`train/<class>/*.jpg` (Food-101, dados próprios, etc.).
+
+## Avaliação
+
+Produz um conjunto plano de artefatos, alinhado com detection/segmentation:
+
+- Métricas: acurácia top-1 / top-k, P/R/F1 macro e ponderado, tabela por classe
+- Curvas: `P_curve`, `R_curve`, `F1_curve`, `PR_curve`
+- Plots: `confusion_matrix`, `error_analysis`, `performance_analysis`, `results`, `prediction_samples`
+- Tabelas: `metrics_summary.json`, `evaluation_metrics.csv`, `per_class_metrics.{json,csv}`,
+  `pr_analysis_results.csv`, `error_statistics.csv`, `evaluation_report.json`,
+  `evaluation_results.json`
+
+```bash
+nectar-ai classify eval --model-path best.pt --dataset-path data/mnist160 \
+    --framework ultralytics --split test --conf-threshold 0.0 --topk 5
+```
+
+## Gerenciamento de dataset
+
+```bash
+
+# Tiny Ultralytics set (recommended for smoke tests)
+
+nectar-ai classify dataset download --source ultralytics --dataset mnist160 \
+    --output data/mnist160
+
+# CIFAR-10 cached under nectar/ai/data/ultralytics/, then a small subset
+
+nectar-ai classify dataset download --source ultralytics --dataset cifar10 \
+    --max-samples 200 --output data/cifar10-subset
+
+nectar-ai classify dataset download --source huggingface --repo ylecun/mnist \
+    --max-samples 128 --output data/mnist-hf
+
+nectar-ai classify dataset analyze --input data/mnist160
+nectar-ai classify dataset convert --input data/raw --output data/normalized
+nectar-ai classify dataset stratify --input data/unsplit --output data/split
+nectar-ai classify dataset subset --input data/full --output data/subset --max-train-samples 1000
+nectar-ai classify dataset upload --target huggingface --repo user/my-cls --dataset data/mnist160 --public
+```
+
+## CLI
+
+```
+nectar-ai classify <command> [options]
+
+Commands: train | predict | eval | dataset
+Aliases: classification, cls
+```
+
+## Frameworks suportados
+
+| Framework | Train | Eval | Predict |
+|-----------|-------|------|---------|
+| Ultralytics YOLO-cls | sim | sim | sim |
+| HuggingFace Transformers | sim | sim | sim |
+
+## Layout
+
+- `classifier.py` — facade e factory `Classifier`
+- `core/` — tipos, configs, `BaseClassificationModel`
+- `models/` — backends Ultralytics e Transformers
+- `training/` — configs de treinamento específicas de framework
+- `evaluation/` — `ClassificationEvaluator` + plots
+- `datasets/` — ferramentas ImageFolder, conversores HF, handlers
+- `cli/`, `configs/`, `scripts/`
+- Compartilhado entre tasks: `nectar.ai.core` (Framework, ModelLoader, utils)

--- a/i18n/pt/modules/ai/detection.md
+++ b/i18n/pt/modules/ai/detection.md
@@ -1,0 +1,1364 @@
+# Módulo de Detecção
+
+Detecção de objetos com Ultralytics YOLO, HuggingFace Transformers (DETR) e RF-DETR, todos
+por meio de uma única interface `Detector` — carregue um modelo, chame `detect` e obtenha
+resultados tipados. A mesma API cobre treinamento, avaliação e inferência com slicing, com
+ferramentas de dataset e uma CLI `nectar-ai`.
+
+## Visão geral
+
+```python
+from nectar.ai.detection import Detector
+
+detector = Detector("yolov8n.pt")     # framework auto-detected from the model name
+detector.load()
+result = detector.detect(image)
+for det in result:
+    print(f"{det.class_name}: {det.confidence:.2f}")
+```
+
+Lado a lado com Ultralytics / Transformers / RF-DETR:
+[Com e sem Nectar](../../get-started/with-without.md)
+([with-without.md](../../get-started/with-without/)).
+
+## Tutorial (Colab)
+
+Passo a passo interativo de ponta a ponta para detecção (dataset → treinamento → TensorBoard → avaliação):
+
+[Abrir no Colab](https://colab.research.google.com/drive/1mQmbWwnwn-nzMdBlzvkuBmYPMHUrCm_Z?usp=sharing)
+
+## Conceitos
+
+`Detector` é uma factory leve sobre três backends de framework (`UltralyticsModel`,
+`TransformersModel`, `RFDETRModel`), todos compartilhando `BaseDetectionModel` e os mesmos
+resultados tipados, slicing, pós-processamento e avaliação:
+
+```mermaid
+flowchart TB
+    subgraph API["User API"]
+        Detector["Detector"]
+    end
+
+    subgraph Core["Core"]
+        BDM["BaseDetectionModel"]
+        Types["Detection / DetectionResult<br/>DetectionInput / Prediction"]
+        Configs["TrainingConfig / EvaluationConfig<br/>TrainingMetrics / EvaluationMetrics<br/>TrainingResult"]
+        Exceptions["DetectionError<br/>ModelNotLoadedError<br/>TrainingError<br/>EvaluationError<br/>..."]
+    end
+
+    subgraph Models["Models"]
+        UM["UltralyticsModel"]
+        TM["TransformersModel"]
+        RM["RFDETRModel"]
+        ML["ModelLoader"]
+    end
+
+    subgraph Slicing["Slicing"]
+        SI["SlicingInference"]
+        SC["SlicingConfig"]
+        SS["SlicingStrategy"]
+    end
+
+    subgraph PostProcess["Post-processing"]
+        NMS["NMSStrategy"]
+        SoftNMS["SoftNMSStrategy"]
+        WBF["WBFStrategy"]
+        NMM["NMMStrategy"]
+        PCF["PerClassConfidenceFilter"]
+    end
+
+    subgraph Evaluation["Evaluation"]
+        ODE["ObjectDetectionEvaluator"]
+    end
+
+    subgraph External["External"]
+        YOLO["ultralytics"]
+        HF["transformers"]
+        RF["rfdetr"]
+        SV["supervision"]
+        HFH["huggingface_hub"]
+        TB["tensorboard"]
+    end
+
+    Detector -->|creates| UM
+    Detector -->|creates| TM
+    Detector -->|creates| RM
+
+    UM -->|extends| BDM
+    TM -->|extends| BDM
+    RM -->|extends| BDM
+
+    BDM -->|uses| Types
+    BDM -->|uses| Configs
+    BDM -->|uses| Slicing
+    BDM -->|raises| Exceptions
+
+    SI -->|uses| SC
+    SI -->|uses| SS
+    SI -->|uses| PostProcess
+
+    UM -->|wraps| YOLO
+    TM -->|wraps| HF
+    RM -->|wraps| RF
+
+    ODE -->|uses| SV
+    PostProcess -->|uses| SV
+    ML -->|uses| HFH
+    Detector -->|uses| TB
+```
+
+## Detector
+
+Detector baseado em factory, com detecção automática ou seleção explícita de framework.
+
+**Detecção automática a partir do nome do modelo**:
+
+```python
+from nectar.ai.core import Framework
+from nectar.ai.detection import Detector
+
+detector = Detector("yolov8n.pt")
+```
+
+**Framework explícito**:
+
+```python
+detector = Detector("model.pt", framework="ultralytics")
+detector = Detector("facebook/detr-resnet-50", framework=Framework.TRANSFORMERS)
+```
+
+**Modelo do HuggingFace** (`user/repo:filename`):
+
+```python
+detector = Detector("user/repo:model.pt")
+```
+
+Carregue e execute:
+
+```python
+detector.load()
+result = detector.detect(image, conf=0.5)
+results = detector.detect_batch([img1, img2, img3])
+annotated = detector.draw_detections(image, result)
+```
+
+**Propriedades**:
+
+```python
+detector.framework          # Framework.ULTRALYTICS
+detector.is_loaded          # bool
+detector.class_names        # Dict[int, str]
+Detector.available_frameworks()  # ['ultralytics', 'transformers', 'rfdetr']
+```
+
+### Enum Framework
+
+```python
+Framework.ULTRALYTICS  # YOLOv8, YOLOv10, YOLO11
+Framework.TRANSFORMERS  # DETR, Conditional DETR
+Framework.RFDETR        # RF-DETR
+```
+
+## Diagrama de Classes
+
+```mermaid
+classDiagram
+    class Framework {
+        <<enum>>
+        ULTRALYTICS
+        TRANSFORMERS
+        RFDETR
+    }
+
+    class Detector {
+        -_builders Dict~str,BuilderFunc~
+        -_model BaseDetectionModel
+        -_framework Framework
+        -_loaded bool
+        -_hf_token Optional~str~
+        -_kwargs Dict
+        +model_source str
+        +device str
+        +confidence_threshold float
+        +framework Framework
+        +is_loaded bool
+        +class_names Dict~int,str~
+        +model BaseDetectionModel
+        +register(framework, builder)$
+        +available_frameworks()$ List~str~
+        +_detect_framework(source)$ Framework
+        +_create_model(framework, model_name)$ BaseDetectionModel
+        +load(model_path) bool
+        +detect(image, conf, iou) DetectionResult
+        +detect_batch(images, conf, iou) List~DetectionResult~
+        +train(config) Dict~str,Any~
+        +evaluate(config) Dict~str,Any~
+        +draw_detections(image, result, show_labels, show_confidence, show_class, annotator_type, thickness, text_scale) ndarray
+        +enable_slicing(config)
+        +disable_slicing()
+    }
+
+    class BaseDetectionModel {
+        <<abstract>>
+        +model_name str
+        +framework str
+        +model Any
+        +class_names Dict~int,str~
+        +slicing_config Optional~SlicingConfig~
+        -_slicing_inference Optional~SlicingInference~
+        -logger Logger
+        +is_loaded bool
+        +load_model(path)*
+        +_predict_single(input)* Prediction
+        +_predict_batch(input) Prediction
+        +predict(input) Prediction
+        +_predict_with_slicing(input) Prediction
+        +detect(image, conf, iou) DetectionResult
+        +detect_batch(images, conf, iou) List~DetectionResult~
+        +train(config)* TrainingResult
+        +save(path)* str
+        +evaluate(config) EvaluationMetrics
+        +draw_detections(image, result, show_labels, show_confidence, show_class, annotator_type, thickness, text_scale) ndarray
+        +enable_slicing(config)
+        +disable_slicing()
+    }
+
+    class UltralyticsModel {
+        -model Optional~YOLO~
+        -_callbacks List
+        +from_scratch bool
+        +load_model(path)
+        +_download_from_huggingface(path) str
+        +train(config) TrainingResult
+        +save(path) str
+    }
+
+    class TransformersModel {
+        -model Optional~AutoModelForObjectDetection~
+        -processor Optional~AutoImageProcessor~
+        +from_scratch bool
+        +load_model(path, id2label, label2id, imgsz)
+        +train(config) TrainingResult
+        +save(path) str
+    }
+
+    class RFDETRModel {
+        -model Optional
+        -model_class Type
+        -base_model_name str
+        -model_path Optional~str~
+        +rfdetr_size Optional~str~
+        +resolution Optional~int~
+        +from_scratch bool
+        +load_model(path)
+        +_infer_model_size(path) str
+        +train(config) TrainingResult
+    }
+
+    class Detection {
+        <<dataclass>>
+        +xyxy ndarray
+        +confidence float
+        +class_id int
+        +class_name str
+        +center Tuple~float,float~
+        +width int
+        +height int
+        +area int
+        +bbox List~int~
+        +to_dict() Dict
+        +from_dict(data)$ Detection
+    }
+
+    class DetectionResult {
+        <<dataclass>>
+        +detections List~Detection~
+        +image Optional~ndarray~
+        +inference_time float
+        +image_path Optional~str~
+        +model_name Optional~str~
+        +__len__() int
+        +__getitem__(idx) Detection
+        +__iter__() Iterator
+        +__bool__() bool
+        +filter_by_confidence(threshold) DetectionResult
+        +filter_by_class(class_names) DetectionResult
+        +filter_by_class_id(class_ids) DetectionResult
+        +to_supervision() sv.Detections
+        +from_supervision(detections, class_names)$ DetectionResult
+        +to_dict() Dict
+    }
+
+    class TrainingConfig {
+        <<dataclass>>
+        +dataset_path str
+        +epochs int
+        +batch_size int
+        +learning_rate float
+        +output_dir str
+        +device str
+        +seed int
+        +tensorboard bool
+        +save_period int
+        +push_to_hub bool
+        +hub_model_id Optional~str~
+        +multi_gpu bool
+        +mixed_precision str
+        +gradient_accumulation_steps int
+        +max_train_samples Optional~int~
+        +max_eval_samples Optional~int~
+        +max_test_samples Optional~int~
+        +train_split float
+        +val_split float
+        +test_split float
+        +dataset_format Optional~str~
+        +framework str
+        +model str
+        +from_scratch bool
+        +imgsz Optional~Union~int,List~int~~
+        +early_stopping_patience Optional~int~
+        +early_stopping_delta float
+        +early_stopping_metric str
+        +early_stopping_mode str
+        +weight_decay float
+        +lr_scheduler_type str
+        +warmup_steps int
+        +warmup_ratio float
+        +max_grad_norm float
+        +optimizer_type str
+        +dropout float
+        +warmup_epochs float
+        +warmup_momentum float
+        +lrf float
+        +freeze Optional~Union~int,List~int~~
+        +cos_lr bool
+        +rfdetr_size Optional~str~
+        +lr_encoder Optional~float~
+        +use_ema bool
+        +gradient_checkpointing bool
+        +drop_path float
+        +ema_decay float
+        +sync_bn bool
+        +num_workers int
+        +gc_per_accumulation bool
+        +evaluate bool
+        +resume bool
+        +to_dict() Dict
+        +to_yaml(path)
+        +from_dict(data)$ TrainingConfig
+        +from_yaml(path)$ TrainingConfig
+    }
+
+    class EvaluationConfig {
+        <<dataclass>>
+        +model_path str
+        +dataset_path str
+        +framework str
+        +output_dir str
+        +dataset_type str
+        +split str
+        +conf_threshold float
+        +iou_threshold float
+        +device str
+        +batch_size int
+        +num_samples Optional~int~
+        +to_dict() Dict
+        +from_dict(data)$ EvaluationConfig
+        +from_yaml(path)$ EvaluationConfig
+    }
+
+    class TrainingMetrics {
+        <<dataclass>>
+        +epoch int
+        +train_loss float
+        +val_loss Optional~float~
+        +map50 Optional~float~
+        +map50_95 Optional~float~
+        +precision Optional~float~
+        +recall Optional~float~
+        +f1_score Optional~float~
+        +learning_rate Optional~float~
+        +to_dict() Dict
+    }
+
+    class EvaluationMetrics {
+        <<dataclass>>
+        +map50 float
+        +map50_95 float
+        +mar50 float
+        +mar50_95 float
+        +precision float
+        +recall float
+        +f1_score float
+        +inference_time_per_image float
+        +total_detections int
+        +per_class_metrics List~Dict~
+        +visualizations Dict~str,str~
+        +to_dict() Dict
+        +save_json(path)
+    }
+
+    class TrainingResult {
+        <<dataclass>>
+        +model_path str
+        +metrics TrainingMetrics
+        +config TrainingConfig
+    }
+
+    class DetectionInput {
+        <<dataclass>>
+        +image Union~ImageType,BatchImageType~
+        +conf_threshold float
+        +iou_threshold float
+        +device Optional~str~
+        +is_batch bool
+        +to_dict() Dict
+    }
+
+    class Prediction {
+        <<dataclass>>
+        +detections Optional~sv.Detections~
+        +batch_detections Optional~List~sv.Detections~~
+        +results Optional~List~DetectionResult~~
+        +inference_time float
+        +image_path Optional~Union~str,List~str~~
+        +model_name Optional~str~
+        +is_batch bool
+        +num_detections int
+        +to_dict() Dict
+        +from_detections(detections, class_names)$ Prediction
+        +from_batch_detections(batch_detections, class_names)$ Prediction
+    }
+
+    class SlicingConfig {
+        <<dataclass>>
+        +strategy SlicingStrategy
+        +slice_size Tuple~int,int~
+        +overlap_ratio float
+        +iou_threshold float
+        +conf_threshold float
+        +min_slice_area_ratio float
+        +max_slices int
+        +adaptive_threshold float
+        +clustering_eps float
+        +clustering_min_samples int
+        +merge_strategy str
+        +include_full_image bool
+        +from_dict(config_dict)$ SlicingConfig
+        +to_dict() Dict
+        +grid(slice_size, overlap_ratio)$ SlicingConfig
+        +adaptive(slice_size, threshold)$ SlicingConfig
+    }
+
+    class SlicingStrategy {
+        <<enumeration>>
+        NONE
+        GRID
+        ADAPTIVE
+        CLUSTERING
+        SUPERVISION
+    }
+
+    class SlicingInference {
+        -config SlicingConfig
+        -slicer ImageSlicer
+        -_merge_strategy BaseMergingStrategy
+        +run_sliced_inference(image, inference_callback, initial_detections) sv.Detections
+        -_create_merge_strategy(strategy_name) BaseMergingStrategy
+    }
+
+    class ObjectDetectionEvaluator {
+        -model Any
+        -config EvaluationConfig
+        -output_dir Path
+        -device str
+        -logger Logger
+        +evaluate() EvaluationMetrics
+    }
+
+    Detector --> Framework
+    Detector --> BaseDetectionModel
+    Detector ..> UltralyticsModel : creates
+    Detector ..> TransformersModel : creates
+    Detector ..> RFDETRModel : creates
+
+    BaseDetectionModel <|-- UltralyticsModel
+    BaseDetectionModel <|-- TransformersModel
+    BaseDetectionModel <|-- RFDETRModel
+
+    BaseDetectionModel --> Detection
+    BaseDetectionModel --> DetectionResult
+    BaseDetectionModel --> DetectionInput
+    BaseDetectionModel --> Prediction
+    BaseDetectionModel --> TrainingConfig
+    BaseDetectionModel --> EvaluationConfig
+    BaseDetectionModel --> SlicingConfig
+    BaseDetectionModel ..> SlicingInference : uses
+
+    DetectionResult o-- Detection
+    DetectionResult --> DetectionInput
+    Prediction o-- DetectionResult
+    Prediction --> DetectionInput
+
+    SlicingInference o-- SlicingConfig
+    SlicingInference --> SlicingStrategy
+    SlicingInference --> BaseMergingStrategy
+
+    ObjectDetectionEvaluator --> EvaluationConfig
+    ObjectDetectionEvaluator --> EvaluationMetrics
+```
+
+## Classes de Modelo Diretas
+
+Para controle avançado:
+
+```python
+from nectar.ai.detection import UltralyticsModel, TransformersModel, RFDETRModel
+
+model = UltralyticsModel("yolov8n.pt")
+model.load_model()
+
+model = TransformersModel("facebook/detr-resnet-50")
+model.load_model()
+
+model = RFDETRModel("rfdetr-medium")
+model.load_model()
+```
+
+## Tipos Principais
+
+### `Detection`
+
+```python
+from nectar.ai.detection import Detection
+
+det = Detection(
+    xyxy=np.array([100, 100, 200, 200]),  # [x1, y1, x2, y2]
+    confidence=0.95,
+    class_id=0,
+    class_name="person",
+)
+
+det.center    # (150, 150)
+det.width     # 100
+det.height    # 100
+det.area      # 10000
+```
+
+### `DetectionResult`
+
+```python
+result = detector.detect(image)
+
+len(result)              # Number of detections
+result.detections        # List[Detection]
+result.inference_time    # Seconds
+
+for det in result:
+    print(det.class_name, det.confidence)
+
+filtered = result.filter_by_confidence(0.5)
+filtered = result.filter_by_class_id([0, 1, 2])          # by class id; filter_by_class([...]) takes class names
+```
+
+## Treinamento
+
+```python
+from nectar.ai.detection import Detector, TrainingConfig
+
+detector = Detector("yolov8n.pt")
+detector.load()
+
+config = TrainingConfig(
+    dataset_path="/path/to/dataset",
+    epochs=100,
+    batch_size=16,
+    learning_rate=0.001,
+    output_dir="outputs/",
+    tensorboard=True,  # enable TensorBoard logging
+    push_to_hub=True,
+    hub_model_id="user/model-name",
+)
+
+result = detector.train(config)
+
+# Training outputs and evaluation results automatically uploaded to HF Hub
+
+print(f"Model saved: {result['model_path']}")
+```
+
+### Fluxo de Treinamento
+
+O treinamento cuida automaticamente de:
+
+- Ciclo de vida do servidor do TensorBoard (start/stop)
+- Uploads para o HuggingFace Hub (checkpoints durante o treinamento, saídas finais, resultados de avaliação)
+- Conversão de formato de dataset (YOLO ↔ COCO)
+- Criação de subconjunto balanceado
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Detector
+    participant Model as BaseDetectionModel
+    participant Framework as External Framework
+    participant HF as HuggingFaceUploader
+    participant TB as TensorBoardManager
+
+    User->>TB: start_server() (nectar-ai train CLI, if tensorboard)
+    User->>Detector: train(TrainingConfig)
+    Detector->>Model: train(config)
+    Model->>Framework: train(**args)
+
+    loop Each epoch
+        Framework-->>Model: Epoch complete
+        opt Push to Hub
+            Model->>HF: upload_file(checkpoint)
+        end
+    end
+
+    Framework-->>Model: Training complete
+    Model-->>Detector: {"model_path", "metrics"}
+    Detector->>HF: upload(training outputs)
+    opt Evaluate
+        Detector->>Model: evaluate()
+        Model-->>Detector: metrics
+        Detector->>HF: upload(evaluation results)
+    end
+    Detector->>TB: stop_server()
+    Detector-->>User: Result dict
+```
+
+### Configs Específicas de Framework
+
+Subclasses específicas de framework estendem o `TrainingConfig` base (lista completa de
+campos no [diagrama de classes acima](#diagrama-de-classes)):
+
+```mermaid
+classDiagram
+    class TrainingConfig {
+        <<dataclass>>
+        shared fields — see Class Diagram above
+    }
+
+    class UltralyticsTrainingConfig {
+        <<dataclass>>
+        +model str
+        +framework str
+        +augment bool
+        +mosaic float
+        +mixup float
+        +hsv_h float
+        +hsv_s float
+        +hsv_v float
+        +degrees float
+        +translate float
+        +scale float
+        +shear float
+        +flipud float
+        +fliplr float
+        +close_mosaic int
+        +nbs int
+        +overlap_mask bool
+        +mask_ratio int
+        +to_ultralytics_args() Dict~str,Any~
+    }
+
+    class TransformersTrainingConfig {
+        <<dataclass>>
+        +model str
+        +framework str
+        +dataloader_num_workers int
+        +load_best_model_at_end bool
+        +metric_for_best_model str
+        +greater_is_better bool
+        +remove_unused_columns bool
+        +eval_do_concat_batches bool
+        +dataloader_pin_memory bool
+        +hub_strategy str
+        +hub_private_repo bool
+        +to_training_args() Dict~str,Any~
+    }
+
+    class RFDETRTrainingConfig {
+        <<dataclass>>
+        +model str
+        +framework str
+        +rfdetr_size Optional~str~
+        +resolution Optional~int~
+        +use_ema bool
+        +gradient_checkpointing bool
+        +lr_encoder Optional~float~
+        +ema_decay float
+        +ema_tau float
+        +lr_vit_layer_decay float
+        +sync_bn bool
+        +set_cost_class float
+        +set_cost_bbox float
+        +set_cost_giou float
+        +to_rfdetr_args() Dict~str,Any~
+    }
+
+    TrainingConfig <|-- UltralyticsTrainingConfig
+    TrainingConfig <|-- TransformersTrainingConfig
+    TrainingConfig <|-- RFDETRTrainingConfig
+```
+
+## Avaliação
+
+```python
+from nectar.ai.detection import Detector, EvaluationConfig
+from nectar.ai.detection.evaluation import ObjectDetectionEvaluator
+
+detector = Detector("best.pt")
+detector.load()
+
+config = EvaluationConfig(
+    model_path="best.pt",
+    dataset_path="/path/to/dataset",
+    framework="ultralytics",
+    split="test",
+    conf_threshold=0.25,
+)
+
+evaluator = ObjectDetectionEvaluator(detector.model, config)
+
+# Optional: add a per-class confidence filter (set_post_processor takes filter_strategy only)
+
+from nectar.ai.detection.postprocess import PerClassConfidenceFilter
+
+evaluator.set_post_processor(
+    filter_strategy=PerClassConfidenceFilter(csv_path="pr_analysis_results.csv"),
+)
+
+metrics = evaluator.evaluate()
+
+print(f"mAP@50: {metrics.map50:.4f}")
+print(f"mAP@50-95: {metrics.map50_95:.4f}")
+```
+
+## Inferência com Slicing
+
+Para imagens de alta resolução:
+
+```python
+detector = Detector("yolov8n.pt")
+detector.load()
+
+detector.enable_slicing({
+    "strategy": "grid",
+    "slice_size": (640, 640),
+    "overlap_ratio": 0.2,
+    "merge_strategy": "nms",  # nms, soft_nms, wbf, nmm
+})
+
+result = detector.detect(large_image)
+detector.disable_slicing()
+```
+
+### Estratégias de Pós-processamento
+
+```mermaid
+classDiagram
+    class BaseMergingStrategy {
+        <<abstract>>
+        +iou_threshold float
+        +name str
+        +merge_boxes(detections)* Tuple
+        +_compute_iou_pair(box1, box2)$ float
+        +_compute_iou_batch(box, boxes)$ ndarray
+    }
+
+    class NMSStrategy {
+        +class_agnostic bool
+        +merge_boxes(detections) Tuple
+    }
+
+    class SoftNMSStrategy {
+        +sigma float
+        +score_threshold float
+        +merge_boxes(detections) Tuple
+    }
+
+    class WBFStrategy {
+        +skip_box_threshold float
+        +conf_type str
+        +merge_boxes(detections) Tuple
+    }
+
+    class NMMStrategy {
+        +merge_boxes(detections) Tuple
+    }
+
+    class PerClassConfidenceFilter {
+        +threshold_mapping Dict
+        +default_threshold float
+        +filter(detections) sv.Detections
+    }
+
+    BaseMergingStrategy <|-- NMSStrategy
+    BaseMergingStrategy <|-- SoftNMSStrategy
+    BaseMergingStrategy <|-- WBFStrategy
+    BaseMergingStrategy <|-- NMMStrategy
+```
+
+### Filtragem de Confiança por Classe
+
+Carregue thresholds ótimos a partir de resultados de análise de PR:
+
+**A partir de um CSV de análise de PR**:
+
+```python
+from nectar.ai.detection.postprocess import PerClassConfidenceFilter
+
+filter = PerClassConfidenceFilter(csv_path="evaluation/pr_analysis_results.csv")
+```
+
+**Mapeamento manual**:
+
+```python
+filter = PerClassConfidenceFilter(threshold_mapping={0: 0.3, 1: 0.5}, default_threshold=0.25)
+```
+
+```python
+filtered = filter.filter(detections)
+```
+
+## Utilitários
+
+Os helpers compartilhados vivem em `nectar.ai.core` (usado por detection, segmentation e classification).
+
+### Gerenciamento do TensorBoard
+
+```python
+from nectar.ai.core import TensorBoardManager
+
+manager = TensorBoardManager()
+manager.start_server(log_dir="outputs", port=6006)
+
+# ... training ...
+
+manager.stop_server()
+```
+
+### Upload para o HuggingFace Hub
+
+```python
+from nectar.ai.core import HuggingFaceUploader
+
+uploader = HuggingFaceUploader(
+    repo_id="user/model-name",
+    local_dir="outputs/",
+    repo_type="model",
+)
+uploader.upload(commit_message="Upload training results")
+```
+
+O treinamento faz upload automático das saídas e dos resultados de avaliação para o HuggingFace Hub quando `push_to_hub=True` e `hub_model_id` está definido.
+
+## Extensão
+
+### Adicionando um Framework
+
+```python
+from nectar.ai.detection import Detector
+from nectar.ai.detection.core.base import BaseDetectionModel
+
+class CustomModel(BaseDetectionModel):
+    def load_model(self, path):
+        pass
+
+    def _predict_single(self, input):
+        pass
+
+    def train(self, config):
+        pass
+
+    def save(self, path):
+        pass
+
+Detector.register("custom", lambda name, **kw: CustomModel(name, **kw))
+detector = Detector("model.pt", framework="custom")
+```
+
+## CLI
+
+O módulo de detecção é operado por meio da CLI unificada `nectar-ai`, sob a tarefa `detect`
+(`detect`, `detection` e `od` são aliases):
+
+**Treinamento**:
+
+```bash
+nectar-ai detect train --config configs/yolo_example.yaml
+```
+
+**Predição**:
+
+```bash
+nectar-ai detect predict --model yolov8n.pt --input image.jpg --output results/
+```
+
+**Avaliação**:
+
+```bash
+nectar-ai detect eval --model-path best.pt --framework ultralytics --dataset-path /path/to/dataset
+```
+
+**Gerenciamento de datasets**:
+
+```bash
+nectar-ai detect dataset download --source visdrone --output datasets/visdrone
+nectar-ai detect dataset convert --input datasets/coco --output datasets/yolo --format yolo
+nectar-ai detect dataset stratify --input datasets/unsplit --output datasets/split --train-ratio 0.8
+nectar-ai detect dataset subset --input datasets/full --output datasets/subset --max-train-samples 1000
+nectar-ai detect dataset augment --input datasets/my_dataset --output datasets/my_dataset_augmented --preset aerial --num-augmented 2 --splits train --num-workers 8
+nectar-ai detect dataset analyze --input datasets/my_dataset
+nectar-ai detect dataset merge --dataset1 datasets/d1 --dataset2 datasets/d2 --output datasets/merged --train-config '{"d1": 1000, "d2": 5000}' --output-format coco
+nectar-ai detect dataset upload --target huggingface --repo user/my-dataset --dataset datasets/my_dataset --title "My Dataset" --model-repo user/my-model
+nectar-ai detect dataset upload --target huggingface --raw --repo user/my-dataset --dataset datasets/my_dataset
+nectar-ai detect dataset upload --target roboflow --api-key KEY --project my-project --dataset datasets/my_dataset --splits train valid test
+nectar-ai detect dataset upload --target roboflow --images-only --api-key KEY --project my-project --dataset images/
+nectar-ai detect dataset upload-images --api-key KEY --project my-project --directory images/
+nectar-ai detect dataset download --source huggingface --repo user/my-dataset --format yolo --output data/local
+```
+
+### Treinamento
+
+**Usando um arquivo de config** (recomendado):
+
+```bash
+nectar-ai detect train --config configs/yolo_example.yaml
+```
+
+**Usando argumentos de CLI**:
+
+```bash
+nectar-ai detect train --model yolov8n.pt --dataset /path/to/dataset --epochs 100 --batch-size 16
+```
+
+### Avaliação
+
+```bash
+nectar-ai detect eval --model-path best.pt --framework ultralytics --dataset-path /path/to/dataset
+```
+
+**Com thresholds de confiança por classe** (pares nome=valor; resolvidos contra os nomes de classe do modelo):
+
+```bash
+nectar-ai detect eval --model-path best.pt --framework ultralytics --dataset-path /path/to/dataset \
+    --conf-per-class 'crack=0.4,pothole=0.55'
+```
+
+## Gerenciamento de Datasets
+
+Utilitários para preparar datasets de detecção, cada um disponível como uma classe Python e
+como um subcomando `nectar-ai detect dataset <command>`:
+
+| Tarefa | API Python | CLI |
+|------|-----------|-----|
+| Detectar / converter formato (COCO ↔ YOLO) | `FormatDetector`, `FormatConverter` | `convert` |
+| Subconjunto balanceado | `SubsetCreator` | `subset` |
+| Divisão treino/val/teste | `Stratifier` | `stratify` |
+| Augmentation | `AugmentationBuilder` | `augment` |
+| Análise e estatísticas | `DatasetAnalyzer` | `analyze` |
+| Download por fonte (VisDrone, Roboflow) | `DatasetHandlerRegistry` | `download` |
+| Mesclar datasets | `DatasetMerger` | `merge` |
+| Upload (HuggingFace / Roboflow) | `HuggingFaceDatasetUploader`, `RoboflowUploader` | `upload` |
+
+### Detecção e Conversão de Formato
+
+Os datasets são detectados e convertidos automaticamente entre os formatos COCO e YOLO, conforme necessário:
+
+```python
+from nectar.ai.detection.datasets import FormatDetector, FormatConverter
+
+# Auto-detect format
+
+detector = FormatDetector("datasets/my_dataset")
+format_type = detector.detect()  # "coco" or "yolo"
+
+# Convert format
+
+converter = FormatConverter("datasets/coco", "datasets/yolo")
+yaml_path = converter.convert(target_format="yolo")
+```
+
+### Criação de Subconjunto Balanceado
+
+Cria subconjuntos balanceados mantendo a distribuição de classes:
+
+```python
+from nectar.ai.detection.datasets import SubsetCreator
+
+creator = SubsetCreator("datasets/full", "datasets/subset", seed=42)
+subset_path = creator.create(
+    max_train_samples=1000,
+    max_eval_samples=200,
+    max_test_samples=100,
+)
+```
+
+### Estratificação de Dataset
+
+Divide datasets não separados em treino/val/teste com distribuição de classes balanceada:
+
+```python
+from nectar.ai.detection.datasets import Stratifier
+
+stratifier = Stratifier("datasets/unsplit", "datasets/split", seed=42)
+split_path = stratifier.stratify(
+    train_ratio=0.8,
+    val_ratio=0.2,
+    test_ratio=0.0,
+)
+```
+
+### Augmentation
+
+Monta configs de augmentation e as aplica aos datasets com processamento paralelo:
+
+**Usando um preset**:
+
+```python
+from nectar.ai.detection.datasets import AugmentationBuilder
+
+builder = AugmentationBuilder(preset="aerial")
+builder.apply(
+    input_path="datasets/my_dataset",
+    output_path="datasets/my_dataset_augmented",
+    num_augmented=2,
+    splits=["train"],
+    num_workers=8,
+)
+```
+
+**Transformações personalizadas**:
+
+```python
+builder = AugmentationBuilder(config={
+    "HorizontalFlip": {"p": 0.5},
+    "Rotate": {"limit": 15, "p": 0.3},
+})
+builder.apply("datasets/input", "datasets/output", num_augmented=3)
+```
+
+**Comportamento da augmentation:**
+
+- `num_augmented`: número de cópias aumentadas geradas por imagem original.
+  - Exemplo: 1000 imagens originais + `num_augmented=2` → 1000 originais + 2000 aumentadas = 3000 no total
+
+- `max_original_samples`: limita quantas imagens originais são selecionadas para a augmentation (não o total gerado).
+  - Exemplo: 1000 imagens originais + `max_original_samples=500` + `num_augmented=2`:
+    - Todas as 1000 imagens originais são mantidas na saída
+    - 500 imagens originais são aumentadas (cada uma produz 2 cópias)
+    - Total: 1000 originais + 1000 aumentadas = 2000 imagens
+
+- `augmentation_ratio`: adiciona dados aumentados como fração do tamanho do treino.
+  - Exemplo: `augmentation_ratio=0.25` com 1000 imagens → adiciona ~250 imagens aumentadas (25% do original)
+  - Calcula `max_original_samples` automaticamente com base na proporção
+
+- `prioritize_rare_classes`: ao usar `max_original_samples`, prioriza imagens contendo categorias sub-representadas para balancear o dataset.
+
+**Uso via CLI:**
+
+**Augmentation básica** (2 cópias por imagem):
+
+```bash
+nectar-ai detect dataset augment \
+  --input datasets/visdrone \
+  --output datasets/visdrone-augmented \
+  --preset aerial \
+  --num-augmented 2 \
+  --splits train \
+  --num-workers 8
+```
+
+**Limitar a 1000 imagens originais**:
+
+```bash
+nectar-ai detect dataset augment \
+  --input datasets/visdrone \
+  --output datasets/visdrone-augmented \
+  --preset aerial \
+  --num-augmented 2 \
+  --max-original-samples 1000
+```
+
+**Adicionar 25% de dados extras via augmentation ratio**:
+
+```bash
+nectar-ai detect dataset augment \
+  --input datasets/visdrone \
+  --output datasets/visdrone-augmented \
+  --preset aerial \
+  --num-augmented 2 \
+  --augmentation-ratio 0.25
+```
+
+**Priorizar classes raras ao limitar amostras**:
+
+```bash
+nectar-ai detect dataset augment \
+  --input datasets/visdrone \
+  --output datasets/visdrone-augmented \
+  --preset aerial \
+  --num-augmented 2 \
+  --max-original-samples 1000 \
+  --prioritize-rare-classes
+```
+
+### Análise de Dataset
+
+Analisa a distribuição do dataset e gera visualizações:
+
+```python
+from nectar.ai.detection.datasets import DatasetAnalyzer
+
+analyzer = DatasetAnalyzer("datasets/my_dataset", output_dir="analysis/")
+results = analyzer.analyze()
+
+# Generates plots and statistics report
+
+```
+
+### Handlers de Dataset
+
+Faz o download de datasets de várias fontes usando o registro de handlers:
+
+```python
+from nectar.ai.detection.datasets import DatasetHandlerRegistry
+
+# VisDrone
+
+handler_class = DatasetHandlerRegistry.get("visdrone")
+handler = handler_class("datasets/visdrone")
+handler.download_and_convert(output_format="coco")
+
+# Roboflow
+
+handler_class = DatasetHandlerRegistry.get("roboflow")
+handler = handler_class("datasets/roboflow", api_key="YOUR_KEY")
+handler.download(workspace="workspace", project="project", version=1, format_type="yolo")
+```
+
+### Mesclagem de Datasets
+
+Mescla dois datasets (formato YOLO ou COCO) com amostragem balanceada:
+
+```python
+from nectar.ai.detection.datasets import DatasetMerger
+
+# Auto-detect formats and merge (output format matches first dataset)
+
+merger = DatasetMerger("datasets/dataset1", "datasets/dataset2", "datasets/merged", seed=42)
+merger.merge({
+    "train": {"d1": 1000, "d2": 5000},
+    "valid": {"d1": "all", "d2": 500},
+    "test": {"d1": 200, "d2": 200}
+})
+
+# Specify output format explicitly
+
+merger = DatasetMerger(
+    "datasets/dataset1",
+    "datasets/dataset2",
+    "datasets/merged",
+    output_format="coco",  # or "yolo", "auto"
+    seed=42
+)
+```
+
+### Upload de Dataset
+
+Faz upload de datasets para o HuggingFace Hub ou Roboflow com imagens **e** anotações.
+
+#### HuggingFace: Parquet nativo (recomendado)
+
+`upload_native()` converte um dataset local COCO/YOLO para o schema nativo do Hub
+(coluna `image` + `objects.{bbox, category, area}` com `ClassLabel`). O viewer de dataset
+do Hub renderiza os overlays de bounding box automaticamente.
+
+```python
+from nectar.ai.detection.datasets import HuggingFaceDatasetUploader
+
+uploader = HuggingFaceDatasetUploader(repo_id="user/my-dataset", private=False)
+
+result = uploader.upload_native(
+    dataset_path="datasets/my_dataset",   # COCO or YOLO, auto-detected
+    commit_message="Upload v1.0",
+    card_metadata={
+        "title": "My Dataset",
+        "description": "Aerial gate detection.",
+        "license": "apache-2.0",
+        "tags": ["drone", "uav"],
+        "model_repo": "user/my-model",     # optional, links the trained model
+    },
+)
+print(result["splits"], result["class_names"])
+
+# Legacy raw-files upload (no viewer):
+
+uploader.upload_dataset(dataset_path="datasets/my_dataset")
+```
+
+#### Roboflow: dataset (imagens + anotações)
+
+`upload_dataset()` detecta automaticamente o formato COCO/YOLO, pareia cada imagem com sua
+anotação, preserva a divisão train/valid/test e faz o upload em paralelo.
+
+```python
+from nectar.ai.detection.datasets import RoboflowUploader
+
+uploader = RoboflowUploader(api_key="YOUR_KEY")
+
+stats = uploader.upload_dataset(
+    dataset_path="datasets/my_dataset",
+    project_name="my-project",
+    annotation_format=None,   # auto-detect ("coco" or "yolo")
+    splits=["train", "valid", "test"],
+    batch_name="batch-1",
+    tag_names=["robotics"],
+    max_workers=10,
+)
+print(stats["per_split"], stats["failed_files"])
+
+# Legacy: upload images only (no annotations) for an annotation workflow.
+
+uploader.upload_directory(directory_path="images/", project_name="my-project")
+```
+
+#### CLI
+
+**Upload nativo para o HuggingFace** (Parquet + viewer):
+
+```bash
+nectar-ai detect dataset upload --target huggingface \
+    --repo user/my-dataset --dataset datasets/my_dataset \
+    --public --title "My Dataset" --model-repo user/my-model
+```
+
+**Fallback de arquivos brutos (raw) para o HuggingFace**:
+
+```bash
+nectar-ai detect dataset upload --target huggingface --raw \
+    --repo user/my-dataset --dataset datasets/my_dataset
+```
+
+**Dataset do Roboflow** (imagens + anotações, padrão):
+
+```bash
+nectar-ai detect dataset upload --target roboflow --api-key KEY \
+    --project my-project --dataset datasets/my_dataset \
+    --splits train valid test
+```
+
+**Somente imagens no Roboflow** (legado):
+
+```bash
+nectar-ai detect dataset upload --target roboflow --images-only \
+    --api-key KEY --project my-project --dataset images/
+```
+
+### Download de Dataset
+
+O handler `huggingface` (alias `hf`) baixa um dataset do HF e o materializa em disco no
+formato COCO ou YOLO, pronto para treinamento.
+
+```python
+from nectar.ai.detection.datasets import HuggingFaceHandler
+
+handler = HuggingFaceHandler("data/imav-gate", token=None)  # uses HF_TOKEN
+handler.download(
+    repo_id="blackbeedrones/imav-2025-gate-dataset",
+    format_type="yolo",   # or "coco"
+)
+
+# data/imav-gate now has data.yaml + train/images + train/labels (YOLO)
+
+# or train/_annotations.coco.json + image files (COCO)
+
+```
+
+CLI:
+
+```bash
+nectar-ai detect dataset download --source huggingface \
+    --repo blackbeedrones/imav-2025-gate-dataset \
+    --format yolo --output data/imav-gate
+
+nectar-ai detect dataset download --source roboflow \
+    --workspace WS --project P --version 1 --format coco \
+    --api-key KEY --output data/roboflow
+```
+
+### Conversores de formato HF
+
+Conversores de baixo nível usados tanto pelo upload quanto pelo download:
+
+```python
+from nectar.ai.detection.datasets import (
+    coco_to_hf, yolo_to_hf, hf_to_coco, hf_to_yolo, generate_dataset_card,
+)
+
+ds = coco_to_hf("datasets/my_dataset")          # COCO -> DatasetDict
+ds = yolo_to_hf("datasets/my_dataset")          # YOLO -> DatasetDict
+hf_to_coco(ds, "out/coco")                      # DatasetDict -> COCO files
+hf_to_yolo(ds, "out/yolo")                      # DatasetDict -> YOLO files + data.yaml
+card = generate_dataset_card(ds, "user/repo", title="My Dataset")
+```
+
+## Arquivos de Configuração
+
+Arquivos de config YAML para treinamento:
+
+```yaml
+data:
+  dataset_path: /path/to/dataset
+  dataset_format: coco
+
+train:
+  framework: transformers
+  model: facebook/detr-resnet-50
+  epochs: 50
+  batch_size: 4
+  learning_rate: 5e-5
+  output_dir: outputs/detr
+  device: cuda
+  tensorboard: true
+  push_to_hub: true
+  hub_model_id: user/model-name
+  mixed_precision: fp16
+  max_train_samples: 1000
+  max_eval_samples: 200
+
+eval:
+  evaluate: true
+  eval_split: test
+  conf_threshold: 0.25
+  iou_threshold: 0.5
+  batch_size: 2
+  device: auto
+  num_samples: 100
+```
+
+Uso:
+
+```bash
+nectar-ai detect train --config configs/detr_example.yaml
+```
+
+## Estrutura
+
+O pacote `detection/` está organizado em:
+
+- [`detector.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/ai/detection/detector.py) — a fachada e a factory do `Detector`
+- [`core/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/core) — `BaseDetectionModel`, tipos de detecção, `TrainingConfig`/`EvaluationConfig`, exceções
+- [`models/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/models) — backends de framework (`UltralyticsModel`, `TransformersModel`, `RFDETRModel`) e dataset loaders
+- [`training/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/training) — configs de treinamento específicas de framework
+- [`evaluation/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/evaluation) — `ObjectDetectionEvaluator`, análise de PR/erro, plots
+- [`slicing/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/slicing) — `SlicingConfig` e `SlicingInference` para tiling em alta resolução
+- [`postprocess/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/postprocess) — estratégias de merge (NMS, Soft-NMS, WBF, NMM) e filtragem de confiança por classe
+- [`datasets/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/datasets) — conversão de formato, subset/stratify/augment/analyze/merge, e handlers de download (VisDrone, Roboflow, HuggingFace)
+- [`cli/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/cli), [`configs/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/configs), [`scripts/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/ai/detection/scripts) — a CLI `nectar-ai`, configs de exemplo e scripts shell de treinamento
+
+Compartilhado entre as tarefas (`nectar.ai.core`): `Framework`, `ModelLoader`, callbacks de device / Hub / TensorBoard / treinamento.

--- a/i18n/pt/modules/ai/index.md
+++ b/i18n/pt/modules/ai/index.md
@@ -1,0 +1,261 @@
+# Módulo de AI
+
+Inferência, treinamento e avaliação de deep learning para robótica aérea.
+
+## Tutoriais (Colab)
+
+| Tarefa | Link |
+|------|------|
+| Detection | [Abrir no Colab](https://colab.research.google.com/drive/1mQmbWwnwn-nzMdBlzvkuBmYPMHUrCm_Z?usp=sharing) |
+| Classification | [Abrir no Colab](https://colab.research.google.com/drive/1mEo05wfYJRsuxKodxbFwBuxRSRh43f-X?usp=sharing) |
+| Segmentation | [Abrir no Colab](https://colab.research.google.com/drive/1qZzAF_iD2sZyuWPin48XpxaY6dtak_gV?usp=sharing) |
+
+## Estrutura
+
+```
+ai/
+├── paths.py            # Shared DEFAULT_DATA_DIR / DEFAULT_OUTPUT_DIR
+├── cli/                # Unified CLI entry point (nectar-ai)
+├── core/               # Shared Framework, ModelLoader, device/Hub/TB/callbacks
+├── detection/          # Object detection (see detection/README.md)
+├── segmentation/       # Image segmentation (see segmentation/README.md)
+├── classification/     # Image classification (see classification/README.md)
+├── data/               # Shared datasets (gitignored)
+└── outputs/            # Shared training outputs (gitignored)
+```
+
+## Arquitetura
+
+```mermaid
+flowchart TB
+    subgraph AI["ai/"]
+        Paths["paths.py<br/>DEFAULT_DATA_DIR / DEFAULT_OUTPUT_DIR"]
+        CLI["cli/<br/>nectar-ai detect|segment|classify ..."]
+        SharedCore["core/<br/>Framework, ModelLoader, utils"]
+
+        subgraph Detection["detection/"]
+            Detector["Detector"]
+            DetCore["Models, Training, Evaluation"]
+        end
+
+        subgraph Segmentation["segmentation/"]
+            Segmentor["Segmentor"]
+            SegCore["Models, Training, Evaluation"]
+        end
+
+        subgraph Classification["classification/"]
+            Classifier["Classifier"]
+            ClsCore["Models, Training, Evaluation"]
+            ClsDatasets["ImageFolder, HuggingFace, Roboflow"]
+        end
+    end
+
+    subgraph External["External"]
+        ultralytics
+        transformers
+        rfdetr
+        supervision
+        huggingface_hub
+        tensorboard
+    end
+
+    CLI --> Detector
+    CLI --> Segmentor
+    CLI --> Classifier
+
+    Detector --> DetCore
+    Segmentor --> SegCore
+    Classifier --> ClsCore
+    Detector --> SharedCore
+    Segmentor --> SharedCore
+    Classifier --> SharedCore
+
+    DetCore --> ultralytics
+    DetCore --> transformers
+    DetCore --> rfdetr
+    SegCore --> ultralytics
+    SegCore --> transformers
+    SegCore --> rfdetr
+    ClsCore --> ultralytics
+    ClsCore --> transformers
+```
+
+## Início rápido
+
+### Detection
+
+```python
+from nectar.ai.detection import Detector
+
+detector = Detector("yolov8n.pt")
+detector.load()
+result = detector.detect(image)
+for det in result:
+    print(f"{det.class_name}: {det.confidence:.2f}")
+```
+
+Lado a lado com as APIs originais dos frameworks:
+[Com e sem Nectar](../../get-started/with-without.md)
+([with-without.md](../../get-started/with-without/)).
+
+### Segmentation
+
+```python
+from nectar.ai.segmentation import Segmentor
+
+segmentor = Segmentor("yolov8n-seg.pt")
+segmentor.load()
+result = segmentor.segment(image)
+for seg in result:
+    print(f"{seg.class_name}: {seg.confidence:.2f}, mask_area={seg.mask_area}px")
+```
+
+### Classification
+
+```python
+from nectar.ai.classification import Classifier
+
+classifier = Classifier("yolo26n-cls.pt")
+classifier.load()
+result = classifier.classify(image)
+print(result.top1_name, result.top1_confidence)
+```
+
+## API pública
+
+### Detection
+
+```python
+from nectar.ai.detection import (
+    Detector, Framework,
+    UltralyticsModel, TransformersModel, RFDETRModel, BaseDetectionModel,
+    Detection, DetectionResult,
+    TrainingConfig, EvaluationConfig,
+    ModelLoader, ObjectDetectionEvaluator,
+)
+```
+
+### Segmentation
+
+```python
+from nectar.ai.segmentation import (
+    Segmentor,
+    UltralyticsSegModel, TransformersSegModel, RFDETRSegModel, BaseSegmentationModel,
+    Segmentation, SegmentationResult,
+    SegTrainingConfig, SegEvaluationConfig,
+    SegmentationEvaluator,
+)
+```
+
+### Classification
+
+```python
+from nectar.ai.classification import (
+    Classifier,
+    UltralyticsClsModel, TransformersClsModel, BaseClassificationModel,
+    Classification, ClassificationResult,
+    ClsTrainingConfig, ClsEvaluationConfig,
+    ClassificationEvaluator,
+    ImageFolderDetector, ClsDatasetAnalyzer, ClsDatasetHandlerRegistry,
+)
+```
+
+## CLI
+
+```
+nectar-ai <task> <command> [options]
+
+Tasks:
+  detect       Object detection (aliases: detection, od)
+  segment      Image segmentation (aliases: segmentation, seg)
+  classify     Image classification (aliases: classification, cls)
+
+Commands:
+  train     Train a model
+  predict   Run inference on images
+  eval      Evaluate a model on a dataset
+  dataset   Dataset management (download, convert, analyze, subset, ...)
+```
+
+### Exemplos
+
+**Detection**:
+
+```bash
+nectar-ai detect train --config configs/visdrone_yolo26n.yaml
+nectar-ai detect dataset download --source visdrone --output data/visdrone
+nectar-ai detect eval --model-path best.pt --dataset-path data/visdrone --framework ultralytics
+```
+
+**Segmentation**:
+
+```bash
+nectar-ai segment train --config configs/crackseg_yolo26n_seg.yaml
+nectar-ai segment dataset download --source ultralytics --dataset crack-seg --output data/crack-seg
+nectar-ai segment eval --model-path best.pt --dataset-path data/crack-seg --framework ultralytics
+```
+
+**Classification**:
+
+```bash
+nectar-ai classify train --config configs/mnist_yolo26n_cls.yaml
+nectar-ai classify dataset download --source ultralytics --dataset mnist160 --output data/mnist160
+nectar-ai classify predict --model yolo26n-cls.pt --input image.jpg --output predictions/
+nectar-ai classify eval --model-path best.pt --dataset-path data/mnist160 --framework ultralytics
+```
+
+## Treinamento
+
+```python
+from nectar.ai.classification import Classifier, ClsTrainingConfig
+classifier = Classifier("yolo26n-cls.pt")
+classifier.load()
+result = classifier.train(ClsTrainingConfig(dataset_path="data/mnist160", epochs=50, imgsz=64))
+```
+
+## Caminhos compartilhados
+
+```python
+from nectar.ai.paths import DEFAULT_DATA_DIR, DEFAULT_OUTPUT_DIR
+```
+
+| Constante | Resolve para |
+|----------|-------------|
+| `DEFAULT_DATA_DIR` | `nectar/nectar/ai/data/` |
+| `DEFAULT_OUTPUT_DIR` | `nectar/nectar/ai/outputs/` |
+
+## Frameworks suportados
+
+| Framework | Detection | Segmentation | Classification |
+|-----------|-----------|--------------|----------------|
+| Ultralytics (YOLO) | Train, Eval, Predict | Train, Eval, Predict | Train, Eval, Predict |
+| RF-DETR | Train, Eval, Predict | Train, Eval, Predict | — |
+| HuggingFace Transformers | Train, Eval, Predict | Train, Eval, Predict | Train, Eval, Predict |
+
+## Gerenciamento de dispositivo
+
+| `device` | Comportamento |
+|----------|----------|
+| `"auto"` | Detecção automática (CUDA → MPS → CPU) |
+| `"cpu"` | Força CPU |
+| `"0"` | Índice de GPU 0 |
+
+## Dependências
+
+| Pacote | Versão | Finalidade |
+|---------|---------|---------|
+| `ultralytics` | 8.4.36 | Modelos YOLO |
+| `transformers` | 5.5.0 | DETR, MaskFormer, ViT |
+| `rfdetr` | 1.7.1 | Detecção + segmentação RF-DETR |
+| `supervision` | 0.27.0 | Métricas, visualização |
+| `huggingface-hub` | 1.9.2 | Upload/download de modelos |
+| `tensorboard` | 2.20.0 | Visualização de treinamento |
+| `albumentations` | 2.0.8 | Data augmentation |
+| `roboflow` | 1.2.13 | Download de datasets |
+
+### Instalação
+
+```bash
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
+pip install -e ".[ai]"
+```

--- a/i18n/pt/modules/ai/segmentation.md
+++ b/i18n/pt/modules/ai/segmentation.md
@@ -1,0 +1,598 @@
+# Módulo de Segmentação
+
+Segmentação de instâncias entre Ultralytics YOLO, HuggingFace Transformers (MaskFormer) e
+RF-DETR Seg por meio de um único `Segmentor` — carregue um modelo, chame `segment`, e obtenha
+máscaras tipadas. A mesma API cobre treinamento e avaliação, com ferramentas de dataset e uma
+CLI `nectar-ai segment`.
+
+## Resumo rápido
+
+```python
+from nectar.ai.segmentation import Segmentor
+
+segmentor = Segmentor("yolov8n-seg.pt")     # framework auto-detected from the model name
+segmentor.load()
+result = segmentor.segment(image)
+for seg in result:
+    print(f"{seg.class_name}: {seg.confidence:.2f}, mask_area={seg.mask_area}px")
+```
+
+## Tutorial (Colab)
+
+Fluxo ponta a ponta de segmentação (dataset → train → TensorBoard → eval → Hub):
+
+[Abrir no Google Colab](https://colab.research.google.com/drive/1qZzAF_iD2sZyuWPin48XpxaY6dtak_gV?usp=sharing)
+
+## Conceitos
+
+`Segmentor` é uma factory sobre três backends de framework (`UltralyticsSegModel`,
+`TransformersSegModel`, `RFDETRSegModel`), todos compartilhando `BaseSegmentationModel`, os
+mesmos resultados tipados, o tratamento de dataset e a avaliação:
+
+```mermaid
+flowchart TB
+    subgraph API["User API"]
+        Segmentor["Segmentor"]
+    end
+
+    subgraph Core["Core"]
+        BSM["BaseSegmentationModel"]
+        Types["Segmentation / SegmentationResult<br/>SegmentationInput / SegPrediction"]
+        Configs["SegTrainingConfig / SegEvaluationConfig<br/>SegEvaluationMetrics"]
+        Exceptions["SegmentationError<br/>ModelNotLoadedError<br/>TrainingError"]
+    end
+
+    subgraph Models["Models"]
+        UM["UltralyticsSegModel"]
+        TM["TransformersSegModel"]
+        RM["RFDETRSegModel"]
+    end
+
+    subgraph Datasets["Datasets"]
+        Handlers["UltralyticsSegHandler<br/>RoboflowSegHandler"]
+        Converter["SegFormatConverter"]
+        Analyzer["SegDatasetAnalyzer"]
+        Loader["load_segmentation_dataset"]
+    end
+
+    subgraph Evaluation["Evaluation"]
+        SE["SegmentationEvaluator"]
+        Analysis["compute_curves / error_statistics"]
+        Viz["Visualizations<br/>PR curves, confusion matrix,<br/>error analysis, prediction samples"]
+    end
+
+    subgraph External["External"]
+        YOLO["ultralytics"]
+        HF["transformers"]
+        RF["rfdetr"]
+        SV["supervision"]
+        HFH["huggingface_hub"]
+        TB["tensorboard"]
+    end
+
+    Segmentor -->|creates| UM
+    Segmentor -->|creates| TM
+    Segmentor -->|creates| RM
+
+    UM -->|extends| BSM
+    TM -->|extends| BSM
+    RM -->|extends| BSM
+
+    BSM -->|uses| Types
+    BSM -->|uses| Configs
+    BSM -->|raises| Exceptions
+
+    UM -->|wraps| YOLO
+    TM -->|wraps| HF
+    RM -->|wraps| RF
+
+    SE -->|uses| Loader
+    SE -->|uses| Analysis
+    SE -->|uses| Viz
+    SE -->|uses| SV
+
+    Handlers -->|downloads| Converter
+    UM -->|converts| Converter
+    RM -->|converts| Converter
+```
+
+## Segmentor
+
+Interface baseada em factory, com detecção automática ou seleção explícita de framework.
+
+**Detecção automática a partir do nome do modelo**:
+
+```python
+from nectar.ai.segmentation import Segmentor
+from nectar.ai.core import Framework
+
+segmentor = Segmentor("yolov8n-seg.pt")
+segmentor = Segmentor("rfdetr-seg-nano")
+segmentor = Segmentor("facebook/maskformer-swin-tiny-coco")
+```
+
+**Framework explícito**:
+
+```python
+segmentor = Segmentor("model.pt", framework="ultralytics")
+segmentor = Segmentor("rfdetr-seg-medium", framework=Framework.RFDETR)
+segmentor = Segmentor("facebook/maskformer-swin-tiny-coco", framework=Framework.TRANSFORMERS)
+```
+
+Carregue e rode:
+
+```python
+segmentor.load()
+result = segmentor.segment(image, conf=0.5)
+annotated = segmentor.draw_segmentations(image, result, show_masks=True, show_boxes=True)
+```
+
+## Tipos principais
+
+```python
+from nectar.ai.segmentation import (
+    Segmentation,          # Single instance: xyxy, confidence, class_id, class_name, mask
+    SegmentationResult,    # Per-image container: list of Segmentation + semantic_map
+    SegmentationInput,     # Model input: image(s), thresholds, device
+    SegPrediction,         # Model output: sv.Detections + SegmentationResult list
+)
+```
+
+`Segmentation` carrega uma máscara binária (`np.ndarray` de shape `(H, W)` dtype `bool`) junto
+com a bounding box. Propriedades: `mask_area`, `polygon`, `center`, `width`, `height`.
+
+`SegmentationResult` converte de/para `supervision.Detections` via `to_supervision()` /
+`from_supervision()`.
+
+## Modelos
+
+| Classe | Framework | Tipo de Segmentação | Formatos |
+|-------|-----------|-------------------|---------|
+| `UltralyticsSegModel` | Ultralytics | Instância | YOLO-seg |
+| `RFDETRSegModel` | RF-DETR | Instância | COCO-seg |
+| `TransformersSegModel` | HuggingFace | Instância + Semântica | COCO-seg |
+
+### Ultralytics
+
+Suporta YOLOv8-seg, YOLO11-seg, YOLO26-seg.
+
+```python
+from nectar.ai.segmentation import UltralyticsSegModel
+
+model = UltralyticsSegModel("yolo26n-seg.pt")
+model.load_model()
+result = model.segment(image, conf=0.5)
+```
+
+### RF-DETR Seg
+
+Suporta os tamanhos nano, small, medium, large, xlarge, 2xlarge.
+
+```python
+from nectar.ai.segmentation import RFDETRSegModel
+
+model = RFDETRSegModel("rfdetr-seg-nano", resolution=312)
+model.load_model()
+result = model.segment(image, conf=0.3)
+```
+
+### Transformers
+
+Segmentação de instâncias via MaskFormer. Segmentação semântica via SegFormer.
+
+```python
+from nectar.ai.segmentation import TransformersSegModel
+
+model = TransformersSegModel("facebook/maskformer-swin-tiny-coco", mode="instance")
+model.load_model()
+result = model.segment(image)
+```
+
+## Treinamento
+
+O treinamento é configurado via a dataclass `SegTrainingConfig` ou arquivos de config YAML.
+Configs específicas de framework estendem a base.
+
+### Config YAML
+
+```yaml
+data:
+  dataset_path: data/crack-seg/data.yaml
+  dataset_format: yolo
+
+train:
+  framework: ultralytics
+  model: yolo26n-seg.pt
+  epochs: 50
+  batch_size: 16
+  imgsz: 640
+  output_dir: outputs/my-run
+  device: "0"
+  tensorboard: true
+  push_to_hub: true
+  hub_model_id: user/model-name
+
+eval:
+  evaluate: true
+  eval_split: test
+  conf_threshold: 0.25
+```
+
+### CLI
+
+```bash
+nectar-ai segment train --config path/to/config.yaml
+nectar-ai segment train --model yolo26n-seg.pt --dataset data/crack-seg/data.yaml --epochs 50
+```
+
+### Configs específicas de framework
+
+```python
+from nectar.ai.segmentation.training.config import (
+    UltralyticsSegTrainingConfig,
+    TransformersSegTrainingConfig,
+    RFDETRSegTrainingConfig,
+)
+```
+
+Cada uma fornece um método `to_*_args()` que mapeia para a API de treinamento do framework
+subjacente.
+
+### Conversão de formato de dataset
+
+O pipeline de treinamento converte automaticamente entre os formatos YOLO-seg e COCO-seg
+conforme necessário:
+
+- Ultralytics exige o formato YOLO-seg (labels de polígono em arquivos `.txt`)
+- RF-DETR e Transformers exigem o formato COCO (anotações de polígono em JSON)
+
+A conversão é feita pelo `SegFormatConverter`.
+
+## Avaliação
+
+O avaliador segue o mesmo padrão do módulo de detecção:
+
+1. Carrega o ground truth com máscaras via `load_segmentation_dataset()`
+2. Roda a inferência com confiança baixa (0.001) para capturar todas as predições
+3. Filtra pelo threshold especificado pelo usuário
+4. Computa as métricas (mAP, precision, recall, F1) via supervision
+5. Gera plots de visualização e relatórios CSV/JSON
+
+```python
+from nectar.ai.segmentation import SegmentationEvaluator, SegEvaluationConfig
+
+config = SegEvaluationConfig(
+    model_path="best.pt",
+    dataset_path="data/crack-seg",
+    framework="ultralytics",
+    output_dir="outputs/eval",
+    split="test",
+    conf_threshold=0.25,
+)
+
+evaluator = SegmentationEvaluator(model, config)
+metrics = evaluator.evaluate()
+```
+
+### Artefatos gerados
+
+| Arquivo | Descrição |
+|------|-------------|
+| `BoxPR_curve.png` / `MaskPR_curve.png` | Curva Precision-Recall (Box sempre; Mask quando há máscaras) |
+| `BoxP_curve.png` / `MaskP_curve.png` | Precision vs confiança |
+| `BoxR_curve.png` / `MaskR_curve.png` | Recall vs confiança |
+| `BoxF1_curve.png` / `MaskF1_curve.png` | F1 vs confiança |
+| `confusion_matrix.png` | Matriz de confusão |
+| `error_analysis.png` | Detalhamento de FP/FN, principais confusões |
+| `performance_analysis.png` | Barra de AP por classe + scatter P-R |
+| `prediction_samples.png` | GT vs Pred com overlays de máscara |
+| `results.png` | Gráfico de barras com o resumo das métricas |
+| `per_class_metrics.csv` | AP, precision, recall, F1 por classe |
+| `evaluation_metrics.csv` | Métricas gerais |
+| `evaluation_report.json` | Relatório completo com config e caminhos de visualização |
+
+### CLI
+
+```bash
+nectar-ai segment eval \
+  --model-path best.pt \
+  --dataset-path data/crack-seg \
+  --framework ultralytics \
+  --output-dir outputs/eval \
+  --split test \
+  --conf-threshold 0.25
+```
+
+## Gerenciamento de dataset
+
+### Download
+
+**Datasets Ultralytics** (crack-seg, coco8-seg, etc.):
+
+```bash
+nectar-ai segment dataset download --source ultralytics --dataset crack-seg --output data/crack-seg
+```
+
+**Projetos Roboflow**:
+
+```bash
+nectar-ai segment dataset download --source roboflow --api-key KEY \
+  --workspace ws --project proj --version 1 --roboflow-format yolov8
+```
+
+**HuggingFace Hub** (dataset de seg nativo → YOLO-seg ou COCO-seg em disco):
+
+```bash
+nectar-ai segment dataset download --source huggingface \
+  --repo blackbeedrones/sae-2026-hook --format yolo --output data/sae-2026-hook
+```
+
+### Upload para o HuggingFace
+
+`upload` converte um dataset YOLO-seg/COCO-seg local para o schema nativo do Hub (`image` +
+`objects.{bbox, category, area, segmentation}`) e envia shards Parquet mais um dataset card
+gerado automaticamente. O viewer do Hub renderiza overlays de bounding-box (derivados dos
+polígonos); os próprios polígonos são armazenados para treinamento com máscara e fazem o caminho
+de volta para YOLO-seg via `HuggingFaceSegHandler`.
+
+**Upload nativo** (Parquet + viewer):
+
+```bash
+nectar-ai segment dataset upload --target huggingface \
+  --repo user/my-seg-dataset --dataset data/my-seg \
+  --public --title "My Seg Dataset" --model-repo user/my-model
+```
+
+**Upload raw** (arquivos como estão, sem viewer / sem Parquet):
+
+```bash
+nectar-ai segment dataset upload --target huggingface --raw \
+  --repo user/my-seg-dataset --dataset data/my-seg
+```
+
+```python
+from nectar.ai.segmentation.datasets import HuggingFaceSegDatasetUploader
+
+uploader = HuggingFaceSegDatasetUploader(repo_id="user/my-seg-dataset", private=False)
+result = uploader.upload_native(
+    dataset_path="data/my-seg",          # YOLO-seg or COCO-seg, auto-detected
+    card_metadata={"title": "My Seg Dataset", "model_repo": "user/my-model"},
+)
+print(result["splits"], result["class_names"])
+```
+
+### Conversão de formato
+
+Labels YOLO-seg usam vértices de polígono normalizados: `class_id x1 y1 x2 y2 ... xN yN`.
+Anotações COCO-seg usam coordenadas absolutas de polígono no campo `segmentation`.
+
+```bash
+nectar-ai segment dataset convert --input data/crack-seg --output data/crack-seg-coco --format coco
+```
+
+```python
+from nectar.ai.segmentation.datasets import SegFormatConverter
+
+converter = SegFormatConverter("data/yolo-seg", "data/coco-seg")
+converter.convert(target_format="coco", copy_images=True)
+```
+
+### Análise
+
+```bash
+nectar-ai segment dataset analyze --input data/crack-seg --output data/crack-seg/analysis
+```
+
+Gera: `sample_mosaic.png` (com overlays de máscara), `class_distribution.png`,
+`mask_area_distribution.png`, `annotations_per_image.png`, `dimension_insights.png`,
+`analysis_report.json`.
+
+### Subconjunto
+
+```bash
+nectar-ai segment dataset subset --input data/crack-seg --output data/crack-seg-small \
+  --max-train-samples 500 --max-eval-samples 100
+```
+
+### Predição
+
+```bash
+nectar-ai segment predict --model best.pt --input image.jpg --output predictions/ --save-masks
+```
+
+## Referência da CLI
+
+```
+nectar-ai segment <command> [options]
+
+Commands:
+  train     Train a segmentation model
+  predict   Run inference
+  eval      Evaluate on a dataset
+  dataset   Dataset management (download, convert, subset, analyze)
+```
+
+## Integrações de treinamento
+
+### Upload para o HuggingFace Hub
+
+Todos os frameworks enviam checkpoints para o HuggingFace Hub **durante o treinamento** (entre
+epochs), não só depois. Configurado via `push_to_hub: true` e `hub_model_id` no config YAML.
+
+> **Nota:** exige a variável de ambiente `HF_TOKEN`.
+
+| Framework | Mecanismo | Momento do Upload |
+|-----------|-----------|---------------|
+| Ultralytics | `model.add_callback("on_train_epoch_end", ...)` | Pesos após cada epoch + diretório completo ao final do treino |
+| RF-DETR | PTL `Callback.on_validation_epoch_end` | Diretório de saída após cada epoch de validação + ao final do fit |
+| Transformers | `push_to_hub` nativo + `hub_strategy="every_save"` | A cada salvamento de checkpoint |
+
+As implementações de callback são compartilhadas entre as tasks via
+`nectar.ai.core.utils.callbacks`.
+
+### TensorBoard
+
+Todos os frameworks logam para o TensorBoard quando `tensorboard: true` está no config:
+
+- **Ultralytics**: eventos em `{save_dir}/` (configurado via `ultralytics_settings`)
+- **RF-DETR**: `TensorBoardLogger` adicionado pelo `build_trainer` (PTL)
+- **Transformers**: `report_to: ["tensorboard"]` em `TrainingArguments`
+
+Veja os logs: `tensorboard --logdir nectar/nectar/ai/outputs/`
+
+## Testes E2E
+
+### Pré-requisitos
+
+```bash
+cd nectar-sdk/nectar
+export PYTHONPATH=$(pwd):$PYTHONPATH
+export HF_TOKEN=<your-hf-token>
+pip install -e ".[ai]"
+```
+
+### Rodar todos os testes de segmentação (Ultralytics + RF-DETR + Transformers)
+
+```bash
+bash nectar/nectar/ai/segmentation/scripts/e2e_cli_test.sh
+```
+
+Este script: baixa o dataset crack-seg -> analisa -> treina o YOLO26n-seg (3 epochs) -> treina
+o RF-DETR Seg Nano (10 epochs) -> treina o MaskFormer Swin-Tiny (2 epochs) -> avalia + faz
+predição de cada um -> verifica TensorBoard + upload HF -> imprime o resumo.
+
+### Rodar frameworks individualmente
+
+```bash
+
+# 1. Download dataset (once)
+
+nectar-ai segment dataset download \
+  --source ultralytics --dataset crack-seg \
+  --output nectar/nectar/ai/data/crack-seg --format yolo
+
+# 2. Train YOLO26n-seg (500 train samples, 3 epochs, 320px)
+
+nectar-ai segment train --config nectar/nectar/ai/segmentation/configs/crackseg_yolo26n_seg.yaml
+
+# 3. Train RF-DETR Seg Nano (full dataset, 10 epochs, 312px)
+
+nectar-ai segment train --config nectar/nectar/ai/segmentation/configs/crackseg_rfdetr_seg_nano.yaml
+
+# 4. Train MaskFormer Swin-Tiny (50 train samples, 2 epochs, 320px, fp32)
+
+nectar-ai segment train --config nectar/nectar/ai/segmentation/configs/crackseg_mask2former.yaml
+```
+
+### Rodar todos os testes de detecção (Ultralytics + RF-DETR + Transformers)
+
+```bash
+bash nectar/nectar/ai/detection/scripts/e2e_cli_test.sh
+```
+
+Este script: baixa o dataset gate do Roboflow -> treina o YOLO26n (3 epochs) -> treina o
+RF-DETR Nano (5 epochs) -> treina o DETR (2 epochs) -> avalia + faz predição de cada um ->
+verifica TensorBoard + upload HF -> imprime o resumo.
+
+### Rodar frameworks de detecção individualmente
+
+```bash
+
+# 1. Download gate dataset (once)
+
+nectar-ai detect dataset download \
+  --source roboflow --api-key $ROBOFLOW_API_KEY \
+  --workspace black-bee-drones --project imav-25-gate-sfbbq --version 1 \
+  --output nectar/nectar/ai/data/imav-gate --format yolo
+
+# 2. Train YOLO26n (100 train samples, 3 epochs, 320px)
+
+nectar-ai detect train --config nectar/nectar/ai/detection/configs/gate_yolo26n.yaml
+
+# 3. Train RF-DETR Nano (100 train samples, 5 epochs, 312px)
+
+nectar-ai detect train --config nectar/nectar/ai/detection/configs/gate_rfdetr_nano.yaml
+
+# 4. Train DETR (100 train samples, 2 epochs, 320px)
+
+nectar-ai detect train --config nectar/nectar/ai/detection/configs/gate_detr.yaml
+```
+
+### O que verificar depois de cada execução
+
+1. **Outputs de treinamento** existem em `nectar/nectar/ai/outputs/<run-name>/`
+2. **Eventos do TensorBoard**: `find nectar/nectar/ai/outputs/<run-name> -name "events.out.tfevents.*"`
+3. **Repo do HuggingFace** atualizado em `https://huggingface.co/blackbeedrones/<hub_model_id>`
+4. **Métricas de avaliação** em `nectar/nectar/ai/outputs/<run-name>/evaluation/metrics_summary.json`
+5. **Predições** em `nectar/nectar/ai/outputs/<run-name>/predictions/`
+
+## Status dos frameworks
+
+Testado ponta a ponta no
+[Crack Segmentation Dataset](https://docs.ultralytics.com/datasets/segment/crack-seg/) (4029
+imagens, 1 classe).
+
+| Framework | Train | Eval | Predict | Upload HF | TensorBoard | Notas |
+|-----------|-------|------|---------|-----------|-------------|-------|
+| Ultralytics (YOLO26n-seg) | OK | OK | OK | Por epoch | OK | Pipeline completo |
+| RF-DETR Seg Nano | OK | OK | OK | Por epoch (PTL) | OK (PTL) | Usa a Custom Training API |
+| Transformers (MaskFormer) | OK | OK | OK | Nativo | OK | Mapas de instância via `CocoInstanceSegDataset`; use fp32 (fp16 gera NaNs no matcher) |
+
+### Ultralytics (YOLO26n-seg) — Pipeline completo
+
+- Download, análise, treino, avaliação e predição, tudo funcionando via CLI
+- Upload HF por epoch via `setup_ultralytics_hf_callbacks()` compartilhado
+- A avaliação usa `MetricTarget.MASKS` para métricas corretas baseadas em máscara
+- A avaliação isolada gera 16 artefatos (13 plots PNG mais relatórios CSV/JSON; veja [Artefatos gerados](#artefatos-gerados) acima)
+
+### RF-DETR Seg Nano — Pipeline completo
+
+- Fixado em `rfdetr[train]==1.7.1` (PyPI)
+- O treinamento usa a [Custom Training API](https://rfdetr.roboflow.com/latest/learn/train/customization/) (`RFDETRModelModule`, `RFDETRDataModule`, `build_trainer`) para injeção de callback
+- Upload HF por epoch via `HuggingFaceUploadPTLCallback` do PTL
+- Nomes de classe sincronizados automaticamente a partir do checkpoint em `load_model()`
+- IDs de classe inválidos filtrados em `_predict_single()`
+- Conversão automática para o formato COCO a partir de YOLO-seg via `SegFormatConverter`
+- **Nota de treinamento**: modelos estilo DETR precisam de epochs suficientes para calibração de confiança. Recomendado: 10+ epochs com `lr=5e-5`, scheduler `cosine`, `warmup_epochs=2`.
+
+### Transformers (MaskFormer) — Pipeline completo
+
+- A inferência pré-treinada e com fine-tuning funciona via CLI / `Segmentor`
+- O treinamento usa `CocoInstanceSegDataset`: polígonos COCO → mapas de instância + `instance_id_to_semantic_id` para o image processor do MaskFormer (não o `annotations=` estilo DETR)
+- O collate devolve `mask_labels` / `class_labels` (tamanho variável por imagem)
+- Processor redimensionado para `imgsz` fixo (padrão 320 no config do crack-seg) para VRAM de GPU pequena
+- **fp16 é desabilitado automaticamente** para treinamento de instância: o matcher Húngaro do MaskFormer produz NaNs sob autocast
+- Logs do TensorBoard sob o diretório de execução do Trainer; upload HF por epoch + final via callback transformers compartilhado quando `push_to_hub: true`
+- Validado no crack-seg (pico de ~1 GB na GTX 1650 em 320px / batch 2; Colab T4 recomendado para subconjuntos maiores)
+- **Dica de avaliação**: checkpoints iniciais são pouco confiantes — use `conf_threshold: 0.01`. O AP da curva PR e o `box_map50` se movem primeiro; o mAP@0.25 de máscara fica perto de zero até os scores calibrarem (mesma observação estilo DETR do RF-DETR)
+
+### Detalhes de implementação importantes
+
+- **Callbacks compartilhados**: `nectar.ai.core.utils.callbacks` fornece `setup_ultralytics_hf_callbacks()`, `setup_ultralytics_gc_callback()` e `get_hf_upload_ptl_callback()`, usados por detection, segmentation e classification
+- **Custom Training API do RF-DETR**: os modelos RF-DETR de detecção e segmentação usam `build_trainer` + `trainer.callbacks.extend()` em vez de `rfdetr_wrapper.train()`, permitindo a injeção de callback
+- **Dependência do RF-DETR**: fixada em `rfdetr==1.7.1` (PyPI) para suporte a treinamento PTL e correções de segmentação
+- **IDs de categoria COCO**: `SegFormatConverter` usa os IDs padrão indexados a partir de 1 (classes do YOLO, indexadas a partir de 0, mapeiam para `category_id = class_id + 1` do COCO)
+- **Métricas de avaliação**: `SegmentationEvaluator` usa `supervision.metrics` com `MetricTarget.MASKS` quando há máscaras presentes; recorre a `MetricTarget.BOXES` caso contrário
+- **Dataset do MaskFormer**: `CocoInstanceSegDataset` + `instance_seg_collate_fn` em `segmentation/models/dataset.py`
+
+## Arquivos de config
+
+Configs de treinamento de exemplo em `configs/`:
+
+| Config | Framework | Descrição |
+|--------|-----------|--------------|
+| `crackseg_yolo26n_seg.yaml` | Ultralytics | YOLO26n-seg, 3 epochs, 320px, 500 amostras de treino |
+| `crackseg_rfdetr_seg_nano.yaml` | RF-DETR | RF-DETR Seg Nano, 10 epochs, 312px, LR cosine |
+| `crackseg_mask2former.yaml` | Transformers | MaskFormer Swin-Tiny, 5 epochs, 320px, fp32, upload no Hub |
+
+## Layout
+
+O pacote `segmentation/` espelha `detection/`:
+
+- `segmentor.py` — a facade e factory `Segmentor`
+- `core/` — `BaseSegmentationModel`, tipos de segmentação, `SegTrainingConfig`/`SegEvaluationConfig`, exceções
+- `models/` — backends de framework (`UltralyticsSegModel`, `RFDETRSegModel`, `TransformersSegModel`) e carregamento de dataset
+- `training/` — configs de treinamento específicas de framework
+- `evaluation/` — `SegmentationEvaluator`, análise de PR/erro, plots
+- `datasets/` — conversão YOLO-seg/COCO-seg, upload para o HuggingFace, análise e handlers de download
+- `cli/`, `configs/` — a CLI `nectar-ai segment` e configs de exemplo

--- a/i18n/pt/modules/control/ardupilot.md
+++ b/i18n/pt/modules/control/ardupilot.md
@@ -1,0 +1,222 @@
+# Núcleo do Veículo ArduPilot
+
+Especialização de firmware ArduPilot do [núcleo do veículo](../vehicle/) compartilhado. `ArduPilotDrone` ([`drone.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/ardupilot/drone.py)) acrescenta a semântica de voo do ArduPilot — arming em modo GUIDED, a configuração de setpoint `GUID_OPTIONS`/`WPNAV`, e o retorno ao ponto de lançamento em modo `RTL` nativo — sobre o [`VehicleDrone`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/drone.py); a navegação agnóstica a transporte, a detecção de takeoff/land, a matemática de GPS e o controle PID são herdados do núcleo. `MavrosDrone` e `MavlinkDrone` são o **mesmo veículo, alcançado por dois transportes diferentes** ([mavros](../mavros/), [mavlink](../mavlink/)).
+
+> Esta página documenta apenas as especificidades do ArduPilot. Os métodos de navegação compartilhados, os frames de referência, as fontes de altitude, a detecção de takeoff/land, o tratamento de GPS/EGM96 e a configuração de PID — que se aplicam a todo veículo — estão no [README do núcleo do veículo](../vehicle/). As especificidades do PX4 estão em [PX4](../px4/).
+
+## Arquitetura
+
+```mermaid
+classDiagram
+    class VehicleDrone {
+        <<abstract>>
+        +takeoff() land() move_to() move_to_gps() move_velocity() rtl()
+    }
+    class ArduPilotDrone {
+        +arm() _rtl_native() capabilities
+        +set_speed() do_servo() set_setpoint_config()
+        -_setpoint_config SetpointNavConfig
+        -_apply_setpoint_config() _prepare_position_setpoint()
+    }
+    class SetpointNavConfig {
+        <<dataclass>>
+        +guid_options speed speed_up speed_down accel radius jerk psc_jerk rfnd_use
+        +use_wpnav «property» from_yaml() from_dict() to_fcu_params()
+    }
+    VehicleDrone <|-- ArduPilotDrone
+    ArduPilotDrone o-- SetpointNavConfig
+```
+
+O diagrama de classes completo do núcleo (`VehicleDrone`, `VehicleNavigator`, `VehicleTransport`, transportes) está no [README do núcleo do veículo](../vehicle/#design).
+
+## Módulos
+
+| Arquivo | Responsabilidade |
+| --- | --- |
+| `drone.py` | `ArduPilotDrone(VehicleDrone)` — semântica de voo do ArduPilot: arming em GUIDED, WPNAV/GUID_OPTIONS, RTL nativo, `set_speed`/`do_servo`. |
+| `setpoint_config.py` | `SetpointNavConfig` — tratamento de parâmetros `GUID_OPTIONS`/`WPNAV` (com aliases 4.6/4.8). |
+| `config/` | Presets YAML de PID + setpoint embutidos (`position_*.yaml`, `setpoint_*.yaml`, incluindo os presets de SITL `*_sim_*`). |
+
+## Capacidades
+
+`ArduPilotDrone.capabilities` é derivado declarativamente da `pose_source` configurada (veja [`capabilities.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/capabilities.py)): outdoor adiciona `GPS_NAV`/`GLOBAL_SETPOINT`, indoor adiciona `VISION_POSE`. Sobre o conjunto compartilhado, ele declara `SERVO` (o caminho de PWM por canal `do_servo` do ArduPilot, que o PX4 não expõe), além de `ACTUATOR` (`DO_SET_ACTUATOR`) e `GRIPPER` (`DO_GRIPPER`) para payloads (ambos compartilhados com o PX4). Operações protegidas por capacidade chamam `_require(...)`, então `do_servo` / `set_actuator` / `set_gripper` lançam `CapabilityNotSupportedError` em um drone que não os declara; consulte com `drone.supports(Capability.SERVO)`.
+
+## MAVLink e o FCU
+
+[MAVLink](https://ardupilot.org/dev/docs/mavlink-basics.html) é o protocolo binário entre o controlador de voo (FCU), estações de solo e computadores de bordo. O SDK envia comandos de velocidade/posição e lê dados de sensor por ele — via MAVROS em um transporte, via pymavlink diretamente no outro. O drone precisa estar em [modo GUIDED](https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html) para controle offboard.
+
+## Modos de Voo
+
+Os [modos de voo](https://ardupilot.org/copter/docs/flight-modes.html) do ArduPilot determinam como o FCU interpreta as entradas. Modos usados por este SDK:
+
+| Modo | Descrição |
+|------|-------------|
+| GUIDED | Controle offboard. Aceita comandos de posição/velocidade do computador de bordo. Exigido para a navegação do SDK. |
+| STABILIZE | Voo estabilizado manual. O piloto controla via RC. |
+| LOITER | Manutenção de posição baseada em GPS. |
+| RTL | Retorno ao ponto de lançamento — voa de volta para home e pousa. |
+| LAND | Auto-pouso na posição atual. |
+
+Definido via `drone.set_mode()`. Veja o [protocolo MAVLink de modo de voo](https://ardupilot.org/dev/docs/mavlink-get-set-flightmode.html).
+
+## Arme (GUIDED)
+
+`ArduPilotDrone.arm()` define o modo `GUIDED`, espera o modo refletir no estado, opcionalmente envia os parâmetros de setpoint (quando `apply_setpoint_params=True`), comanda o arme, e faz poll de `is_armed` para confirmar. GUIDED é o modo de controle offboard e persiste durante toda a navegação, então — diferente do OFFBOARD do PX4 — nenhum stream contínuo de setpoint é necessário para permanecer nele.
+
+## EKF (Filtro de Kalman Estendido)
+
+O [EKF](https://ardupilot.org/copter/docs/common-apm-navigation-extended-kalman-filter-overview.html) é o estimador de estado do ArduPilot. Ele funde dados de IMU, GPS, barômetro e, opcionalmente, visão/rangefinder, em uma estimativa de posição/velocidade/atitude. Todos os valores de altitude e posição neste SDK vêm, em última instância, da saída do EKF, exposta pelo transporte como `local_pose`, `gps`, `rel_alt`, etc.
+
+### Origem do EKF (Requisito Indoor)
+
+O frame local do EKF precisa de uma origem — a referência (0,0,0) para o NED. Outdoor,
+o GPS geralmente a define. Indoor, sem fix de GPS, defina-a manualmente (Mission Planner
+"Set EKF Origin Here" ou [`SET_GPS_GLOBAL_ORIGIN`](https://mavlink.io/en/messages/common.html#SET_GPS_GLOBAL_ORIGIN)).
+Home (RTL) é um conceito diferente. Regras completas (ArduPilot vs. PX4, persistência em 4.7+,
+por que o ícone do mapa da GCS aparece, o que o Nectar não envia):
+[Localization → Origem do EKF](localization/#ekf-origin).
+
+### Sistemas de Visão (Fonte de Posição Indoor)
+
+Um sistema de visão externo alimenta dados de pose para o EKF do ArduPilot como [`VISION_POSITION_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE). O EKF funde isso com o IMU e produz a pose local. Os dois transportes injetam isso de forma diferente — veja o README de cada transporte — mas o comportamento do veículo é idêntico.
+
+Parâmetros-chave do ArduPilot: `EK3_SRC1_POSXY=6`, `EK3_SRC1_POSZ=6`, `EK3_SRC1_YAW=6` (ExternalNav), `VISO_TYPE=1`. Veja a [configuração de VIO do ArduPilot](https://ardupilot.org/copter/docs/common-vio-tracking-camera.html), o [guia de VIO com ROS](https://ardupilot.org/dev/docs/ros-vio-tracking-camera.html) e o [Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html).
+
+## Controladores de Posição do Modo GUIDED do ArduPilot
+
+Quando o SDK publica um setpoint de posição local (`NavigationMethod.POSITION` / `POSITION_GLOBAL`, documentado no [README do núcleo do veículo](../vehicle/#navegacao-por-setpoint-posicao)), o modo GUIDED do ArduPilot o roteia para um de dois controladores, selecionados pelo parâmetro [`GUID_OPTIONS`](https://ardupilot.org/copter/docs/ac2_guidedmode.html#guided-mode-options):
+
+| Controlador | GUID_OPTIONS | SubMode | Trajetória | Controle de Velocidade |
+|---|---|---|---|---|
+| **AC_PosControl** (padrão) | bit 6 = 0 | `SubMode::Pos` | PID direto ao alvo | Limites de velocidade do WPNAV na inicialização |
+| **AC_WPNav** | bit 6 = 1 (valor 64) | `SubMode::WP` | Planejamento de trajetória em S-curve | Conjunto completo de parâmetros WPNAV |
+
+Fonte: [`mode_guided.cpp :: set_pos_NED_m()`](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_guided.cpp) — `use_wpnav_for_position_control()` seleciona o submodo a partir do bit 6 de `GUID_OPTIONS`.
+
+- **AC_PosControl (SubMode::Pos)** — PID direto em direção ao alvo, sem modelagem de trajetória. Limites de velocidade lidos uma vez na inicialização do modo. Sem raio de chegada interno (a verificação de chegada do SDK cuida disso). Adequado para streaming contínuo de posição; pode produzir movimento abrupto em alta velocidade/longa distância.
+- **AC_WPNav (SubMode::WP)** — caminho em linha reta com um perfil de velocidade em S-curve; respeita todos os parâmetros `WPNAV_*` dinamicamente (incluindo `WPNAV_RADIUS` para desaceleração e chegada), suporta planejamento de trajetória com desvio de obstáculos. Cada novo alvo dispara um replanejamento completo — melhor para missões ponto a ponto, não para retargeting rápido.
+
+### Parâmetros WPNAV
+
+Os [parâmetros `WPNAV_*`](https://ardupilot.org/copter/docs/parameters-Copter-stable-V4.6.3.html#wpnav-parameters) do ArduPilot v4.6.3 controlam velocidade, aceleração e precisão de navegação:
+
+| Parâmetro | Descrição | Padrão do ArduPilot | Unidade |
+|---|---|---|---|
+| `WPNAV_SPEED` | Velocidade horizontal | 1000 (10 m/s) | cm/s |
+| `WPNAV_SPEED_UP` | Velocidade de subida | 250 (2,5 m/s) | cm/s |
+| `WPNAV_SPEED_DN` | Velocidade de descida | 150 (1,5 m/s) | cm/s |
+| `WPNAV_ACCEL` | Aceleração horizontal | 250 (2,5 m/s²) | cm/s/s |
+| `WPNAV_RADIUS` | Raio de chegada ao waypoint | 200 (2,0 m) | cm |
+| `WPNAV_JERK` | Jerk horizontal | 1,0 | m/s/s/s |
+| `WPNAV_RFND_USE` | Terrain following por rangefinder | 1 (habilitado) | bool |
+
+> No ArduPilot dev (v4.8+) esses parâmetros são renomeados para `WP_*`. `SetpointNavConfig` usa nomes de campo descritivos e carrega um mapa `PARAM_ALIASES` (`WPNAV_SPEED` → `WP_SPD`, etc.), então mudanças de versão exigem apenas a tabela de alias.
+
+O SDK também define `PSC_JERK_XY` (4.6.3) / `PSC_JERK_NE` (4.8+) — jerk horizontal do controlador de posição, padrão 5,0 m/s³ — via `SetpointNavConfig.psc_jerk`. Isso controla a velocidade de resposta do AC_PosControl em SubMode::Pos; o SITL tipicamente precisa de valores mais altos (por exemplo, 50) para uma resposta usável.
+
+**Efeito em runtime de `set_param` por submodo**: em SubMode::WP, todos os `WPNAV_*` são relidos a cada novo alvo (`wp_nav->set_wp_destination()`). Em SubMode::Pos, os limites de velocidade/aceleração são definidos uma vez na entrada do submodo — use `set_speed()` para mudanças dinâmicas. O `_prepare_position_setpoint()` do SDK usa a releitura do WPNav para atualizar `WPNAV_RADIUS` a partir do argumento `precision`, em cada chamada `POSITION`/`POSITION_GLOBAL`, quando o WPNav está habilitado e `apply_setpoint_params=True`.
+
+### Controle de Velocidade em Runtime
+
+`set_speed(speed, speed_type)` envia [`MAV_CMD_DO_CHANGE_SPEED`](https://ardupilot.org/copter/docs/common-mavlink-mission-command-messages-mav_cmd.html#mav-cmd-do-change-speed) (178), que atualiza imediatamente os limites de velocidade ativos do AC_PosControl em **ambos** os submodos:
+
+```python
+drone.set_speed(0.5, "horizontal")   # 0.5 m/s horizontal
+drone.set_speed(0.3, "climb")        # 0.3 m/s climb
+drone.set_speed(0.3, "descent")      # 0.3 m/s descent
+drone.set_speed(-2, "horizontal")    # revert to WPNAV_SPEED default
+```
+
+Em contraste, `set_param("WPNAV_SPEED", value)` só entra em efeito no próximo alvo (WP) ou na próxima inicialização de modo (Pos).
+
+## RTL
+
+`rtl()` usa por padrão `RTLMethod.NAVIGATE` (o caminho PID compartilhado do SDK até home — veja o [núcleo do veículo](../vehicle/#rtl)). `RTLMethod.NATIVE` usa o próprio modo de voo `RTL` do ArduPilot:
+
+```python
+drone.rtl(method=RTLMethod.NATIVE)   # ArduPilot RTL mode, auto-land
+```
+
+- **NATIVE**: define `RTL_ALT` (altitude de retorno, ou 0 para manter a altitude atual em vez do padrão de 15 m do ArduPilot) e `RTL_ALT_FINAL` (0 para auto-pousar, ou a altitude de retorno para manter acima de home), depois define o modo `RTL`. Os nomes de parâmetro diferem por versão: `RTL_ALT` / `RTL_ALT_FINAL` (v4.6.3, cm) vs. `RTL_ALT_M` / `RTL_ALT_FINAL_M` (v4.8+, m); o SDK tenta primeiro o nome da v4.6.3 e recorre automaticamente ao outro. Veja o [modo RTL](https://ardupilot.org/copter/docs/rtl-mode.html).
+
+## Manipulação de Parâmetros
+
+`drone.set_param(name, value)` repassa para o transporte. Inteiros são enviados como int, floats como double. O ArduPilot persiste `PARAM_SET` em armazenamento, então os valores sobrevivem a reinicializações.
+
+```python
+drone.set_param("RTL_ALT", 1500)        # int, cm
+drone.set_param("WPNAV_SPEED", 200.0)   # float, cm/s
+drone.set_param("GUID_OPTIONS", 65)     # int, bits 0 + 6
+```
+
+Parâmetros dependentes de versão (WPNAV/PSC, RTL) são escritos primeiro com o nome da v4.6.3, recorrendo ao alias da v4.8+ em caso de falha, usando `SetpointNavConfig.PARAM_ALIASES`. Como um `set_param` é confirmado depende do transporte (resultado de serviço vs. eco de `PARAM_VALUE`) — veja os READMEs de transporte. Veja [Get/Set Parameters](https://ardupilot.org/dev/docs/mavlink-get-set-params.html).
+
+## Configuração de Navegação por Setpoint
+
+`SetpointNavConfig` controla o comportamento do modo GUIDED para `NavigationMethod.POSITION` / `POSITION_GLOBAL`: o submodo do controlador de posição (AC_PosControl vs. AC_WPNav) e os parâmetros WPNAV/PSC.
+
+**Ciclo de vida**:
+
+1. **Na inicialização**: `_load_setpoint_config()` carrega de `setpoint_config_file`, senão os `setpoint_indoor.yaml` / `setpoint_outdoor.yaml` embutidos, por `is_indoor`. Sempre carregado para a lógica do lado do SDK (por exemplo, verificações de `use_wpnav`).
+2. **No arme** (somente se `apply_setpoint_params=True`): `_apply_setpoint_config()` envia `GUID_OPTIONS` e os parâmetros `WPNAV_*` / `PSC_JERK_*` para o FCU via `set_param()`, logando cada resultado.
+3. **Em `move_to` / `move_to_gps` com um método POSITION** (somente se `apply_setpoint_params=True` e `use_wpnav`): `_prepare_position_setpoint()` sincroniza `WPNAV_RADIUS` com `precision`.
+
+> **Persistência no FCU**: `set_param` escreve no armazenamento do autopiloto e sobrevive a reinicializações. `apply_setpoint_params` tem padrão `False`, então por padrão o SDK não toca nos parâmetros do FCU. Defina-o como `True` para deixar o SDK ser o proprietário deles (por exemplo, em SITL). `drone.set_setpoint_config(config)` envia sob demanda independentemente dessa flag (passe `apply=False` para atualizar apenas a config do lado do SDK).
+
+**Padrões da dataclass** (unidades SI; velocidade/aceleração/raio são convertidos para cm/s, cm por `to_fcu_params()`):
+
+| Campo | Padrão | Padrão de fábrica do ArduPilot |
+|---|---|---|
+| `guid_options` | `1` (bit 0) | `0` |
+| `speed` | 2,0 m/s | 10,0 m/s |
+| `speed_up` | 1,5 m/s | 2,5 m/s |
+| `speed_down` | 1,5 m/s | 1,5 m/s |
+| `accel` | 1,0 m/s² | 2,5 m/s² |
+| `radius` | 0,2 m | 2,0 m |
+| `jerk` | 1,0 m/s³ | 1,0 m/s³ |
+| `psc_jerk` | 5,0 m/s³ | 5,0 m/s³ |
+| `rfnd_use` | 1 | 1 |
+
+`guid_options` é a bitmask do [`GUID_OPTIONS`](https://ardupilot.org/copter/docs/ac2_guidedmode.html#guided-mode-options); `use_wpnav` é `True` quando o bit 6 está definido. Valores comuns: `1` (arme pela TX), `64` (apenas WPNav), `65` (arme pela TX + WPNav). Os padrões de velocidade do SDK são intencionalmente conservadores em relação aos valores de fábrica do ArduPilot, para evitar movimento agressivo.
+
+**Enviar para o FCU**:
+
+```python
+drone.set_setpoint_config({"guid_options": 65, "speed": 0.5, "radius": 0.1})
+```
+
+**Atualizar apenas a config do lado do SDK** (`apply=False`):
+
+```python
+drone.set_setpoint_config({"speed": 0.5}, apply=False)
+```
+
+## Configuração de PID
+
+O ArduPilot carrega seu `PositionPIDConfig` a partir dos [presets embutidos](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/control/ardupilot/config) (`position_indoor.yaml` / `position_outdoor.yaml`, mais os presets de SITL `position_sim_*.yaml`) — o ciclo de carregamento e as sobrescritas em runtime são compartilhados e documentados no [README do núcleo do veículo](../vehicle/#configuracao-de-pid). Os internos do controlador (ganhos, clamps de saída, tratamento integral) estão no [módulo PID](pid.md).
+
+## Transportes
+
+- [Transporte MAVROS](../mavros/) — `MavrosTransport`: subscriptions → telemetria, service clients → comandos, publishers → setpoints. Exige um `mavros_node` em execução.
+- [Transporte MAVLink direto](../mavlink/) — `PymavlinkTransport`: possui o link do FCU, decodificação por timer de RX, `mav.*_send` direto, ponte de visão embutida.
+
+## Referências
+
+### MAVLink e ArduPilot
+
+- [MAVLink Basics](https://ardupilot.org/dev/docs/mavlink-basics.html) · [Mensagens comuns do MAVLink](https://mavlink.io/en/messages/common.html) · [MAV_FRAME](https://mavlink.io/en/messages/common.html#MAV_FRAME)
+- [ArduPilot Copter Documentation](https://ardupilot.org/copter/) · [Flight Modes](https://ardupilot.org/copter/docs/flight-modes.html) · [GUIDED Mode](https://ardupilot.org/copter/docs/ac2_guidedmode.html)
+- [GUIDED Mode Commands](https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html) · [PosControl and Navigation Overview](https://ardupilot.org/dev/docs/code-overview-copter-poscontrol-and-navigation.html)
+- [WPNAV Parameters (v4.6.3)](https://ardupilot.org/copter/docs/parameters-Copter-stable-V4.6.3.html#wpnav-parameters) · [MAV_CMD_DO_CHANGE_SPEED](https://ardupilot.org/copter/docs/common-mavlink-mission-command-messages-mav_cmd.html#mav-cmd-do-change-speed)
+- [Understanding Altitude](https://ardupilot.org/copter/docs/common-understanding-altitude.html) · [EKF Overview](https://ardupilot.org/copter/docs/common-apm-navigation-extended-kalman-filter-overview.html) · [RTL Mode](https://ardupilot.org/copter/docs/rtl-mode.html)
+- [Get/Set Parameters](https://ardupilot.org/dev/docs/mavlink-get-set-params.html) · [Set/Get flight mode](https://ardupilot.org/dev/docs/mavlink-get-set-flightmode.html)
+
+### Código-fonte do ArduPilot
+
+- [`mode_guided.cpp`](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_guided.cpp) — submodos GUIDED, `pva_control_start()`, `set_pos_NED_m()`
+- [`AC_WPNav.cpp`](https://github.com/ArduPilot/ardupilot/blob/Copter-4.6.3/libraries/AC_WPNav/AC_WPNav.cpp) · [`AC_PosControl.h`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AC_AttitudeControl/AC_PosControl.h) · [`GCS_MAVLink_Copter.cpp`](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/GCS_MAVLink_Copter.cpp)
+
+### Visão e Navegação Indoor
+
+- [VIO Tracking Camera](https://ardupilot.org/copter/docs/common-vio-tracking-camera.html) · [ROS VIO Setup](https://ardupilot.org/dev/docs/ros-vio-tracking-camera.html) · [Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html)
+- Navegação, frames e altitude compartilhados, GPS/EGM96: [README do núcleo do veículo](../vehicle/)

--- a/i18n/pt/modules/control/bebop.md
+++ b/i18n/pt/modules/control/bebop.md
@@ -1,0 +1,223 @@
+# Módulo de Controle do Bebop
+
+Controle do Parrot Bebop 2 via o pacote ROS 2 [`ros2_bebop_driver`](https://github.com/jeremyfix/ros2_bebop_driver),
+para voo baseado em velocidade.
+
+## Resumo rápido
+
+```python
+import nectar
+from nectar.control import DroneFactory, BebopConfig
+
+nectar.init()
+drone = DroneFactory.create("bebop", BebopConfig())
+
+drone.takeoff()                              # fixed preset height (altitude arg ignored)
+drone.move_velocity(vx=0.3, duration=2.0)    # body-frame, normalized [-1, 1]
+drone.land()
+nectar.shutdown()
+```
+
+## Capacidades
+
+`BebopDrone.capabilities` declara `VELOCITY_BODY` (`move_velocity` em frame do corpo via
+`cmd_vel`) e `NATIVE_RTL` (`navigate_home`). Ele **não** suporta controle de posição, GPS,
+vision pose, parâmetros, ou navegação do lado do companion. Consulte com
+`drone.supports(Capability.VELOCITY_BODY)`.
+
+Comportamentos específicos do hardware Bebop:
+
+- **A velocidade é apenas em frame do corpo**, normalizada para `[-1, 1]`; as referências
+  `WORLD`/`TAKEOFF` não são suportadas.
+- **A altitude de takeoff é fixa** — o argumento `altitude` de `takeoff()` é ignorado (o
+  Bebop sobe até sua altura predefinida; ajuste depois com `move_velocity(vz=...)`).
+- `move_to()` / `move_to_gps()` levantam `CapabilityNotSupportedError` (sem posicionamento
+  onboard — sem GPS, sem PID do companion).
+- `connect()` apenas verifica se o processo `bebop_driver` está em execução; não há
+  handshake com um controlador de voo.
+- `rtl()` publica o comando autoflight `navigate_home`; com `land=True` ele aguarda um
+  delay fixo pela manobra (ele **não** chama `land()`).
+
+## Arquitetura
+
+```mermaid
+classDiagram
+    class BebopDrone {
+        -_takeoff_pub Publisher~Empty~
+        -_land_pub Publisher~Empty~
+        -_vel_pub Publisher~Twist~
+        -_flip_pub Publisher~UInt8~
+        -_gimbal_pub Publisher~Vector3~
+        -_emergency_pub Publisher~Empty~
+        -_flattrim_pub Publisher~Empty~
+        -_photo_pub Publisher~Bool~
+        -_navigate_home_pub Publisher~Empty~
+        +config BebopConfig
+        +node Node
+        +is_ready bool
+        +obstacle_manager ObstacleManager
+        +from_config(config, executor)$ BebopDrone
+        +connect() bool
+        +disconnect()
+        +arm() bool
+        +disarm() bool
+        +takeoff(altitude) bool
+        +land(timeout) bool
+        +move_velocity(vx, vy, vz, vyaw, duration, reference)
+        +move_to() CapabilityNotSupportedError
+        +move_to_gps() CapabilityNotSupportedError
+        +emergency_stop()
+        +rtl(altitude, precision, method, land) bool
+        +flip(direction)
+        +camera_control(tilt, pan)
+        +snapshot()
+        +flat_trim()
+        -_setup_publishers()
+        -_get_driver_name() str
+        -_start_driver() bool
+    }
+
+    class BebopConfig {
+        <<dataclass>>
+        +name str
+        +start_driver bool
+        +ip str
+        +namespace str
+    }
+
+    class BaseDrone {
+        <<abstract>>
+        +add_obstacle_detector()
+        +enable_obstacle_detector()
+        +cleanup()
+    }
+
+    BaseDrone <|-- BebopDrone
+    BebopDrone o-- BebopConfig
+```
+
+## Configuração
+
+```python
+from nectar.control import DroneFactory, BebopConfig
+
+config = BebopConfig(
+    name="bebop_drone",
+    start_driver=True,        # auto-start the ROS 2 driver on init
+    ip="192.168.42.1",        # Bebop WiFi IP
+    namespace="bebop",        # ROS 2 topic namespace prefix
+)
+drone = DroneFactory.create("bebop", config)
+```
+
+O Bebop cria sua própria rede WiFi — conecte-se a `Bebop2-XXXXXX` (IP padrão
+`192.168.42.1`) antes de iniciar o driver.
+
+## API de Controle
+
+### Controle de Velocidade
+
+```python
+drone.move_velocity(
+    vx=0.0,    # forward (+) / backward (-), normalized [-1, 1]
+    vy=0.0,    # left (+) / right (-), normalized [-1, 1]
+    vz=0.0,    # up (+) / down (-), normalized [-1, 1]
+    vyaw=0.0,  # CCW (+) / CW (-), normalized [-1, 1]
+    duration=None,                 # None = single publish; float = republish at 30 Hz for the duration
+    reference=MoveReference.BODY,  # BODY only
+)
+```
+
+Todas as entradas são limitadas a `[-1, 1]`.
+
+### Operações de Voo
+
+```python
+drone.takeoff(altitude=1.5)   # altitude ignored (fixed height)
+drone.land(timeout=30.0)
+drone.rtl(land=True)          # autoflight navigate_home
+drone.emergency_stop()        # reset command (hard stop)
+```
+
+### Recursos Específicos do Bebop
+
+```python
+drone.flip(0)                                # 0=Front, 1=Back, 2=Right, 3=Left
+drone.camera_control(tilt=-45.0, pan=15.0)   # degrees; tilt +down/-up, pan +left/-right
+drone.snapshot()                             # capture a photo
+drone.flat_trim()                            # IMU calibration (on a flat, level surface)
+```
+
+## Tópicos ROS 2
+
+Todos os tópicos usam o prefixo de namespace configurado (padrão `/bebop`):
+
+| Tópico | Tipo | Finalidade |
+|-------|------|---------|
+| `/{ns}/takeoff` | Empty | Dispara o takeoff |
+| `/{ns}/land` | Empty | Dispara o pouso |
+| `/{ns}/cmd_vel` | Twist | Comandos de velocidade (`linear.x/y/z`, `angular.z`, cada um `[-1, 1]`) |
+| `/{ns}/flip` | UInt8 | Executa a manobra de flip |
+| `/{ns}/move_camera` | Vector3 | Controle do gimbal (x=tilt, y=pan) |
+| `/{ns}/reset` | Empty | Parada de emergência / reset |
+| `/{ns}/flattrim` | Empty | Calibração da IMU |
+| `/{ns}/photo` | Bool | Captura uma foto |
+| `/{ns}/autoflight/navigate_home` | Empty | Comando de RTL |
+
+## Instalação
+
+**Automatizada (Nectar)**:
+
+```bash
+make drone-bebop            # or: ./scripts/setup.sh drone bebop
+```
+
+Instala as dependências apt, clona `ros2_parrot_arsdk` e `ros2_bebop_driver` no
+workspace se estiverem faltando, e os builda na ordem correta (aplicando o patch do
+FFmpeg abaixo). Os passos manuais equivalentes são:
+
+```bash
+sudo apt install ros-${ROS_DISTRO}-camera-info-manager ros-${ROS_DISTRO}-image-transport \
+  ros-${ROS_DISTRO}-cv-bridge libavdevice-dev libavahi-client-dev python-is-python3
+cd ~/ros2_ws/src
+git clone https://github.com/jeremyfix/ros2_parrot_arsdk.git
+git clone https://github.com/jeremyfix/ros2_bebop_driver.git
+cd ~/ros2_ws
+colcon build --packages-select ros2_parrot_arsdk
+colcon build --packages-select ros2_bebop_driver --symlink-install
+```
+
+- `python-is-python3` é necessário porque o build Alchemy do ARSDK invoca `python`, que
+  está ausente por padrão no Ubuntu 24.04.
+- No Ubuntu 24.04 (FFmpeg 5/6), `avcodec_find_decoder()` retorna `const AVCodec*`, então
+  `AVCodec *p_codec_` precisa se tornar `const AVCodec *p_codec_` em
+  `include/ros2_bebop_driver/video_decoder.hpp`. O `make drone-bebop` aplica esse patch
+  automaticamente.
+
+Launch manual (quando `start_driver=False`):
+
+```bash
+ros2 launch ros2_bebop_driver bebop_node_launch.xml ip:=192.168.42.1
+```
+
+## Exemplo de Uso
+
+```python
+import nectar
+from nectar.control import DroneFactory, BebopConfig
+
+nectar.init()
+drone = DroneFactory.create("bebop", BebopConfig(ip="192.168.42.1"))
+drone.connect()                              # verifies the bebop_driver process
+
+drone.takeoff(altitude=1.5)                  # fixed height
+drone.move_velocity(vx=0.3, duration=2.0)    # forward 2s
+drone.move_velocity(vyaw=0.5, duration=1.0)  # rotate CCW 1s
+drone.flip(0)                                # front flip
+drone.rtl(land=True)                         # navigate home
+```
+
+## Referências
+
+- [ros2_bebop_driver](https://github.com/jeremyfix/ros2_bebop_driver) · [ros2_parrot_arsdk](https://github.com/jeremyfix/ros2_parrot_arsdk)
+- [Especificações do Parrot Bebop 2](https://www.parrot.com/en/support/documentation/bebop-range) · [Bebop Commands and Events](https://developer.parrot.com/docs/bebop/index.html?c#commands-and-events) · [Documentação do ARSDK](https://developer.parrot.com/docs/SDK3/)

--- a/i18n/pt/modules/control/crazyflie.md
+++ b/i18n/pt/modules/control/crazyflie.md
@@ -1,0 +1,514 @@
+# Módulo de Controle do Crazyflie
+
+Controle do drone [Bitcraze Crazyflie 2.x](https://www.bitcraze.io/products/crazyflie-2-1/)
+via [Crazyswarm2](https://imrclab.github.io/crazyswarm2/) para ROS 2 — o mesmo protocolo
+`Drone` usado pelos drones com FCU, mas sobre uma bridge Crazyswarm2 em vez de MAVROS.
+
+## Resumo rápido
+
+```python
+import nectar
+from nectar.control import DroneFactory, CrazyflieConfig
+
+nectar.init()
+drone = DroneFactory.create("crazyflie", CrazyflieConfig(cf_name="cf231"))
+
+drone.takeoff(altitude=0.5)
+drone.move_to(x=0.5, y=0.0, z=0.0)   # POSITION via the onboard goTo planner
+drone.land()
+nectar.shutdown()
+```
+
+## Capacidades
+
+`CrazyflieDrone.capabilities` declara `LOCAL_SETPOINT` (`move_to` POSITION via o planner
+onboard `goTo`), `VELOCITY_BODY`/`VELOCITY_WORLD`/`VELOCITY_TAKEOFF` (`move_velocity` via
+streaming) e `PARAMS` (acesso a parâmetros do firmware). Não suporta navegação por GPS,
+PID do lado do companion, vision pose, telemetria de rangefinder, controle de servo, ou
+RTL nativo. Consulte com `drone.supports(Capability.LOCAL_SETPOINT)`.
+
+## Conceitos Principais
+
+### Crazyswarm2
+
+O [Crazyswarm2](https://github.com/IMRCLab/crazyswarm2) é um stack ROS 2 para controlar
+drones Crazyflie. Ele fornece um node `crazyflie_server` que trata a comunicação de rádio
+via [Crazyradio PA/2](https://www.bitcraze.io/products/crazyradio-pa/), a sincronização de
+parâmetros do firmware, o streaming de log variables, e expõe comandos de voo como
+serviços e tópicos ROS 2.
+
+Este SDK usa o Crazyswarm2 como bridge de comunicação — o mesmo padrão usado pelo MAVROS
+para ArduPilot/PX4 e pelo `ros2_bebop_driver` para o Parrot Bebop. A classe
+`CrazyflieDrone` se comunica exclusivamente via ROS 2, nunca diretamente com o rádio do
+Crazyflie.
+
+### Comandos de Alto Nível vs Baixo Nível
+
+O firmware do Crazyflie tem dois modos de comando:
+
+| Modo | Comandos | Descrição |
+|------|----------|-------------|
+| **Alto nível** | `takeoff`, `land`, `goTo`, `startTrajectory` | Planner polinomial onboard. Define o alvo e a duração, o firmware planeja uma trajetória suave. |
+| **Baixo nível (streaming)** | `cmdFullState`, `cmdPosition` | Setpoints diretos em alta frequência (~50Hz). O firmware rastreia o setpoint. |
+
+Trocar de streaming para alto nível exige chamar `notify_setpoints_stop()`. O SDK trata
+isso automaticamente em `move_to()`, `land()`, e `go_to()` quando precedidos por comandos
+de streaming.
+
+### Flow Deck v2
+
+O [Flow Deck v2](https://www.bitcraze.io/products/flow-deck-v2/) fornece estimativa de
+posição relativa usando:
+
+- **Sensor de fluxo óptico**: rastreia o movimento sobre a superfície do solo
+- **Rangefinder ToF**: mede a altura em relação ao solo (alcance ~0,2m a ~4m)
+
+O [estimador Kalman](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/functional-areas/sensor-to-control/state_estimators/)
+(EKF) onboard funde esses sensores com a IMU para produzir estimativas de posição.
+
+**Restrições**:
+
+- A posição deriva com o tempo (sem referência absoluta)
+- Exige uma superfície de piso texturizada para o fluxo óptico
+- Altura máxima prática de voo ~3m (limite de alcance do ToF)
+- A proximidade de paredes pode confundir as leituras do ToF (detecção em formato de cone)
+
+### Controlador Onboard
+
+O Crazyflie suporta dois controladores onboard:
+
+- **PID** (`controller=1`): controlador PID em cascata padrão
+- **Mellinger** (`controller=2`): controlador de tracking geométrico para manobras
+  agressivas
+
+A seleção do controlador é um parâmetro de firmware definido na inicialização via
+`CrazyflieConfig.controller`.
+
+## Arquitetura
+
+```mermaid
+classDiagram
+    class CrazyflieDrone {
+        -_status Optional~Status~
+        -_pose Optional~PoseStamped~
+        -_position List~float~
+        -_takeoff_position Optional~List~float~~
+        -_takeoff_yaw float
+        -_in_streaming_mode bool
+        -_prefix str
+        +is_armed Optional~bool~
+        +is_flying bool
+        +is_tumbled bool
+        +can_fly bool
+        +battery_voltage Optional~float~
+        +rssi Optional~int~
+        +capabilities frozenset~Capability~
+        +pose Optional~PoseStamped~
+        +position List~float~
+        +height float
+        +from_config(config, executor)$ CrazyflieDrone
+        +connect() bool
+        +arm() bool
+        +disarm() bool
+        +takeoff(altitude, duration) bool
+        +land(timeout, duration) bool
+        +move_velocity(vx, vy, vz, vyaw, duration, reference)
+        +move_to(x, y, z, yaw, reference, timeout, precision, method, altitude_source) bool
+        +emergency_stop()
+        +rtl(altitude, precision, method, land) bool
+        +go_to(goal, yaw, duration, relative)
+        +cmd_full_state(pos, vel, acc, yaw, omega)
+        +cmd_position(pos, yaw)
+        +notify_setpoints_stop(remain_valid_ms)
+        +upload_trajectory(trajectory_id, pieces)
+        +start_trajectory(trajectory_id, timescale, reverse, relative)
+        +set_firmware_param(name, value)
+        +get_firmware_param(name)
+        +set_group_mask(group_mask)
+    }
+
+    class CrazyflieConfig {
+        <<dataclass>>
+        +name str
+        +start_driver bool
+        +uri str
+        +cf_name str
+        +controller int
+        +estimator int
+        +default_velocity float
+        +landing_height float
+        +max_height float
+        +enable_logging bool
+        +log_pose_frequency int
+        +backend str
+        +mocap bool
+    }
+
+    class BaseDrone {
+        <<abstract>>
+    }
+
+    BaseDrone <|-- CrazyflieDrone
+    CrazyflieDrone o-- CrazyflieConfig
+```
+
+## CrazyflieDrone
+
+### Inicialização
+
+```python
+from nectar.control import DroneFactory, CrazyflieConfig
+
+config = CrazyflieConfig(
+    cf_name="cf231",                   # Robot name in crazyflies.yaml
+    uri="radio://0/80/2M/E7E7E7E7E7",  # Crazyradio URI
+    controller=2,                       # 1=PID, 2=Mellinger
+    estimator=2,                        # 2=Kalman (required for Flow Deck)
+    default_velocity=0.3,               # m/s for goTo duration estimation
+    max_height=3.0,                     # Flow Deck v2 ToF limit
+)
+
+drone = DroneFactory.create("crazyflie", config)
+```
+
+### Propriedades
+
+```python
+drone.is_armed             # Optional[bool]: Motor arm state from supervisor
+drone.is_flying            # bool: Whether currently in flight
+drone.is_tumbled           # bool: Crash detection
+drone.can_fly              # bool: Ready for flight commands
+drone.battery_voltage      # Optional[float]: Battery voltage (V)
+drone.rssi                 # Optional[int]: Radio signal strength (dBm)
+drone.pose                 # Optional[PoseStamped]: Full estimated pose
+drone.position             # List[float]: Current [x, y, z] in meters
+drone.height               # float: Current height above ground (m)
+```
+
+### Operações de Voo
+
+```python
+drone.connect()                        # Wait for status, verify connection
+drone.takeoff(altitude=0.5)            # Takeoff to 0.5m (duration auto-estimated)
+drone.takeoff(altitude=0.5, duration=2.0)  # Explicit duration
+
+drone.move_to(x=0.5, y=0.0, z=0.0)    # 0.5m forward (BODY); POSITION method (default, only option)
+drone.move_to(x=1.0, reference=MoveReference.TAKEOFF)  # 1m forward of takeoff
+
+drone.move_velocity(vx=0.2, duration=2.0)  # Streaming velocity for 2 seconds
+
+drone.land()                            # Land from current height
+drone.emergency_stop()                  # Hard kill (requires reboot)
+drone.rtl()                             # Return to takeoff (NAVIGATE method, default) and land
+```
+
+### Recursos Específicos do Crazyflie
+
+#### Comando GoTo Direto
+
+```python
+drone.go_to(goal=[1.0, 0.0, 0.5], yaw=0.0, duration=3.0, relative=False)
+```
+
+#### Trajetórias Polinomiais
+
+```python
+drone.upload_trajectory(0, trajectory_pieces)
+drone.start_trajectory(0, timescale=1.0, relative=True)
+```
+
+#### Streaming Full-State
+
+```python
+drone.cmd_full_state(
+    pos=[0.0, 0.0, 0.5],
+    vel=[0.1, 0.0, 0.0],
+    acc=[0.0, 0.0, 0.0],
+    yaw=0.0,
+    omega=[0.0, 0.0, 0.0],
+)
+
+# After streaming, before high-level commands:
+
+drone.notify_setpoints_stop()
+```
+
+#### Parâmetros de Firmware
+
+```python
+drone.set_firmware_param("stabilizer.controller", 2)   # Switch to Mellinger
+drone.set_firmware_param("ring.effect", 7)              # Solid LED color
+drone.get_firmware_param("stabilizer.controller")       # Read current value
+```
+
+#### Group Mask do Swarm
+
+```python
+drone.set_group_mask(1)  # Assign to group 1 for broadcast commands
+```
+
+## API de Movimento
+
+### Frames de Referência
+
+| MoveReference | Mapeamento no goTo | Descrição |
+|---------------|-------------|-------------|
+| **BODY** | Offset rotacionado pelo yaw atual, enviado como absoluto | Relativo à posição e ao heading atuais |
+| **WORLD** | Coordenadas absolutas | Alvo direto em frame do mundo |
+| **TAKEOFF** | Offset rotacionado pelo yaw do takeoff, enviado como absoluto | Relativo à posição e ao heading do takeoff |
+
+**Importante**: o `goTo(relative=True)` do Crazyswarm2 é alinhado ao mundo (não relativo ao
+heading). O SDK rotaciona os offsets BODY pelo yaw atual para produzir o comportamento
+correto relativo ao heading.
+
+### Estimativa de Duração
+
+O serviço `goTo` do Crazyflie exige um parâmetro `duration` explícito. Para `move_to`, o
+SDK estima esse valor a partir tanto da distância percorrida quanto da mudança de yaw:
+
+```
+yaw_duration = yaw_diff / radians(60)              # ~60 deg/s
+duration = max(distance / default_velocity, yaw_duration, 1.0)
+```
+
+Onde `default_velocity` vem do `CrazyflieConfig` (padrão 0.3 m/s). O takeoff usa uma
+duração mínima de 2.0 s; o land usa 1.0 s. Para controle preciso de timing, use o método
+`go_to()` diretamente.
+
+### Controle de Velocidade
+
+`move_velocity()` usa setpoints de streaming `cmd_full_state`. Isso muda o Crazyflie para
+o modo de baixo nível. O SDK chama `notify_setpoints_stop()` automaticamente ao voltar
+para comandos de alto nível.
+
+### Métodos de navegação (`move_to` / `rtl`)
+
+`move_to` aceita `method: NavigationMethod` (padrão `NavigationMethod.POSITION`). O
+**CrazyflieDrone só suporta `NavigationMethod.POSITION`** (`goTo` onboard de alto nível).
+`NavigationMethod.PID`, `NavigationMethod.PID_EKF`, e `NavigationMethod.POSITION_GLOBAL`
+levantam `CapabilityNotSupportedError`.
+
+`rtl` aceita `method: RTLMethod` (padrão `RTLMethod.NAVIGATE`). O **CrazyflieDrone só
+suporta `RTLMethod.NAVIGATE`** (mesmo caminho baseado em goTo que `move_to`, até a pose de
+takeoff). `RTLMethod.NATIVE` levanta `CapabilityNotSupportedError`.
+
+### Matriz de Capacidades
+
+| Método | Suportado | Notas |
+|--------|-----------|-------|
+| `takeoff` | Sim | Commander onboard de alto nível |
+| `land` | Sim | Commander onboard de alto nível |
+| `move_to` | Sim | Somente `NavigationMethod.POSITION` (goTo); outros métodos levantam `CapabilityNotSupportedError`; todos os frames de `MoveReference` são suportados |
+| `move_velocity` | Sim | Via streaming cmd_full_state |
+| `move_to_gps` | Não | Sem GPS no Crazyflie 2.x |
+| `rtl` | Sim | Somente `RTLMethod.NAVIGATE` (goTo até a posição de takeoff); `RTLMethod.NATIVE` levanta `CapabilityNotSupportedError` |
+| `emergency_stop` | Sim | Hard kill, exige reboot |
+| `set_home` | Não | Sem GPS |
+
+## Interface ROS 2
+
+### Serviços (por robô: `/<cf_name>/...`)
+
+| Serviço | Tipo | Finalidade |
+|---------|------|---------|
+| `/<cf>/emergency` | `std_srvs/Empty` | Mata os motores, trava o firmware |
+| `/<cf>/takeoff` | `crazyflie_interfaces/Takeoff` | Voa até a altura em uma duração |
+| `/<cf>/land` | `crazyflie_interfaces/Land` | Desce até a altura em uma duração |
+| `/<cf>/go_to` | `crazyflie_interfaces/GoTo` | Navegação polinomial suave |
+| `/<cf>/upload_trajectory` | `crazyflie_interfaces/UploadTrajectory` | Envia um polinômio por partes |
+| `/<cf>/start_trajectory` | `crazyflie_interfaces/StartTrajectory` | Executa a trajetória enviada |
+| `/<cf>/notify_setpoints_stop` | `crazyflie_interfaces/NotifySetpointsStop` | Encerra o modo streaming |
+| `/<cf>/arm` | `crazyflie_interfaces/Arm` | Arma/desarma (Bolt/brushless) |
+
+### Tópicos
+
+| Tópico | Tipo | Direção | Finalidade |
+|-------|------|-----------|---------|
+| `/<cf>/cmd_full_state` | `crazyflie_interfaces/FullState` | Pub | Setpoint full-state em streaming |
+| `/<cf>/cmd_position` | `crazyflie_interfaces/Position` | Pub | Setpoint de posição em streaming |
+| `/<cf>/pose` | `geometry_msgs/PoseStamped` | Sub | Pose estimada pelo state estimator |
+| `/<cf>/status` | `crazyflie_interfaces/Status` | Sub | Bateria, RSSI, estado do supervisor |
+| `/tf` | `tf2_msgs/TFMessage` | Sub | Pose de simulação quando `backend:=sim` (o Crazyswarm2 publica o TF do modelo aqui; `connect()` espera por esse caminho em vez de `/<cf>/pose`) |
+
+### Parâmetros (via crazyflie_server)
+
+Os parâmetros do firmware são expostos como parâmetros ROS 2 no `/crazyflie_server` sob
+`<cf_name>.params.<group>.<name>`. Exemplos:
+
+- `cf231.params.stabilizer.controller` (1=PID, 2=Mellinger)
+- `cf231.params.stabilizer.estimator` (1=complementary, 2=kalman)
+- `cf231.params.commander.enHighLevel` (1=enable high-level commander)
+
+## Instalação
+
+**Automatizada (Nectar)**:
+
+```bash
+make drone-crazyflie        # or: ./scripts/setup.sh drone crazyflie
+```
+
+Instala os pacotes apt abaixo (quando disponíveis para sua distro ROS) mais o `rowan`, e
+configura as permissões USB do Crazyradio (passo 2). Depois disso só o `crazyflies.yaml`
+(passo 3) precisa ser editado com sua URI de rádio. Faça logout e login de novo uma vez
+para que a mudança de grupo `plugdev` seja aplicada.
+
+### 1. Instalar o Crazyswarm2
+
+**Binário (recomendado)**:
+
+```bash
+sudo apt install ros-${ROS_DISTRO}-crazyflie ros-${ROS_DISTRO}-crazyflie-interfaces
+pip3 install rowan
+```
+
+**A partir do source**:
+
+```bash
+cd ~/ros2_ws/src
+git clone https://github.com/IMRCLab/crazyswarm2 --recursive
+cd ~/ros2_ws
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+```
+
+### 2. Configurar as Permissões USB do Crazyradio
+
+```bash
+sudo groupadd plugdev
+sudo usermod -a -G plugdev $USER
+cat <<EOF | sudo tee /etc/udev/rules.d/99-bitcraze.rules
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="7777", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="0101", MODE="0664", GROUP="plugdev"
+EOF
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+Faça logout e login de novo para que as mudanças de grupo tenham efeito.
+
+### 3. Configurar o crazyflies.yaml
+
+Edite o arquivo de configuração do Crazyswarm2 (tipicamente em
+`<crazyswarm2_ws>/src/crazyswarm2/crazyflie/config/crazyflies.yaml`):
+
+```yaml
+robots:
+    cf231:
+        enabled: true
+        uri: radio://0/80/2M/E7E7E7E7E7
+        initial_position: [0, 0, 0]
+        type: cf21
+
+robot_types:
+    cf21:
+        motion_capture:
+            enabled: false
+        big_quad: false
+        battery:
+            voltage_warning: 3.8
+            voltage_critical: 3.7
+
+all:
+    firmware_logging:
+        enabled: true
+        default_topics:
+            pose:
+                frequency: 10
+    firmware_params:
+        commander:
+            enHighLevel: 1
+        stabilizer:
+            estimator: 2  # Kalman (required for Flow Deck)
+            controller: 2  # Mellinger
+```
+
+### 4. Verificar a Conexão
+
+**Terminal 1 — servidor Crazyflie**:
+
+```bash
+ros2 launch crazyflie launch.py
+```
+
+**Terminal 2 — verificar os tópicos**:
+
+```bash
+ros2 topic list | grep cf231
+ros2 topic echo /cf231/status
+```
+
+## Exemplos de Uso
+
+### Voo Básico
+
+```python
+import nectar
+from nectar.control import DroneFactory, CrazyflieConfig
+
+nectar.init()
+drone = DroneFactory.create("crazyflie", CrazyflieConfig())
+drone.connect()
+
+drone.takeoff(altitude=0.5)
+drone.move_to(x=0.3, y=0.0, z=0.0)
+drone.move_to(x=0.0, y=0.3, z=0.0)
+drone.rtl()
+```
+
+### Controle de Velocidade
+
+```python
+drone.takeoff(altitude=0.5)
+
+# Fly forward for 2 seconds
+
+drone.move_velocity(vx=0.2, duration=2.0)
+
+# Fly in a circle-like pattern
+
+for _ in range(20):
+    drone.move_velocity(vx=0.2, vyaw=0.5, duration=0.1)
+
+# Transition back to high-level for landing
+
+drone.land()
+```
+
+### Simulação
+
+**Terminal 1 — backend de simulação**:
+
+```bash
+ros2 launch crazyflie launch.py backend:=sim
+```
+
+**Terminal 2 — executar um script** (mesmo código):
+
+```bash
+python3 basic.py --drone crazyflie --backend sim
+```
+
+## O que é distinto no Crazyflie
+
+Para os conjuntos de capacidades declarados em todos os drones, veja a
+[matriz de capacidades do módulo control](../#capacidades). Características específicas
+do Crazyflie:
+
+- O controle de posição é **somente onboard** (`NavigationMethod.POSITION` via o planner
+  `goTo` do firmware) — sem PID do lado do companion, GPS, ou caminho de vision-pose.
+- A estimativa de altitude/posição vem do rangefinder ToF do Flow Deck, fundido pelo EKF
+  onboard.
+- Suporta upload + execução de trajetórias polinomiais por partes e streaming
+  FullState/Position a ~50 Hz.
+- A simulação usa o SIL do Crazyswarm2 (bindings de firmware), não o SITL/Gazebo do
+  ArduPilot.
+
+## Referências
+
+- [Documentação do Crazyswarm2](https://imrclab.github.io/crazyswarm2/)
+- [Crazyswarm2 no GitHub](https://github.com/IMRCLab/crazyswarm2)
+- [Página do produto Crazyflie 2.1](https://www.bitcraze.io/products/crazyflie-2-1/)
+- [Flow Deck v2](https://www.bitcraze.io/products/flow-deck-v2/)
+- [Tutorial do Flow Deck](https://www.bitcraze.io/documentation/tutorials/getting-started-with-flow-deck/)
+- [Parâmetros de Firmware do Crazyflie](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/api/params/)
+- [Log Variables de Firmware do Crazyflie](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/api/logs/)
+- [Paper do Crazyswarm2 (v1)](https://doi.org/10.1109/ICRA.2017.7989376)

--- a/i18n/pt/modules/control/index.md
+++ b/i18n/pt/modules/control/index.md
@@ -1,0 +1,570 @@
+# Módulo de Controle de Drones
+
+## Papel
+
+Controle de drones baseado em protocolo (protocol) para ROS 2. `DroneFactory` constrói um drone por chave por meio do protocolo comum `Drone`; cada plataforma implementa a mesma interface (takeoff, land, move_to, move_to_gps, move_velocity, rtl, gerenciamento de obstáculos).
+
+## Índice da documentação {#indice-da-documentacao}
+
+As páginas abaixo detalham cada submódulo:
+
+| README | Escopo |
+|--------|-------|
+| [Vehicle core](vehicle/) | Núcleo do veículo agnóstico a firmware: navegação, frames, takeoff/land, GPS/EGM96, PID, hooks de firmware |
+| [ArduPilot](ardupilot/) | Especialização ArduPilot: arming em GUIDED, `GUID_OPTIONS`/WPNAV, RTL nativo, parâmetros |
+| [PX4](px4/) | Especialização PX4: streaming de setpoint OFFBOARD, AUTO.LAND/RTL; backends MAVROS / MAVLink direto / uXRCE-DDS |
+| [MAVROS transport](mavros/) | Transporte MAVROS (`MavrosDrone`, `Px4MavrosDrone`) |
+| [MAVLink transport](mavlink/) | Transporte pymavlink neutro em relação a firmware (`MavlinkDrone`, `Px4MavlinkDrone`) |
+| [Localization](localization/) | Navegação externa (external-nav) por VSLAM indoor: arquitetura, Run, FCU, SOP indoor |
+| [Localization concepts](localization/concepts/) | Teoria de SLAM / VIO / V-SLAM e fusão com o FCU |
+| [Legacy T265](localization/legacy/) | Histórico do T265 + `vision_to_mavros` |
+| [Obstacles](obstacles/) | Detecção de obstáculos + estratégias de desvio de obstáculos |
+| [PID](pid/) | Controlador PID e ajuste (tuning) |
+| [Bebop](bebop/) | Parrot Bebop 2 (`BebopDrone`) |
+| [Crazyflie](crazyflie/) | Bitcraze Crazyflie (`CrazyflieDrone`) |
+
+## Resumo rápido
+
+```python
+import nectar
+from nectar.control import DroneFactory, MavrosConfig, PoseSource
+
+nectar.init()
+drone = DroneFactory.create("mavros", MavrosConfig(pose_source=PoseSource.GPS))
+
+drone.takeoff(altitude=2.0)
+drone.move_to(x=5.0, y=0.0, z=0.0, precision=0.3)   # same calls on every backend
+drone.land()
+nectar.shutdown()
+```
+
+Escolha um backend pela chave — `mavros`, `mavlink`, `px4`, `px4_mavlink`, `px4_dds`, `bebop`,
+`crazyflie` — com o config correspondente; as chamadas de voo permanecem as mesmas.
+
+Lado a lado com MAVROS / pymavlink puro:
+[Com e sem Nectar](../../get-started/with-without.md)
+([with-without.md](../../get-started/with-without/)).
+
+## Conceitos
+
+ArduPilot e PX4 compartilham um único núcleo agnóstico a firmware (`VehicleDrone`) e alcançam o
+FCU por meio de transportes intercambiáveis (MAVROS, MAVLink direto, PX4 uXRCE-DDS); Bebop e
+Crazyflie implementam o protocolo `Drone` diretamente.
+
+```mermaid
+classDiagram
+    class DroneFactory {
+        <<singleton>>
+        -_builders Dict~str,BuilderFunc~
+        +create(type, config, executor) Drone
+        +register(type, factory_func)
+        +available_types() list~str~
+        +is_registered(type) bool
+    }
+
+    class Drone {
+        <<protocol>>
+        +is_ready bool
+        +connect() bool
+        +disconnect()
+        +arm() bool
+        +disarm() bool
+        +takeoff(altitude) bool
+        +land(timeout) bool
+        +move_velocity(vx, vy, vz, vyaw, duration, reference)
+        +move_to(x, y, z, yaw, reference, timeout, precision, method) bool
+        +move_to_gps(lat, lon, alt, heading, timeout, precision, method) bool
+        +emergency_stop()
+        +set_home() bool
+        +rtl(altitude, precision, method, land) bool
+    }
+
+    class BaseDrone {
+        <<abstract>>
+        -_config DroneConfig
+        -_node Node
+        -_connected bool
+        -_driver_running bool
+        -_obstacle_manager ObstacleManager
+        -_subscribers List~Subscription~
+        -_publishers List~Publisher~
+        -_clients List~Client~
+        -_callback_group ReentrantCallbackGroup
+        +config DroneConfig
+        +node Node
+        +is_ready bool
+        +driver_running bool
+        +is_armed Optional~bool~
+        +flight_mode Optional~str~
+        +is_fcu_connected Optional~bool~
+        +driver_session_name str
+        +obstacle_manager ObstacleManager
+        +add_obstacle_detector(name, detector, strategy, config)
+        +remove_obstacle_detector(name)
+        +enable_obstacle_detector(name)
+        +disable_obstacle_detector(name)
+        +enable_all_obstacle_detectors()
+        +disable_all_obstacle_detectors()
+        +check_driver_status() bool
+        +start_driver_process() bool
+        +stop_driver_process() bool
+        +delay(seconds)
+        +cleanup()
+        #_init_driver()
+        #_wait_for_driver(timeout) bool
+        #_create_subscriber(msg_type, topic, callback, qos) Subscription
+        #_create_publisher(msg_type, topic, qos) Publisher
+        #_create_client(srv_type, service_name) Client
+        #_get_driver_name()* str
+        #_start_driver()* bool
+        #_get_driver_command()* str
+    }
+
+    class VehicleDrone {
+        <<abstract>>
+        -_transport VehicleTransport
+        -_navigator VehicleNavigator
+        -_sequencer FlightSequencer
+        -_pid_config Optional~PositionPIDConfig~
+        -_setpoint_config Optional~SetpointConfig~
+        -_takeoff_position Optional
+        -_pose_source PoseSource
+        +is_indoor bool
+        +is_armed flight_mode is_fcu_connected
+        +gps heading rel_alt
+        +local_pose vision_pose Optional~LocalPose~
+        +lidar_available bool
+        +position position_as_target
+        +get_altitude(source) Optional~float~
+        +distance_sensors get_distance(orientation)
+        +takeoff() land() move_to() move_to_gps() move_velocity() rtl()
+        +set_mode() set_param() set_speed() set_home()
+        +set_actuator() set_gripper()
+        +set_takeoff_position() set_pid_config() set_setpoint_config()
+        +arm()* _rtl_native()* _change_speed()* capabilities*
+    }
+
+    class ArduPilotDrone {
+        GUIDED arm, GUID_OPTIONS/WPNAV
+        native RTL, do_servo, DO_CHANGE_SPEED
+    }
+
+    class Px4Drone {
+        OFFBOARD + setpoint pump
+        AUTO.LAND/RTL, MPC_* speed
+    }
+
+    class MavrosDrone {
+        +from_config(config, executor)$ MavrosDrone
+    }
+
+    class MavlinkDrone {
+        +connection MavlinkConnection
+        +from_config(config, executor)$ MavlinkDrone
+    }
+
+    class Px4MavrosDrone {
+        +from_config(config, executor)$ Px4MavrosDrone
+    }
+
+    class Px4MavlinkDrone {
+        +connection MavlinkConnection
+        +from_config(config, executor)$ Px4MavlinkDrone
+    }
+
+    class Px4DdsDrone {
+        +from_config(config, executor)$ Px4DdsDrone
+    }
+
+    class CrazyflieDrone {
+        +from_config(config, executor)$ CrazyflieDrone
+    }
+
+    class VehicleTransport {
+        <<abstract>>
+        +state local_pose vision_pose gps heading rel_alt rangefinder distance_sensors
+        +arm() set_mode() command_takeoff() command_land() set_param()
+        +send_velocity_target() send_local_target() send_global_target()
+    }
+
+    class MavrosTransport
+    class PymavlinkTransport
+    class Px4DdsTransport
+
+    class BebopDrone {
+        +from_config(config, executor)$ BebopDrone
+        +flip(direction)
+        +camera_control(tilt, pan)
+        +snapshot()
+        -_setup_publishers()
+    }
+
+    class DroneConfig {
+        <<dataclass>>
+        +name str
+        +start_driver bool
+    }
+
+    class MavrosConfig {
+        <<dataclass>>
+        +pose_source PoseSource
+        +expect_lidar bool
+        +sensor_timeout float
+        +connection_string str
+        +pid_config_file setpoint_config_file Optional~str~
+        +apply_setpoint_params bool
+        +state_topic gps_topic vision_topic str
+        +heading_topic rel_alt_topic lidar_topic str
+        +local_position_topic str
+    }
+
+    class MavlinkConfig {
+        <<dataclass>>
+        +pose_source PoseSource
+        +expect_lidar bool
+        +connection_string str
+        +baud source_system source_component int
+        +rx_rate_hz heartbeat_hz vision_rate_hz float
+        +stream_rates Optional~Dict~
+        +vision_pose_topic str
+        +pid_config_file setpoint_config_file Optional~str~
+        +apply_setpoint_params bool
+    }
+
+    class BebopConfig {
+        <<dataclass>>
+        +name str
+        +start_driver bool
+        +ip str
+        +namespace str
+    }
+
+    class Px4MavrosConfig {
+        <<dataclass>>
+        +pose_source PoseSource
+        +offboard_rate_hz float
+        +mavros_launch str
+        +connection_string str
+        +shares MavrosConfig telemetry topics
+    }
+
+    class Px4MavlinkConfig {
+        <<dataclass>>
+        +pose_source PoseSource
+        +offboard_rate_hz float
+        +connection_string str
+        +shares MavlinkConfig link settings
+    }
+
+    class Px4DdsConfig {
+        <<dataclass>>
+        +pose_source PoseSource
+        +offboard_rate_hz float
+        +px4_namespace str
+        +agent_port int
+        +local_position_topic status_topic global_position_topic str
+    }
+
+    class ObstacleManager {
+        -_handlers dict~str,ObstacleHandler~
+        +add(name, handler) remove(name) get(name)
+        +enable(name) disable(name) enable_all() disable_all()
+        +should_continue_navigation(drone) bool
+        +get_axis_control() tuple~bool,bool,bool~
+        +reset_all() cleanup()
+    }
+
+    DroneFactory --> BaseDrone : creates
+    Drone <|.. BaseDrone : implements
+    BaseDrone <|-- VehicleDrone
+    BaseDrone <|-- BebopDrone
+    BaseDrone <|-- CrazyflieDrone
+    VehicleDrone <|-- ArduPilotDrone
+    VehicleDrone <|-- Px4Drone
+    VehicleDrone o-- VehicleTransport
+    ArduPilotDrone <|-- MavrosDrone
+    ArduPilotDrone <|-- MavlinkDrone
+    Px4Drone <|-- Px4MavrosDrone
+    Px4Drone <|-- Px4MavlinkDrone
+    Px4Drone <|-- Px4DdsDrone
+    VehicleTransport <|.. MavrosTransport
+    VehicleTransport <|.. PymavlinkTransport
+    VehicleTransport <|.. Px4DdsTransport
+    MavrosDrone ..> MavrosTransport : builds
+    MavlinkDrone ..> PymavlinkTransport : builds
+    Px4MavrosDrone ..> MavrosTransport : builds
+    Px4MavlinkDrone ..> PymavlinkTransport : builds
+    Px4DdsDrone ..> Px4DdsTransport : builds
+    BaseDrone *-- ObstacleManager
+    BaseDrone o-- DroneConfig
+    MavrosDrone o-- MavrosConfig
+    MavlinkDrone o-- MavlinkConfig
+    Px4MavrosDrone o-- Px4MavrosConfig
+    Px4MavlinkDrone o-- Px4MavlinkConfig
+    Px4DdsDrone o-- Px4DdsConfig
+    BebopDrone o-- BebopConfig
+    DroneConfig <|-- MavrosConfig
+    DroneConfig <|-- MavlinkConfig
+    DroneConfig <|-- Px4MavrosConfig
+    DroneConfig <|-- Px4MavlinkConfig
+    DroneConfig <|-- Px4DdsConfig
+    DroneConfig <|-- BebopConfig
+```
+
+## Modelo de runtime
+
+Cada drone possui seu próprio `Node` do ROS 2 (criado internamente com um nome sufixado por UUID). Todos os nós de subsistema do SDK são adicionados a um `MultiThreadedExecutor` compartilhado, gerenciado por [`nectar.runtime`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/runtime.py), que gira (spin) em uma thread de fundo. Chamadas bloqueantes (`takeoff`, `land`, `move_to`) dormem na thread do usuário; o executor continua disparando callbacks (state, pose, GPS, lidar, IMU) sem contenção.
+
+Três padrões de uso compartilham as mesmas primitivas:
+
+- **Script standalone**: `nectar.init()` cria o executor compartilhado de forma lazy e inicia a thread de spin. `DroneFactory.create("mavros", config)` registra o nó do drone nele. Chame `nectar.shutdown()` ao sair.
+- **Missão Yasmin**: chame `nectar.use_executor(YasminNode.get_instance()._executor)` uma vez no início. Os subsistemas do SDK criados depois se registram no executor do Yasmin em vez de criar uma segunda thread de spin.
+- **GUI**: `ROSExecutor.start()` registra seu `MultiThreadedExecutor` em `nectar.runtime`. Drones/handlers criados dentro das abas compartilham esse executor automaticamente.
+
+## Arquitetura de transporte
+
+Os dois firmwares são alcançados por transportes intercambiáveis por meio de um único núcleo. Toda a lógica de voo/navegação vive uma única vez no [`VehicleDrone`](vehicle/), agnóstico a transporte; as especializações de firmware ([`ArduPilotDrone`](ardupilot/), [`Px4Drone`](px4/)) acrescentam somente a semântica do firmware, lendo telemetria e emitindo comandos/setpoints por meio de um `VehicleTransport` plugável:
+
+- `MavrosTransport` — subscriptions → telemetria, service clients → comandos, publishers → setpoints (exige um `mavros_node` em execução). Compartilhado por `MavrosDrone` (ArduPilot) e `Px4MavrosDrone`.
+- `PymavlinkTransport` — possui o link do FCU diretamente (um timer do ROS drena o RX; comandos/setpoints saem via `mav.*_send`). Neutro em relação a firmware: um `MavlinkModeCodec` injetado isola a única diferença de firmware — encode/decode do modo de voo. `ArduPilotModeCodec` (padrão, `SET_MODE`) apoia o `MavlinkDrone`; `Px4ModeCodec` (`MAV_CMD_DO_SET_MODE`) apoia o `Px4MavlinkDrone`. Indoor (`PoseSource.VISION`): a pose do companion vem do tópico VSLAM; o feed do FCU é feito por `vision_pose` externo por padrão (`auto_vision_feed` é opt-in). Veja [MAVLink transport](mavlink/).
+- `Px4DdsTransport` — uORB nativo do PX4 pela ponte uXRCE-DDS (`px4_msgs`), para o `Px4DdsDrone`. Veja [PX4](px4/).
+
+Assim o PX4 oferece três backends (`px4` = MAVROS, `px4_mavlink` = MAVLink direto, `px4_dds` = uXRCE-DDS) e o ArduPilot dois (`mavros`, `mavlink`) — todos compartilhando a mesma lógica de voo do `Px4Drone` / `ArduPilotDrone`, então as missões são agnósticas ao backend.
+
+O núcleo opera sobre tipos simples, sem ROS; cada transporte converte seus tipos on-wire (`mavros_msgs`/`geometry_msgs`, MAVLink puro, ou `px4_msgs`) de/para esses tipos. ENU/FLU e radianos em todo lugar; os transportes tratam a conversão NED/FRD.
+
+### Capacidades
+
+Cada drone declara um `frozenset[Capability]` (veja `capabilities.py`); consulte com `drone.supports(Capability.GPS_NAV)`. Novos drones declaram o que suportam sobrescrevendo a propriedade `capabilities`. Operações não suportadas levantam `CapabilityNotSupportedError`.
+
+Conjuntos declarados por drone (`Sim` = suportado, `—` = não suportado):
+
+| Capacidade | ArduPilot (`mavros`, `mavlink`) | PX4 (`px4`, `px4_mavlink`, `px4_dds`) | Crazyflie | Bebop |
+|------------|:---:|:---:|:---:|:---:|
+| `PID_NAV` | Sim | Sim | — | — |
+| `LOCAL_SETPOINT` | Sim | Sim | Sim | — |
+| `VELOCITY_BODY` | Sim | Sim | Sim | Sim |
+| `VELOCITY_WORLD` | Sim | Sim | Sim | — |
+| `VELOCITY_TAKEOFF` | Sim | Sim | Sim | — |
+| `SERVO` | Sim | — | — | — |
+| `ACTUATOR` | Sim | Sim | — | — |
+| `GRIPPER` | Sim | Sim | — | — |
+| `PARAMS` | Sim | Sim | Sim | — |
+| `NATIVE_RTL` | Sim | Sim | — | Sim |
+| `OBSTACLE_AVOIDANCE` | Sim | Sim | — | — |
+| `RANGEFINDER` | Sim | Sim | — | — |
+| `DISTANCE_SENSORS` | Sim | Sim | — | — |
+| `GPS_NAV` | outdoor | outdoor | — | — |
+| `GLOBAL_SETPOINT` | outdoor | outdoor | — | — |
+| `VISION_POSE` | indoor | indoor | — | — |
+
+`GPS_NAV`/`GLOBAL_SETPOINT` (outdoor) ou `VISION_POSE` (indoor) são selecionados a partir de `pose_source`. O PX4 não tem `SERVO` (sem PWM por canal via `do_servo`) mas mantém `ACTUATOR` (`DO_SET_ACTUATOR`) e `GRIPPER` (`DO_GRIPPER`) para payloads; suas capacidades são idênticas nos três backends PX4.
+
+## Componentes principais
+
+### DroneFactory
+
+Instanciação centralizada de drones com registro de tipos.
+
+**API**:
+
+```python
+DroneFactory.create(drone_type: str, config: DroneConfig,
+                    executor: Optional[Executor] = None) -> BaseDrone
+DroneFactory.register(drone_type: str, factory_func: Callable)
+```
+
+**Tipos suportados**:
+
+| Chave | Firmware / plataforma | Transporte | Classe de config |
+|-----|---------------------|-----------|--------------|
+| `mavros` | ArduPilot | MAVROS | `MavrosConfig` |
+| `mavlink` | ArduPilot | pymavlink direto (sem MAVROS) | `MavlinkConfig` |
+| `px4` | PX4 | MAVROS (streaming de setpoint OFFBOARD) | `Px4MavrosConfig` |
+| `px4_mavlink` | PX4 | pymavlink direto (sem MAVROS) | `Px4MavlinkConfig` |
+| `px4_dds` | PX4 | uXRCE-DDS nativo (`px4_msgs`) | `Px4DdsConfig` |
+| `bebop` | Parrot Bebop 2 | `bebop_driver` (ROS) | `BebopConfig` |
+| `crazyflie` | Bitcraze Crazyflie | Crazyswarm2 | `CrazyflieConfig` |
+
+**Exemplo**:
+
+```python
+import nectar
+from nectar.control import DroneFactory, MavrosConfig, PoseSource
+
+nectar.init()
+config = MavrosConfig(pose_source=PoseSource.VISION)
+drone = DroneFactory.create("mavros", config)   # optional: executor=<your Executor>
+```
+
+### Protocolo Drone
+
+Interface com tipagem estrutural (duck-typed) que define o contrato do drone. Todos os drones devem implementar:
+
+**Operações principais**:
+
+- `connect()`, `disconnect()`: Gerenciamento de conexão
+- `arm()`, `disarm()`: Controle dos motores
+- `takeoff()`, `land()`: Manobras verticais
+- `emergency_stop()`: Parada forçada
+
+**Movimento**:
+
+- `move_velocity()`: Controle direto de velocidade
+- `move_to()`: Navegação por posição
+- `move_to_gps()`: Navegação por waypoint GPS
+- `rtl()`: Retorno ao ponto de lançamento (return-to-launch)
+
+**Estado**:
+
+- `is_ready`: status de conexão e do driver (todos os drones)
+- Drones com FCU (ArduPilot/PX4) também expõem `is_armed`, `flight_mode`, `is_fcu_connected` (veja [Vehicle core](vehicle/)); as demais plataformas expõem seus próprios campos de prontidão
+
+### BaseDrone
+
+Base abstrata que fornece funcionalidade comum.
+
+**Responsabilidades**:
+
+- Ciclo de vida do driver (start, monitor)
+- Gerenciamento de recursos do ROS2 (subscribers, publishers, clients)
+- Integração com o obstacle manager
+- Utilitário de delay com spin do ROS
+
+**Métodos protegidos**:
+
+- `_create_subscriber()`, `_create_publisher()`, `_create_client()`
+- `_init_driver()`, `check_driver_status()`, `_wait_for_driver()`
+- `delay(seconds)`: Delay não bloqueante
+
+### Sistema de configuração
+
+Hierarquia de dataclasses com tipagem segura.
+
+**MavrosConfig**:
+
+```python
+MavrosConfig(
+    pose_source: PoseSource = PoseSource.GPS,     # GPS or VISION
+    expect_lidar: bool = True,
+    connection_string: str = "serial:///dev/ttyUSB0:921600",
+    pid_config_file: Optional[str] = None,
+    local_position_topic: str = "/mavros/local_position/pose",
+    # ... topic configurations with sensible defaults
+)
+```
+
+**BebopConfig**:
+
+```python
+BebopConfig(
+    ip: str = "192.168.42.1",
+    namespace: str = "bebop"
+)
+```
+
+## Movimento, navegação, RTL
+
+`MoveReference` seleciona o frame: `BODY` (relativo ao heading atual), `WORLD` (frame mundo ENU), `TAKEOFF` (relativo à pose de takeoff). A API pública de movimento — `move_velocity`, `move_to`, `move_to_gps`, `rtl` — além dos métodos de navegação (`POSITION`, `POSITION_GLOBAL`, `PID`, `PID_EKF`), das fontes de altitude, do tratamento de GPS/EGM96 e dos modos de RTL, é definida uma única vez no núcleo compartilhado: veja **[Vehicle core](vehicle/)**. Bebop e Crazyflie suportam um subconjunto (veja seus READMEs e a matriz de capacidades acima).
+
+## Detecção de obstáculos
+
+Detector + estratégia + handler/manager, integrados à navegação via `drone.add_obstacle_detector(...)`. O design completo, os detectores e as estratégias estão documentados em **[Obstacles](obstacles/)**.
+
+```python
+from nectar.control import DepthObstacleDetector, strategies
+
+drone.add_obstacle_detector("depth", DepthObstacleDetector(), strategies.PauseStrategy())
+drone.enable_all_obstacle_detectors()
+```
+
+## Controle PID
+
+PID de posição por eixo (x/y/z/yaw), carregado do `config/*.yaml` de cada firmware conforme `is_indoor` e sobrescritível em runtime via `drone.set_pid_config(...)`. O ciclo de carregamento vive em **[Vehicle core](vehicle/#pid-configuration)**; o ajuste (tuning) e o schema de config estão em **[PID](pid/)**.
+
+## Exceções
+
+`DroneError` é a exceção base; todo erro de controle levantado pelo SDK a subclassa:
+
+- `DriverNotFoundError` — o executável do driver/bridge não foi encontrado
+- `TakeoffPositionNotSetError` — um movimento relativo ao takeoff foi solicitado antes da decolagem
+- `SensorNotAvailableError` — um sensor obrigatório (GPS, vision, rangefinder) está faltando
+- `CapabilityNotSupportedError` — o drone não declara a `Capability` solicitada
+
+## Exemplos de uso
+
+### Missão de waypoints GPS
+
+```python
+config = MavrosConfig(pose_source=PoseSource.GPS)
+drone = DroneFactory.create("mavros", config)
+
+waypoints = [
+    (-27.1234, -48.4567, 15.0),
+    (-27.1245, -48.4578, 15.0),
+    (-27.1256, -48.4589, 15.0)
+]
+
+drone.takeoff(altitude=15.0)
+
+for lat, lon, alt in waypoints:
+    drone.move_to_gps(lat, lon, alt, precision=1.0)
+
+drone.land()
+```
+
+### Múltiplos frames de referência
+
+**Relativo ao corpo (body)** — 1m para frente e 0,5m para a esquerda a partir da posição atual:
+
+```python
+from nectar.control.types import MoveReference
+
+drone.takeoff(1.5)
+drone.move_to(x=1.0, y=0.5, z=0.0, reference=MoveReference.BODY)
+```
+
+**Relativo ao takeoff** — 2m para frente do ponto de takeoff, depois de volta a ele:
+
+```python
+drone.move_to(x=2.0, y=0.0, z=0.0, reference=MoveReference.TAKEOFF)
+drone.move_to(x=0.0, y=0.0, z=0.0, reference=MoveReference.TAKEOFF)
+```
+
+**Velocidade em frame mundo**:
+
+```python
+drone.move_velocity(vx=0.5, vy=0.0, vz=0.0, reference=MoveReference.WORLD)
+```
+
+### Navegação com desvio de obstáculos
+
+```python
+from nectar.control import DepthObstacleDetector, strategies
+
+detector = DepthObstacleDetector()
+drone.add_obstacle_detector("depth", detector, strategies.PauseStrategy())
+drone.enable_obstacle_detector("depth")
+
+drone.takeoff(1.5)
+drone.move_to(x=10.0, y=0.0, z=0.0)  # Pauses when obstacles detected
+drone.land()
+```
+
+Cada submódulo está documentado em seu próprio README, indexado na tabela do
+[Índice da documentação](#indice-da-documentacao) no topo desta página.
+
+## Sistema de tipos
+
+**Enums**:
+
+- `PoseSource`: GPS, VISION
+- `MoveReference`: BODY, WORLD, TAKEOFF
+- `NavigationMethod`: POSITION, POSITION_GLOBAL, PID, PID_EKF
+- `RTLMethod`: NAVIGATE, NATIVE
+- `AltitudeSource`: AUTO, LIDAR, VISION, REL_ALT
+- `ObstacleDirection`: FRONT, BACK, LEFT, RIGHT, UP, DOWN
+
+**Dataclasses**:
+
+- `ObstacleInfo`: Resultado da detecção de obstáculo (direção, distância, zona)

--- a/i18n/pt/modules/control/localization/concepts.md
+++ b/i18n/pt/modules/control/localization/concepts.md
@@ -1,0 +1,255 @@
+# Conceitos de localização indoor
+
+Fundamentos para voo sem GPS (indoor) com navegação visual externa. Esta página explica
+**o que** são SLAM / VIO / V-SLAM e **como** o controlador de voo funde essa pose. Para
+comandos do SDK e tabelas de parâmetros do FCU, veja o [README de Localização](../)
+(incluindo o [procedimento indoor](../#procedimento-indoor) e a
+[origem do EKF](../#origem-do-ekf)). Para o caminho mais antigo com T265, veja
+[Legado T265](../legacy/).
+
+> Seções marcadas como *prática Black Bee* são orientações operacionais das nossas voos.
+> Todo o resto é baseado na documentação citada dos fabricantes e dos firmwares.
+
+## Por que navegação externa indoor
+
+Sem GNSS, o piloto automático ainda precisa de uma posição local consistente para manter o
+Loiter, executar setpoints GUIDED/OFFBOARD ou voar missões autônomas. ArduPilot e PX4
+resolvem isso tratando uma estimativa de visão do companion como uma fonte de **navegação
+externa** para o EKF (EKF3 / EKF2), o mesmo papel que o GPS desempenha outdoor
+([estimação de posição sem GPS do ArduPilot](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html),
+[estimação de posição externa do PX4](https://docs.px4.io/main/en/ros/external_position_estimation.html)).
+
+Duas consequências decorrem disso:
+
+1. **Alguém precisa produzir uma pose** — um tracker visual-inercial ou um stack de
+   V-SLAM no companion (ou em uma câmera de tracking dedicada).
+2. **No ArduPilot, alguém precisa definir a origem do EKF** quando nenhum GPS fornece um
+   fix (ou confiar na restauração de origem gravada da 4.7+, ou em
+   `set_ekf_origin:=true` no vision feeder); a fusão EV local do PX4 não precisa disso
+   para os modos estilo Position. Detalhes:
+   [Origem do EKF](../#origem-do-ekf),
+   [frames de coordenadas do veículo](../../vehicle/#coordinate-frames).
+
+O módulo de localização do Nectar é a **ponte**: ele pega uma pose ROS do producer de
+visão e a entrega ao FCU via MAVROS, MAVLink direto, ou PX4 DDS. Ele não implementa o
+SLAM propriamente dito.
+
+## SLAM, VO, VIO, V-SLAM
+
+O [Simultaneous Localization and Mapping (SLAM)](https://en.wikipedia.org/wiki/Simultaneous_localization_and_mapping)
+estima conjuntamente a pose do sensor e um mapa do ambiente. Uma revisão amplamente citada
+é Cadena et al., *Past, Present, and Future of Simultaneous Localization and Mapping*
+(IEEE Transactions on Robotics, 2016)
+([IEEE Xplore](https://ieeexplore.ieee.org/document/7747236)).
+
+Distinções úteis para o voo:
+
+| Termo | Significado | Modo de falha típico |
+|------|---------|----------------------|
+| **Visual odometry (VO)** | Pose incremental apenas a partir do movimento da câmera | Deriva sem limite; sensível a textura e iluminação |
+| **Visual-inertial odometry (VIO)** | VO fundida com uma IMU | Ainda deriva, mas com melhor suavidade de curto prazo e observabilidade de escala |
+| **V-SLAM** | VO/VIO mais um **mapa** e geralmente **loop closure** | Pode corrigir a deriva ao revisitar lugares conhecidos; a qualidade do mapa depende da cena |
+
+**Odometria** responde "onde estou em relação a onde comecei?" e acumula erro.
+**Mapeamento + loop closure** responde "eu já estive aqui antes?" e pode trazer a
+estimativa de volta quando os mesmos landmarks são reconhecidos novamente.
+
+O [cuVSLAM](https://nvidia-isaac-ros.github.io/concepts/visual_slam/cuvslam/index.html) da
+NVIDIA é uma biblioteca de SLAM visual-inercial estéreo/multi-câmera acelerada por GPU,
+exposta em ROS 2 por meio do
+[Isaac ROS Visual SLAM](https://nvidia-isaac-ros.github.io/repositories_and_packages/isaac_ros_visual_slam/isaac_ros_visual_slam/index.html).
+A Intel RealSense **T265** era uma câmera de tracking dedicada que executava um pipeline
+VIO no próprio dispositivo e publicava pose / TF (agora descontinuada; veja
+[Legado T265](../legacy/)).
+
+Os overlays de trajetória do RViz (trajetória verde do SLAM vs trajetória roxa de VO no
+nosso perfil light) **visualizam a estimativa**. Eles não são uma etapa de calibração. O
+movimento de aquecimento que constrói a cobertura do mapa continua útil — isso é prática
+operacional, não calibração de extrinsics do sensor. Veja
+[Procedimento indoor](../#procedimento-indoor) e [Visualização](../#visualizacao).
+
+## Matemática básica
+
+Apenas um esboço em nível didático. Para um tratamento completo da estimação em
+manifolds, veja Barfoot, *State Estimation for Robotics*, ou a revisão de Cadena acima.
+
+### Pose
+
+A pose de um corpo rígido é um elemento do grupo especial euclidiano \(SE(3)\): uma
+rotação \(R \in SO(3)\) e uma translação \(t \in \mathbb{R}^3\),
+
+\[
+T = \begin{bmatrix} R & t \\ 0^\top & 1 \end{bmatrix} \in SE(3).
+\]
+
+A composição \(T_{WA} = T_{WB}\,T_{BA}\) encadeia frames. O núcleo do SDK usa **ENU /
+FLU**; o FCU usa **NED / FRD**. Os transportes convertem no wire — veja
+[frames de coordenadas do veículo](../../vehicle/#coordinate-frames).
+
+Sistemas de visão costumam publicar a pose em um frame de câmera ou de odometria que ainda
+precisa de um offset de frame do corpo (`VISO_POS_*` / `EKF2_EV_POS_*`) para que o EKF
+saiba onde a câmera está posicionada em relação ao centro do veículo.
+
+### Front-end e back-end (conceitual)
+
+A maioria dos stacks de SLAM visual compartilha uma estrutura de duas camadas
+(Cadena et al.):
+
+- **Front-end** — detecta e casa features (ou usa resíduos fotométricos densos) entre
+  frames; associa medições a landmarks; rejeita outliers.
+- **Back-end** — estima poses (e opcionalmente posições de landmarks) com um filtro (por
+  exemplo, EKF) ou um otimizador (bundle adjustment / pose graph).
+
+O **loop closure** adiciona uma restrição de pose relativa (ou de landmark) entre poses
+não consecutivas quando o mesmo lugar é reconhecido. Resolver o grafo então corrige a
+deriva acumulada ao longo do caminho. No Isaac ROS Visual SLAM você pode ver essa correção
+como a trajetória verde `/visual_slam/tracking/slam_path` se ajustando em relação à
+trajetória roxa `/visual_slam/tracking/vo_path`
+([Visualização](../#visualizacao)).
+
+### Medição no EKF do controlador de voo
+
+O companion **não** substitui o estimador de atitude/posição do FCU. Ele envia uma pose
+externa (e opcionalmente velocidade) que o EKF funde como uma medição. No caminho MAVLink
+a mensagem usual é a
+[`VISION_POSITION_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE)
+(#102); a velocidade pode usar a
+[`VISION_SPEED_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_SPEED_ESTIMATE)
+(#103). O ArduPilot documenta a taxa esperada (≥ 4 Hz) e a seleção de fonte em
+[Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html).
+O PX4 documenta a fusão de external vision e as expectativas de taxa em
+[External Position Estimation](https://docs.px4.io/main/en/ros/external_position_estimation.html)
+e [VIO](https://docs.px4.io/main/en/computer_vision/visual_inertial_odometry.html).
+
+Conceitualmente, cada pose de visão é uma medição da posição do veículo (e frequentemente
+do yaw) no frame local, com um delay e um modelo de ruído:
+
+- **Delay** — a visão chega atrasada em relação à IMU. O firmware expõe isso como
+  `VISO_DELAY_MS` (ArduPilot) ou `EKF2_EV_DELAY` (PX4). Um delay errado aparece como
+  atraso ou oscilação no Loiter.
+- **Confiança / ruído** — quão fortemente o EKF acredita na atualização de visão
+  (`VISO_POS_M_NSE`, `VISO_YAW_M_NSE`, PX4 `EKF2_EVP_NOISE` / `EKF2_EVA_NOISE`, etc.).
+  Ruído apertado sobre uma estimativa ruim compete com a IMU; ruído solto subutiliza uma
+  estimativa boa.
+- **Seleção de fonte** — o ArduPilot `EK3_SRC1_* = 6` (ExternalNav) ou os bits de
+  `EKF2_EV_CTRL` do PX4 precisam habilitar a fusão, senão as mensagens são recebidas mas
+  ignoradas ([EKF source selection](https://ardupilot.org/copter/docs/common-ekf-sources.html)).
+
+As bridges do Nectar enviam **posição por padrão**. A velocidade opcional
+(`send_speed:=true`) está documentada em [Velocidade](../#velocidade-opcional): o twist do
+cuVSLAM em `/visual_slam/tracking/odometry` é uma diferença finita sobre poses recentes no
+wrapper do Isaac ROS, não um estado de velocidade independente — então habilitar tanto a
+fusão de posição quanto a de velocidade pode contar em dobro uma medição se o ruído for
+configurado de forma agressiva.
+
+### Escala
+
+A VO monocular tem uma escala métrica não observável; o estéreo e a VIO (com excitação da
+IMU) tornam a escala observável. Pares infra estéreo da RealSense e pipelines auxiliados
+por IMU são as escolhas indoor usuais para um Loiter métrico. Historicamente, as
+orientações de bring-up do T265 incluíam levantar o veículo ~1 m antes do voo para que o
+movimento vertical exercitasse a escala — veja [Procedimento indoor](../#procedimento-indoor)
+e [Legado T265](../legacy/).
+
+## Componentes de VIO / V-SLAM
+
+Um stack indoor funcional precisa de mais do que "uma câmera e ROS":
+
+| Peça | Papel |
+|-------|------|
+| **Câmera(s)** | Intensidade (e opcionalmente profundidade) para o matching do front-end. Estéreo melhora a escala métrica. |
+| **IMU** | Taxa angular e aceleração em alta taxa; preenche lacunas da visão e ajuda na escala. Precisa estar sincronizada no tempo com as imagens. |
+| **Extrinsics** | Transforms câmera↔IMU e câmera↔corpo. Offsets errados enviesam a estimativa fundida. |
+| **Sincronização de tempo** | Timestamps de imagem e IMU em um relógio comum; um desvio grande parece delay. |
+| **Producer** | VIO do dispositivo (T265) ou SLAM onboard (cuVSLAM no Jetson). |
+| **Bridge** | Alinhamento de frame, limitação de taxa, entrega por MAVLink/MAVROS/DDS. |
+| **EKF do FCU** | Funde a visão com a IMU (e opcionalmente rangefinder / baro para altura). |
+
+### Modos de falha (prática)
+
+Estes aparecem repetidamente na documentação de firmware e em voo:
+
+- **Cenas sem textura ou repetitivas** — paredes em branco, pisos brilhantes, padrões
+  repetitivos fortes → fome de features ou matches falsos.
+- **Motion blur / movimento abrupto** — translação ou yaw rápidos demais excedem as
+  premissas do tracker.
+- **Vibração** — faça o soft-mount da câmera; o acoplamento rígido injeta ruído das
+  hélices na IMU e na imagem (*prática Black Bee*: espuma e elásticos entre as fixações).
+- **Objetos em movimento no campo de visão** — pessoas caminhando perto da lente durante o
+  bring-up corrompem o mapa / a pose.
+- **Mudanças de iluminação** — variações súbitas de exposição confundem o matching.
+- **Rolling shutter** (dependendo do sensor) — rotação rápida distorce a geometria;
+  global-shutter ou movimento cuidadoso ajuda.
+- **Interferência de emissor / IR** (D435i) — as notas do Isaac ROS RealSense alertam que
+  o projetor de IR pode perturbar o matching estéreo se deixado ligado durante o VSLAM;
+  siga o [tutorial cuVSLAM da RealSense](https://nvidia-isaac-ros.github.io/concepts/visual_slam/cuvslam/tutorial_realsense.html).
+
+## Como o firmware consome a visão
+
+```mermaid
+flowchart LR
+  cam[Camera plus IMU]
+  slam[VIO or V-SLAM producer]
+  bridge[Vision pose bridge]
+  ekf[FCU EKF]
+  cam --> slam
+  slam -->|"ROS pose ENU"| bridge
+  bridge -->|"VISION_POSITION_ESTIMATE or DDS odom"| ekf
+```
+
+1. O producer publica a pose (caminho atual do Nectar:
+   `/visual_slam/tracking/vo_pose_covariance` a ~90 Hz a partir do Isaac ROS Visual
+   SLAM).
+2. A bridge converte frames se necessário e encaminha ao FCU
+   ([Backends](../#backends)).
+3. O EKF funde quando as fontes estão configuradas (e a origem, quando necessário —
+   [Configuração do FCU](../#configuracao-do-fcu), [Origem do EKF](../#origem-do-ekf)).
+4. Os modos de posição (Loiter, GUIDED, OFFBOARD) usam a pose local fundida — a mesma pose
+   que o núcleo do veículo lê para a navegação indoor `PoseSource.VISION`.
+
+Exatamente **um** processo pode alimentar o FCU com visão por vez
+([Regra do feeder único](../#regra-do-feeder-unico)).
+
+## Dois sistemas que usamos
+
+| | T265 + VIO no dispositivo | D435i + Isaac ROS cuVSLAM |
+|---|---|---|
+| **Onde o tracking roda** | ASIC de tracking na câmera | Jetson (container Isaac ROS) |
+| **Mapa / loop closure** | VIO do dispositivo (visibilidade externa limitada) | Tópicos explícitos de V-SLAM; loop closure visível nas trajetórias / vis clouds |
+| **Companion (Black Bee)** | Raspberry Pi (2023–2024) | Jetson Orin Nano |
+| **Link com o FCU** | `vision_to_mavros` → MAVROS → `VISION_POSITION_ESTIMATE` | Backends `vision_pose` do Nectar (MAVROS / MAVLink / DDS) |
+| **`VISO_TYPE` do ArduPilot** | `2` (Intel T265) | `1` (MAVLink) |
+| **Tópico de pose típico no MAVROS** | `/mavros/vision_pose/pose` | `/mavros/vision_pose/pose_cov` |
+| **Status** | Câmera descontinuada; fallback | Caminho indoor atual |
+
+Detalhes sobre o stack antigo: [Legado T265](../legacy/).
+Detalhes sobre executar o novo stack: [README de Localização](../).
+
+## Referências
+
+### Levantamentos e teoria
+
+- C. Cadena et al., *Past, Present, and Future of Simultaneous Localization and Mapping*, IEEE TRO, 2016 — [IEEE Xplore](https://ieeexplore.ieee.org/document/7747236)
+- T. D. Barfoot, *State Estimation for Robotics* (Cambridge University Press)
+
+### NVIDIA / cuVSLAM
+
+- [Página de conceito do cuVSLAM](https://nvidia-isaac-ros.github.io/concepts/visual_slam/cuvslam/index.html)
+- [Isaac ROS Visual SLAM (`isaac_ros_visual_slam`)](https://nvidia-isaac-ros.github.io/repositories_and_packages/isaac_ros_visual_slam/isaac_ros_visual_slam/index.html)
+- [Tutorial RealSense + cuVSLAM](https://nvidia-isaac-ros.github.io/concepts/visual_slam/cuvslam/tutorial_realsense.html)
+- [Relatório técnico do cuVSLAM (arXiv:2506.04359)](https://arxiv.org/abs/2506.04359)
+
+### Autopilot / MAVLink
+
+- [ArduPilot: Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html)
+- [ArduPilot: EKF Source Selection](https://ardupilot.org/copter/docs/common-ekf-sources.html)
+- [ArduPilot: ROS VIO tracking camera](https://ardupilot.org/dev/docs/ros-vio-tracking-camera.html)
+- [ArduPilot: Intel RealSense T265](https://ardupilot.org/copter/docs/common-vio-tracking-camera.html)
+- [PX4: External Position Estimation](https://docs.px4.io/main/en/ros/external_position_estimation.html)
+- [PX4: Visual Inertial Odometry (VIO)](https://docs.px4.io/main/en/computer_vision/visual_inertial_odometry.html)
+- [Mensagem MAVLink `VISION_POSITION_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE)
+
+### Comunidade / bridge legado
+
+- LuckyBird (Thien Nguyen), série T265 no Discourse do ArduPilot — [parte 1](https://discuss.ardupilot.org/t/integration-of-ardupilot-and-vio-tracking-camera-part-1-getting-started-with-the-intel-realsense-t265-on-rasberry-pi-3b/43162), [parte 2](https://discuss.ardupilot.org/t/integration-of-ardupilot-and-vio-tracking-camera-part-2-complete-installation-and-indoor-non-gps-flights/43405)
+- [thien94/vision_to_mavros](https://github.com/thien94/vision_to_mavros) (ROS 1) e [Black-Bee-Drones/vision_to_mavros](https://github.com/Black-Bee-Drones/vision_to_mavros) (adaptação para ROS 2)

--- a/i18n/pt/modules/control/localization/index.md
+++ b/i18n/pt/modules/control/localization/index.md
@@ -1,0 +1,496 @@
+# Localização (control/localization)
+
+## Índice da documentação
+
+| Doc | Escopo |
+|-----|-------|
+| Este README | Arquitetura, Executar, configuração do FCU, origem do EKF, SOP indoor, SITL, RViz |
+| [concepts.md](concepts/) | Teoria de SLAM / VIO / V-SLAM, matemática, fusão com o FCU, T265 vs cuVSLAM |
+| [legacy.md](legacy/) | Histórico e versões do T265 + `vision_to_mavros` (2023–2024) |
+
+## Papel
+
+Integração de navegação externa (external-nav) para voo sem GPS (indoor). Alimenta o FCU
+com uma pose de Visual SLAM para que seu EKF (ArduPilot EKF3 / PX4 EKF2) possa estimar a
+posição sem GPS.
+
+Vive sob `control` porque faz a ponte entre o producer de VSLAM e os transportes MAVROS e
+MAVLink. O pipeline é dividido em um **producer** (RealSense + Isaac ROS Visual SLAM,
+executado no container Isaac) e um **consumer** (uma bridge de vision-pose que encaminha a
+pose ao FCU, executada do lado do SDK). Eles se comunicam por host networking com um
+`ROS_DOMAIN_ID` compartilhado.
+
+## Topologia
+
+```mermaid
+flowchart LR
+  subgraph isaac [Isaac container]
+    rs[realsense2_camera infra1/2 + IMU]
+    vslam[isaac_ros_visual_slam]
+    rs --> vslam
+  end
+  subgraph sdk [SDK container or host]
+    bridge[vision_pose_node backend mavros/mavlink/dds]
+    mavros[MAVROS indoor]
+  end
+  vslam -->|"/visual_slam/tracking/vo_pose_covariance"| bridge
+  bridge -->|"mavros: /mavros/vision_pose/pose_cov"| mavros
+  bridge -->|"mavlink: VISION_POSITION_ESTIMATE"| fcu[FCU]
+  bridge -->|"dds: VehicleOdometry"| fcu
+  mavros --> fcu
+```
+
+## Componentes
+
+| Parte | Caminho | Papel |
+|------|------|------|
+| Launch do producer | `nectar/launch/isaac_vslam_realsense.launch.py` | RealSense + Visual SLAM (container Isaac) |
+| Launch do consumer | `nectar/launch/vision_pose.launch.py` | MAVROS (opcional) + bridge de vision-pose |
+| Relay MAVROS | `control/localization/vision_pose_bridge.py` (`MavrosVisionRelay`) | republica a pose em `/mavros/vision_pose/pose_cov` |
+| Bridge MAVLink | reaproveitado de `nectar.control.mavlink.VisionPoseBridge` | envia `VISION_POSITION_ESTIMATE` |
+| Bridge DDS | `control/px4/vision_bridge.py` (`Px4VisionOdometryBridge`) | publica `px4_msgs/VehicleOdometry` em `/fmu/in/vehicle_visual_odometry` |
+| Velocidade (opcional) | `MavrosVisionSpeedRelay`, `nectar.control.mavlink.VisionSpeedBridge`, `speed_topic` na bridge DDS | veja [Velocidade](#velocidade-opcional) |
+| Conversões de frame | `control/localization/frames.py` | twist do corpo -> mundo -> NED |
+| Node | `control/localization/nodes/vision_pose_node.py` | seleciona o backend, conecta a bridge |
+| Parâmetros VSLAM | `control/localization/config/vslam_realsense.yaml` | ajuste (tuning) de RealSense + Visual SLAM |
+| Config MAVROS | `control/mavros/config/indoor_mavros.yaml`, `indoor_pluginlists.yaml` | perfil MAVROS indoor |
+
+## Executar
+
+> **Pré-requisito:** producer e consumer compartilham o `ROS_DOMAIN_ID` (padrão `14`, veja
+> [`scripts/lib/config.sh`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/lib/config.sh)).
+> Jetson, computador de bordo/host e o laptop opcional (RViz) devem usar o mesmo domínio.
+
+### 1. Produtor (container Isaac)
+
+```bash
+make isaac-run          # or: ./docker/isaac_vslam/run_docker.sh
+
+# inside:
+
+nectar-vslam            # = ros2 launch nectar/launch/isaac_vslam_realsense.launch.py
+```
+
+Confirme que a RealSense é enumerada e que os tópicos do VSLAM publicam. Notas do Docker:
+[Isaac ROS Visual SLAM (Jetson)](../../../setup/docker/#isaac-ros-visual-slam-jetson).
+
+### 2. Consumidor — feeder de vision (manter em execução) {#2-consumidor-feeder-de-vision-manter-em-execucao}
+
+| Backend | Comando |
+|---------|---------|
+| MAVROS | `ros2 launch nectar vision_pose.launch.py backend:=mavros fcu_url:=…` |
+| MAVLink direto | `ros2 launch nectar vision_pose.launch.py backend:=mavlink mavlink_url:=…` |
+| PX4 DDS | `ros2 launch nectar vision_pose.launch.py backend:=dds` |
+
+Ou: `make driver DRONE=mavlink ENV=indoor`. Verifique a pose fundida
+([Procedimento indoor](#procedimento-indoor)) e só então inicie a missão em um endpoint
+MAVLink **diferente** do feeder.
+
+`mavlink_url` / `fcu_url` são de formato livre — ajuste à sua linha serial ou ao fan-out do
+roteador. Layout MAVProxy de exemplo no Jetson da Black Bee (GCS / missão / feeder):
+`14550` / `14551` / `14552`.
+
+Respeite a [regra do feeder único](#regra-do-feeder-unico): não inicie também um segundo
+feeder de vision no mesmo link do FCU a partir de uma missão.
+
+### 3. Missão
+
+`PoseSource.VISION` com `auto_vision_feed=False` (padrão): a missão **assina** o tópico do
+VSLAM para navegação do companion e **não** envia `VISION_*`. Ative `auto_vision_feed=True`
+para um feed em processo único (nesse caso, não execute também o feeder standalone de
+mavlink no mesmo endpoint). Velocidade opcional nesse caminho: `vision_send_speed=True`.
+
+## Procedimento indoor
+
+Checklist do dia de voo para o stack **atual** (D435i + cuVSLAM). Os comandos e as tabelas
+do FCU estão acima e em [Configuração do FCU](#configuracao-do-fcu); esta seção trata
+apenas de ordem e prática.
+
+### Montagem (*prática Black Bee*)
+
+VIO / V-SLAM assume que a câmera e a IMU se movem junto com a aeronave. Vibração ou uma
+fixação solta parece movimento para o estimador.
+
+- Alinhe o eixo óptico da D435i com as extrinsics configuradas (`VISO_POS_*` / frames do
+  launch do Isaac).
+- Fixação soft-mount: elásticos e espuma entre a câmera e o frame; espuma no case do
+  sensor onde ajudar sem bloquear as lentes ou o USB.
+- Depois de transportar ou remontar, reinicie o producer + a bridge e refaça as
+  verificações abaixo — não reaproveite a sessão de mapa do dia anterior.
+
+### Bring-up
+
+1. **Produtor** — [Executar §1](#1-produtor-container-isaac).
+2. **Consumidor** — [Executar §2](#2-consumidor-feeder-de-vision-manter-em-execucao).
+3. **Verificação do pipeline** — mova a aeronave manualmente; a pose local fundida do FCU
+   precisa mudar (`vision_fcu_check.py` e/ou o MAVLink Inspector da GCS). RViz opcional:
+   [Visualização](#visualizacao).
+4. **Origem do EKF** — apenas quando necessário; veja [Origem do EKF](#origem-do-ekf). Flag
+   opcional do feeder: `set_ekf_origin:=true`.
+5. **Aquecimento (warm-up)** — caminhe com o veículo lentamente pelo volume onde ele vai
+   voar (quadrado / círculo / volta pela arena). Movimento suave; evite yaw abrupto e
+   pessoas cruzando o FOV ([modos de falha](concepts/#modos-de-falha-pratica)). Isso
+   constrói a cobertura do mapa e permite abortar no chão se o tracking parecer ruim.
+6. **Sanidade de escala / vertical** — levante e translade manualmente; X/Y/Z fundidos
+   devem se mover aproximadamente a distância certa. (O bring-up do T265 historicamente
+   pedia um levantamento de ~1 m para a escala vertical — [Legado](legacy/); com D435i +
+   cuVSLAM trate isso como uma verificação, não uma calibração oculta.)
+7. **Primeiro voo** — Stabilize ou AltHold → movimento suave observando a pose fundida →
+   Loiter somente quando o tracking parecer estável (pronto para reverter imediatamente).
+   Depois, missão / perfis mais exigentes. Padrão do LuckyBird
+   [Discourse parte 2](https://discuss.ardupilot.org/t/integration-of-ardupilot-and-vio-tracking-camera-part-2-complete-installation-and-indoor-non-gps-flights/43405).
+
+Após muito tempo ligado, mudanças de fixação/USB/parâmetros, ou avisos estranhos na GCS:
+reinicie o producer + a bridge (e reinicie o FCU depois de mudanças de parâmetro).
+
+### Triagem
+
+| Sintoma | Causa provável | O que tentar |
+|---------|--------------|-------------|
+| Nenhum tópico VSLAM | Câmera / Isaac / USB | `rs-enumerate-devices` no container Isaac; USB3; reinicie o `nectar-vslam` |
+| VSLAM OK, pose do FCU congelada | Bridge, domínio ou feeder duplicado | `ROS_DOMAIN_ID` compartilhado; reinicie o consumer; [regra do feeder único](#regra-do-feeder-unico) |
+| Vision no ROS, EKF não usa | Parâmetros / origem | [Configuração do FCU](#configuracao-do-fcu), [Origem do EKF](#origem-do-ekf); reinicie após mudar parâmetros |
+| Caminho instável / divergindo | Vibração, textura, movimento abrupto, sessão obsoleta | Soft-mount; aquecimento mais lento; reinicie o producer |
+| Loiter oscila / desloca | Delay / ruído; velocidade contada em dobro | Ajuste `VISO_DELAY_MS` / ruído; deixe `send_speed` desligado a menos que os logs mostrem benefício |
+| Flags estranhas na GCS após muito tempo ligado | Nós obsoletos / estado do EKF | Reinicie FCU + producer + bridge |
+
+## Velocidade (opcional)
+
+Por padrão, os feeders enviam **apenas posição**. `send_speed:=true` em
+`vision_pose.launch.py` (ou `vision_send_speed=True` com `auto_vision_feed`) também envia a
+velocidade do VSLAM; a pose continua sendo enviada normalmente. O EKF3 não inicializa
+apenas com velocidade ([ardupilot#23485](https://github.com/ArduPilot/ardupilot/issues/23485)).
+
+| Backend | Portador da velocidade |
+|---------|------------------|
+| `mavros` | `geometry_msgs/TwistStamped` em `/mavros/vision_speed/speed_twist`; o plugin [`vision_speed`](https://github.com/mavlink/mavros/blob/ros2/mavros_extras/src/plugins/vision_speed_estimate.cpp) converte ENU -> NED e envia [`VISION_SPEED_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_SPEED_ESTIMATE) |
+| `mavlink` | `VISION_SPEED_ESTIMATE` (#103) pelo mesmo link pymavlink usado pela pose |
+| `dds` | `velocity` + `velocity_frame = VELOCITY_FRAME_NED` na `VehicleOdometry` já publicada para a pose |
+
+```bash
+ros2 launch nectar vision_pose.launch.py backend:=mavros send_speed:=true
+ros2 launch nectar vision_pose.launch.py backend:=mavlink send_speed:=true mavlink_url:=…
+```
+
+Argumentos: `speed_topic` (padrão `/visual_slam/tracking/odometry`); o node também tem
+`speed_output_topic`, `speed_timeout_s`.
+
+### O que o cuVSLAM realmente fornece
+
+O cuVSLAM estima **pose e covariância da pose**; ele não tem estado de velocidade. O twist
+em `/visual_slam/tracking/odometry` é produzido pelo wrapper ROS como uma diferença finita
+sobre as últimas 10 poses,
+`dp = pose(t0)⁻¹ · pose(t1)`
+([`PoseCache::GetVelocity`](https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_visual_slam/blob/main/isaac_ros_visual_slam/src/impl/pose_cache.cpp)).
+Portanto, ele é derivado da mesma pose que já enviamos, não é uma medição independente. A
+aceleração é uma *entrada* (IMU da RealSense, `tracking_mode:=1`), não uma saída.
+
+Essa forma de `dp` torna o twist **no frame do corpo** (`child_frame_id`, FLU), como o
+`nav_msgs/Odometry` exige. O `VISION_SPEED_ESTIMATE` não carrega atitude, então o FCU não
+pode rotacioná-lo: as bridges rotacionam de corpo para mundo usando a atitude da mesma
+amostra de odometria antes da troca ENU -> NED (`frames.py`). O `ODOMETRY` é o
+contraexemplo — ele carrega o quaternion e o próprio ArduPilot rotaciona a velocidade
+body-FRD.
+
+### Configuração do FCU para velocidade
+
+O ArduPilot lista a velocidade como opcional, junto com a posição
+([Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html)).
+Ela só é fundida depois que a fonte é selecionada:
+
+- `EK3_SRC1_VELXY = 6`, `EK3_SRC1_VELZ = 6` (ExternalNav). Com `0` as mensagens são
+  recebidas e logadas, mas não fundidas.
+- `VISO_VEL_M_NSE` define o ruído de medição da velocidade. O ArduPilot **ignora** o campo
+  de covariância do `VISION_SPEED_ESTIMATE` e sempre usa este parâmetro
+  ([`AP_VisualOdom_MAV.cpp`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_VisualOdom/AP_VisualOdom_MAV.cpp)),
+  então é o único ajuste para o quanto o EKF confia nessa entrada. Como o twist é derivado
+  da posição que já enviamos, começar de forma conservadora (o padrão de `0.1` m/s) evita
+  contar em dobro uma única medição como se fossem duas independentes.
+- PX4: o bit 2 de `EKF2_EV_CTRL` habilita a fusão de velocidade 3D.
+
+Verifique as inovações de `XKFS`/`XKF3` nos logs antes e depois de habilitar.
+
+## Configuração do FCU {#configuracao-do-fcu}
+
+A bridge apenas entrega a pose — o estimador do FCU ainda precisa ser configurado para
+fundi-la. **ArduPilot (EKF3) e PX4 (EKF2) usam parâmetros diferentes e uma taxa mínima
+diferente**. Os dois backends MAVLink enviam o
+[`VISION_POSITION_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE)
+(#102); o EKF o funde uma vez configurado. As regras de origem variam por firmware — veja
+[Origem do EKF](#origem-do-ekf).
+
+> Nossos voos indoor em **hardware** até hoje são em **ArduPilot 4.6.x / 4.8-dev**. O
+> conjunto de PX4 abaixo é baseado na documentação do PX4 e corresponde ao pipeline de
+> referência (o mesmo relay MAVROS) usado pelo
+> [tutorial VSLAM-UAV](https://www.andrewbernas.com/docs/tutorials/robots/vslam/setup) no
+> PX4 v1.15.4. O **SITL** já exercita esse caminho (`ENV=indoor` → `indoor_room_px4` +
+> `gz_vision_source`); valide no seu Pixhawk antes de usar em competição.
+
+### ArduPilot (EKF3)
+
+| Parâmetro | Valor | Finalidade |
+|-----------|-------|---------|
+| `VISO_TYPE` | `1` (MAVLink) | Habilita o backend external-nav que consome `VISION_POSITION_ESTIMATE` de um companion (o caminho T265 usa `2`, veja [Notas de hardware](#notas-de-hardware)) |
+| `EK3_SRC1_POSXY` | `6` (ExternalNav) | Posição horizontal a partir do VSLAM |
+| `EK3_SRC1_VELXY` | `6` ou `0` | Velocidade horizontal — `6` apenas com `send_speed:=true`, veja [Velocidade](#velocidade-opcional) |
+| `EK3_SRC1_POSZ` | `6` (ExternalNav) | Altura — veja [Fonte de altura](#fonte-de-altura) |
+| `EK3_SRC1_VELZ` | `6` ou `0` | Velocidade vertical, mesma condição de `VELXY` |
+| `EK3_SRC1_YAW` | `6` (ExternalNav) | Yaw a partir do VSLAM (com `COMPASS_USE=0`), ou `1` para manter a bússola |
+| `VISO_POS_X/Y/Z` | offset da câmera (m) | Posição da câmera no frame do corpo |
+| `GPS1_TYPE` | `0` | Desabilita o GPS indoor (renomeado de `GPS_TYPE` a partir da 4.5+) |
+
+Taxa ≥ 4 Hz. Ajuste (tuning): `VISO_POS_M_NSE`, `VISO_YAW_M_NSE`, `VISO_DELAY_MS`,
+`VISO_QUAL_MIN`. Referências:
+[EKF source selection](https://ardupilot.org/copter/docs/common-ekf-sources.html),
+[Non-GPS position estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html),
+[`VISO_TYPE`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_VisualOdom/AP_VisualOdom.cpp),
+[`EK3_SRC*`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF/AP_NavEKF_Source.cpp).
+
+### PX4 (EKF2)
+
+| Parâmetro | Valor | Finalidade |
+|-----------|-------|---------|
+| `EKF2_EV_CTRL` | bitmask — bit0 h-pos, bit1 v-pos, bit2 vel 3D, bit3 yaw (`15` = todos) | Habilita a fusão de external-vision. O PX4 lançado (≥1.14) já vem com `15`, então a fusão inicia automaticamente quando os dados chegam — **verifique no seu firmware** |
+| `EKF2_HGT_REF` | `3` (Vision) | Referência de altura — veja [Fonte de altura](#fonte-de-altura) |
+| `EKF2_EV_DELAY` | ~`50` ms | Delay do EV em relação à IMU; ajuste a partir dos logs |
+| `EKF2_EV_POS_X/Y/Z` | offset da câmera (m) | Posição da câmera no frame do corpo |
+| `EKF2_GPS_CTRL` | `0` | Desabilita o GNSS indoor |
+| `EKF2_MAG_TYPE` | `None` | Só se estiver usando yaw da visão |
+
+Taxa de 30–50 Hz — **o PX4 rejeita external vision quando a taxa é baixa demais** (muito
+mais estrito que o ArduPilot); o cuVSLAM a ~90 Hz atende esse requisito. Ajuste:
+`EKF2_EV_NOISE_MD`, `EKF2_EVP_NOISE`, `EKF2_EVA_NOISE`, `EKF2_EV_QMIN`. Referências:
+[External position estimation](https://docs.px4.io/main/en/ros/external_position_estimation.html),
+[VIO](https://docs.px4.io/main/en/computer_vision/visual_inertial_odometry.html),
+[EKF2 tuning](https://docs.px4.io/main/en/advanced_config/tuning_the_ecl_ekf.html),
+[`params_external_vision.yaml`](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/ekf2/params_external_vision.yaml),
+[padrão de `EKF2_EV_CTRL` (#24298)](https://github.com/PX4/PX4-Autopilot/issues/24298).
+
+Os backends `mavros`/`mavlink` entregam essa estimativa como `VISION_POSITION_ESTIMATE`; o
+backend nativo `dds` publica `px4_msgs/VehicleOdometry` em
+`/fmu/in/vehicle_visual_odometry` no lugar (mesmos parâmetros do EKF2, sem MAVROS/MAVLink).
+Veja [Backends](#backends).
+
+### Origem do EKF
+
+A **origem** do EKF é o lat/lon/alt global que define o NED local `(0,0,0)`. Ela **não é**
+o Home (ponto de retorno do RTL) e **não é** a origem do mapa do VSLAM. O Home permanece
+com o FCU: o ArduPilot o inicializa depois da origem (e novamente ao armar, para o RTL do
+Copter). A bridge nunca envia `SET_HOME_POSITION`.
+
+**Opt-in a partir do vision feeder** (desligado por padrão):
+
+```bash
+ros2 launch nectar vision_pose.launch.py backend:=mavlink set_ekf_origin:=true
+
+# optional overrides:
+
+#   origin_lat:=… origin_lon:=… origin_alt_m:=… origin_timeout_s:=2.0
+
+```
+
+Os padrões são o lat/lon do laboratório da Black Bee (`-22.41434308754571`,
+`-45.44843145453864`) com `origin_alt_m:=0.0` (defina a AMSL do local se a altura no mapa
+da GCS precisar ficar correta). Se `GPS_GLOBAL_ORIGIN` já estiver presente, o envio é
+ignorado. Suportado em `mavros`, `mavlink` e `dds`.
+
+Alternativas manuais: *Set EKF Origin Here* do Mission Planner, `SET_GPS_GLOBAL_ORIGIN`, ou
+[`ahrs-set-origin.lua`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/examples/ahrs-set-origin.lua).
+
+**ArduPilot**
+([Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html),
+[Home / origin](https://ardupilot.org/dev/docs/mavlink-get-set-home-and-origin.html)):
+
+- Se **nenhum GPS** estiver fornecendo fix, defina a origem antes que o EKF possa estimar
+  a posição (necessário para Loiter / Guided / Auto e para publicar a pose local).
+- Os valores de lat/lon só precisam ser um WGS84 válido; são uma referência, não um
+  levantamento topográfico.
+- Uma vez definida, a origem não pode ser movida até o próximo reboot.
+- Se um **GPS estiver presente e obtiver fix**, o ArduPilot normalmente define a origem
+  por conta própria ([Non-GPS Navigation](https://ardupilot.org/copter/docs/common-non-gps-navigation-landing-page.html)).
+- A partir da **4.7+**, `AHRS_OPTIONS` bit 3 (RecordOrigin) + bit 4
+  (UseRecordedOriginForNonGPS) podem salvar/restaurar a origem entre ciclos de energia,
+  então não é preciso defini-la a cada boot.
+- O ícone do veículo no mapa do Mission Planner aparece quando existe uma origem ([wiki do
+  T265](https://ardupilot.org/copter/docs/common-vio-tracking-camera.html), LuckyBird);
+  isso é visualização da GCS, não uma etapa de calibração separada.
+
+Stabilize / AltHold não precisam de uma estimativa de posição. Se você "simplesmente
+rodar" sem definir a origem e o Loiter ainda funcionar, a origem já estava definida (fix de
+GPS, origem gravada na 4.7+, ou uma definição anterior via GCS/script/`set_ekf_origin`).
+
+**PX4**
+([External position estimation](https://docs.px4.io/main/en/ros/external_position_estimation.html)):
+
+- A fusão EV local (Position / OFFBOARD local) usa o frame local vindo da visão; o guia de
+  setup do VSLAM-UAV não exige definir uma origem para esse caminho.
+- `SET_GPS_GLOBAL_ORIGIN` serve para construir uma estimativa **global** a partir da pose
+  local, para que **modos automáticos que precisam de posição global** (Mission, Return,
+  …) possam rodar indoor (`set_ekf_origin:=true` nos backends `dds` / `mavros` cobre esse
+  caso).
+
+**Nota histórica:** o caminho ROS do LuckyBird e o `set_origin.py` / clique no MP eram
+explícitos. O `t265_to_mavlink.py` upstream pode opcionalmente enviar
+`SET_GPS_GLOBAL_ORIGIN`. O `vision_to_mavros` (ROS 2) da Black Bee apenas republica a pose.
+Veja [Legado](legacy/).
+
+### Fonte de altura
+
+Não usamos o **barômetro** indoor — ele deriva perto do solo e no fluxo de ar das hélices.
+Escolhemos o POSZ entre duas fontes e mantemos o resto do conjunto (POSXY / VELXY / YAW) na
+visão:
+
+- **Vision** (`EK3_SRC1_POSZ=6` / `EKF2_HGT_REF=Vision`): a altitude é relativa à origem
+  do VSLAM, **sem terrain following** — o drone mantém uma altura constante ao cruzar
+  plataformas ou obstáculos na arena. Este é o nosso padrão e tem sido útil em missões com
+  plataformas elevadas.
+- **Rangefinder voltado para baixo** (`EK3_SRC1_POSZ=2` / `EKF2_HGT_REF=Range` +
+  `EKF2_RNG_CTRL`): a altitude **acompanha o terreno**. O ArduPilot avisa que isso é "só
+  apropriado ... onde o piso é plano, sem obstruções no solo"
+  ([EKF sources](https://ardupilot.org/copter/docs/common-ekf-sources.html)); o PX4
+  observa que "a origem NED local vai subir e descer com o nível do solo"
+  ([EKF2 tuning](https://docs.px4.io/main/en/advanced_config/tuning_the_ecl_ekf.html)).
+  Sobre obstáculos fixos o veículo então sobe para compensar, então mascaramos as quedas
+  abruptas upstream com o [`ObstacleMaskFilter`](../../sensors/#obstaclemaskfilter) antes
+  que o FCU chegue a vê-las.
+
+## Backends
+
+- `mavros`: o `MavrosVisionRelay` republica o `PoseWithCovarianceStamped` do VSLAM (ENU) em
+  `/mavros/vision_pose/pose_cov`; o MAVROS converte para NED para o FCU.
+- `mavlink`: `nectar.control.mavlink.VisionPoseBridge` converte ENU->NED e envia
+  `VISION_POSITION_ESTIMATE` por um link pymavlink dedicado.
+- `dds`: `nectar.control.px4.Px4VisionOdometryBridge` converte ENU->NED e publica
+  `px4_msgs/VehicleOdometry` em `/fmu/in/vehicle_visual_odometry` (uXRCE-DDS nativo do
+  PX4). Precisa de um `MicroXRCEAgent` em execução e de `px4_msgs`; defina `px4_namespace`
+  para corresponder a um cliente com namespace.
+
+Cada backend ganha um caminho de velocidade com `send_speed:=true`
+([Velocidade](#velocidade-opcional)); o caminho de pose acima não é afetado.
+
+## Regra do feeder único {#regra-do-feeder-unico}
+
+Exatamente **um** processo pode enviar vision externa para o FCU:
+
+| Transporte | Feeder padrão | Papel na missão |
+|-----------|----------------|--------------|
+| MAVROS | `vision_pose_node backend:=mavros` | Assina `/mavros/vision_pose/…` |
+| pymavlink direto | `vision_pose_node backend:=mavlink` standalone em um endpoint dedicado | `PoseSource.VISION`, `auto_vision_feed=False` (somente assinatura) |
+| uXRCE-DDS | `vision_pose_node backend:=dds` | Lê a pose fundida dos tópicos DDS do PX4 |
+
+Opt-in `auto_vision_feed=True`: a missão envia `VISION_*` (opcional `vision_send_speed`).
+Nunca execute também o feeder standalone de mavlink no mesmo endpoint.
+
+## SITL
+
+Gazebo indoor: ground-truth → tópicos canônicos do VSLAM → mesmos backends → EKF3 / EKF2.
+
+| Firmware | Terminal 1 | Terminal 2 (`sim-bridge`) | Feeder | Missão |
+|----------|------------|---------------------------|--------|---------|
+| ArduPilot `PROTOCOL=mavlink` (padrão) | `sim-start … ENV=indoor` | Gazebo + `vision_pose_node` no SERIAL0 (`tcp:…:5760`) | node mavlink | SERIAL1 (`tcp:…:5762`) |
+| ArduPilot `PROTOCOL=mavros` | igual | Gazebo + MAVROS + `vision_pose_node` | node mavros | SERIAL0 |
+| PX4 `mavros` / `dds` | `sim-start FIRMWARE=px4 ENV=indoor` | producer + consumer | node mavros / dds | preset correspondente |
+| PX4 `PROTOCOL=mavlink` | igual | apenas producer (UDP offboard único) | missão `auto_vision_feed=True` | `PX4_MAVLINK_SITL_VISION_CONFIG` |
+
+Arena compartilhada: o ArduPilot compõe `nectar_indoor`; o PX4 usa `indoor_room_px4` +
+`x500_nectar` (PosePublisher ~50 Hz). Parâmetros: ArduPilot `indoor.parm`; PX4
+`px4_indoor.env`. O `x500_vision` padrão do PX4 só via override explícito. Matriz completa:
+[README de simulação](../../simulation/).
+
+Para exercitar a origem opcional do EKF no ArduPilot indoor:
+
+```bash
+make sim-start  FIRMWARE=ardupilot ENV=indoor
+make sim-bridge FIRMWARE=ardupilot ENV=indoor ARGS='set_ekf_origin:=true'
+
+# vision_pose_node log: "EKF origin: sent …" or "already set, skip send"
+
+```
+
+Observação: o SITL padrão do ArduPilot ainda fixa uma origem SIM home (Camberra) mesmo com
+`GPS1_TYPE=0`, então uma sobrescrita tardia geralmente não se mantém — use a linha de log
+para confirmar o caminho do feeder; valide lat/lon em hardware sem GPS (ou depois de um FCU
+limpo, sem origem).
+
+```bash
+ros2 topic hz /visual_slam/tracking/vo_pose_covariance   # ~50 Hz
+ros2 topic echo /mavros/vision_pose/pose_cov --once        # PROTOCOL=mavros
+```
+
+## Visualização {#visualizacao}
+
+Os overlays de trajetória mostram a **estimativa de SLAM / odometria** para que você possa
+avaliar a qualidade do tracking e o loop closure — eles não são uma etapa de calibração.
+Use-os no [bring-up](#bring-up) para verificar: a trajetória acompanha o movimento manual,
+o ruído é aceitável para o Loiter, e a trajetória verde do SLAM se ajusta ao revisitar um
+local (loop closure).
+
+A NVIDIA recomenda rodar o RViz em um PC remoto, não no Jetson
+([tutorial RealSense](https://nvidia-isaac-ros.github.io/concepts/visual_slam/cuvslam/tutorial_realsense.html)).
+
+Dois perfis (`rviz/vslam_light.rviz`, `rviz/vslam_full.rviz`):
+
+| Perfil | Mostra | Custo no producer |
+|---------|-------|---------------|
+| `light` (padrão) | TF + odometria + trajetória SLAM (verde) + trajetória VO (roxa) | nenhum (os tópicos de tracking são sempre publicados) |
+| `full` | light + nuvens de landmarks / loop-closure + pose graph | exige `enable_visualization:=true` |
+
+O perfil `light` desenha duas trajetórias sempre publicadas: a trajetória **verde** do SLAM
+(`/visual_slam/tracking/slam_path`, corrigida por loop closure) e a trajetória **roxa** de
+VO (`/visual_slam/tracking/vo_path`, odometria bruta). Quando um loop se fecha, a
+trajetória verde se ajusta em relação à roxa — esse é o loop closure, visível sem custo no
+producer. A nuvem de pontos roxa literal do loop closure vive no `full` (é um tópico
+`/visual_slam/vis/*`, publicado apenas com `enable_visualization:=true`).
+
+As duas trajetórias `light` são mostradas como um **buffer deslizante** (últimos 15 s por
+padrão) para que a janela não se preencha com a trajetória inteira. O `vslam_rviz.launch.py`
+executa um relay `path_window_node` junto com o RViz (sem custo no Jetson) que republica
+`/visual_slam/tracking/{slam,vo}_path` recortado para os últimos `window_seconds` em
+tópicos `*_windowed`, que o perfil light assina. Defina `window_seconds` como `0` para o
+histórico completo.
+
+**Laptop (nectar buildado)**:
+
+```bash
+ros2 launch nectar vslam_rviz.launch.py profile:=light            # or profile:=full
+ros2 launch nectar vslam_rviz.launch.py window_seconds:=30        # longer buffer
+```
+
+**Laptop (apenas o repo, sem build)** — execute o relay também, senão as trajetórias light
+ficam vazias:
+
+```bash
+ros2 run nectar path_window_node.py    # if built; otherwise: python3 .../nodes/path_window_node.py
+rviz2 -d src/nectar-sdk/nectar/nectar/control/localization/rviz/vslam_light.rviz
+```
+
+O perfil `full` exige que o producer publique os tópicos `/visual_slam/vis/*`, que ficam
+desligados por padrão para manter o Jetson leve:
+
+```bash
+nectar-vslam enable_visualization:=true
+```
+
+## Notas de hardware
+
+**Atual:** Intel RealSense **D435i** + **Isaac ROS Visual SLAM (cuVSLAM)** em um Jetson
+Orin Nano; pose a ~90 Hz. Producer / consumer: [Executar](#executar). Dia do voo:
+[Procedimento indoor](#procedimento-indoor).
+
+**Legado / fallback:** RealSense **T265** +
+[`vision_to_mavros`](https://github.com/Black-Bee-Drones/vision_to_mavros) (`VISO_TYPE=2`).
+Histórico completo, versões e bring-up: [Legado T265](legacy/). Comparação conceitual:
+[Conceitos](concepts/#dois-sistemas-que-usamos).
+
+## Referências
+
+Teoria do módulo e uma bibliografia mais completa:
+[Conceitos → Referências](concepts/#referencias).
+
+- [Isaac ROS Visual SLAM (isaac_ros_visual_slam)](https://nvidia-isaac-ros.github.io/repositories_and_packages/isaac_ros_visual_slam/isaac_ros_visual_slam/index.html)
+- [cuVSLAM](https://nvidia-isaac-ros.github.io/concepts/visual_slam/cuvslam/index.html)
+- [Isaac ROS Development Environment](https://nvidia-isaac-ros.github.io/v/release-3.2/concepts/docker_devenv/index.html)
+- [ArduPilot: Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html)
+- [ArduPilot: Setting Home and/or EKF origin](https://ardupilot.org/dev/docs/mavlink-get-set-home-and-origin.html)
+- [ArduPilot: Non-GPS Navigation](https://ardupilot.org/copter/docs/common-non-gps-navigation-landing-page.html)
+- [PX4: External Position Estimation](https://docs.px4.io/main/en/ros/external_position_estimation.html)

--- a/i18n/pt/modules/control/localization/legacy.md
+++ b/i18n/pt/modules/control/localization/legacy.md
@@ -1,0 +1,173 @@
+# Legado: T265 e vision_to_mavros
+
+Caminho indoor histórico que a Black Bee voou antes da D435i + Isaac ROS Visual SLAM:
+câmera de tracking Intel RealSense **T265**, computador de bordo (tipicamente um
+Raspberry Pi), MAVROS, e [`vision_to_mavros`](https://github.com/Black-Bee-Drones/vision_to_mavros).
+
+Esta página serve para entender logs mais antigos, hardware de fallback, e como a bridge
+atual do Nectar evoluiu. Para o stack **atual**, use o
+[README de Localização](../) ([procedimento indoor](../#procedimento-indoor),
+[origem do EKF](../#origem-do-ekf)). Conceitos: [Conceitos](../concepts/).
+
+## Linha do tempo
+
+| Período | Stack | Notas |
+|--------|-------|-------|
+| **2023** | ROS 1, RPi, T265, `vision_to_mavros` (thien94), ArduPilot | Primeiro drone de competição indoor; IMAV 2023 indoor (3º lugar). |
+| **2024** | ROS 2 Humble, RPi, T265, port [`vision_to_mavros`](https://github.com/Black-Bee-Drones/vision_to_mavros) da Black Bee | Mesmo fluxo de dados; launches ROS 2 (`t265_all_nodes_launch.py`). |
+| **Depois de 2024** | Jetson Orin Nano, D435i, Isaac ROS cuVSLAM, `vision_pose` do Nectar | T265 descontinuada; sensível a vibração e ao ambiente; um acidente que trincou a tampa da lente deixou o tracking menos confiável. O T265 permanece como fallback documentado. |
+
+## Fluxo de dados
+
+```mermaid
+flowchart LR
+  t265[T265 on-device VIO]
+  rs[realsense-ros TF / odom]
+  v2m[vision_to_mavros]
+  mavros[MAVROS]
+  fcu[FCU EKF]
+  t265 --> rs
+  rs -->|"/tf"| v2m
+  v2m -->|"/mavros/vision_pose/pose"| mavros
+  mavros -->|"VISION_POSITION_ESTIMATE"| fcu
+```
+
+Comparado a hoje:
+
+| | T265 legado | D435i + cuVSLAM atual |
+|---|-------------|-------------------------|
+| Producer da pose | VIO no dispositivo (on-camera) | Isaac ROS Visual SLAM no Jetson |
+| Bridge | Pacote externo `vision_to_mavros` | `control/localization` do Nectar (`vision_pose_node`) |
+| Tópico MAVROS | `/mavros/vision_pose/pose` | `/mavros/vision_pose/pose_cov` (típico) |
+| `VISO_TYPE` do ArduPilot | `2` (Intel T265) | `1` (MAVLink) |
+| Limitação de taxa / alinhamento ENU | Dentro do `vision_to_mavros` | Producer + backends do Nectar / MAVROS |
+
+A visão geral do LuckyBird sobre frames e por que uma bridge é necessária:
+[Discourse parte 2](https://discuss.ardupilot.org/t/integration-of-ardupilot-and-vio-tracking-camera-part-2-complete-installation-and-indoor-non-gps-flights/43405).
+O `realsense-ros` já publica nas convenções ENU do ROS, mas a montagem da câmera e o
+alinhamento corpo/mundo do T265 ainda precisam de uma rotação para que o heading do FCU
+corresponda ao do veículo — esse é um dos principais papéis do `vision_to_mavros`.
+
+## O que o vision_to_mavros faz
+
+A partir do [README ROS 2 da Black Bee](https://github.com/Black-Bee-Drones/vision_to_mavros)
+e do pacote upstream [thien94](https://github.com/thien94/vision_to_mavros):
+
+1. **TF → pose** — consulta `source_frame_id` → `target_frame_id` (padrões em torno de
+   `/camera_link` e `/camera_odom_frame`) e publica `geometry_msgs/PoseStamped` em
+   `/mavros/vision_pose/pose`.
+2. **Limitação de taxa** — o T265 / TF pode ser muito mais rápido do que o FCU precisa; o
+   LuckyBird cita ~10–15 Hz como mínimo prático e ~30 Hz como típico (`output_rate`,
+   padrão `30.0` no port ROS 2).
+3. **Alinhamento de montagem / mundo** — `roll_cam`, `pitch_cam`, `yaw_cam`, e
+   `gamma_world` rotacionam os frames de câmera e de mundo para a convenção de corpo ENU
+   que o MAVROS espera antes da conversão para NED no wire.
+
+Padrões de exemplo voltados para frente (porta USB à direita): `roll_cam=0`,
+`pitch_cam=0`, `yaw_cam=0`, `gamma_world=-1.5707963`. Outras orientações estão tabeladas
+no README do pacote.
+
+Launches (ROS 2):
+
+```bash
+ros2 launch vision_to_mavros t265_tf_to_mavros_launch.py   # bridge only
+ros2 launch vision_to_mavros t265_all_nodes_launch.py       # T265 + MAVROS + bridge
+```
+
+## Versões de software (pins do SDK)
+
+O T265 precisa de librealsense / realsense-ros **mais antigos** do que os padrões atuais
+para D4xx. Os pins vivem em
+[`scripts/lib/config.sh`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/lib/config.sh),
+[COMPATIBILITY](../../../../setup/compatibility/),
+[docs/setup/realsense.md](../../../../setup/realsense/), e
+[guia Docker](../../../../setup/docker/).
+
+| Alvo | librealsense | realsense-ros | Notas |
+|--------|--------------|---------------|-------|
+| D4xx Humble (padrão do SDK) | v2.55.1 | 4.55.1 | `make realsense` |
+| **T265 (somente Humble)** | **v2.53.1** | **4.51.1** | `LIBREALSENSE_VERSION=v2.53.1 REALSENSE_ROS_TAG=4.51.1 make realsense` |
+| Docker `:humble-t265` | v2.53.1 | 4.51.1 | Imagem pré-buildada voltada para T265 |
+| Camada Isaac VSLAM (producer D435i) | v2.55.1 (RSUSB) | **4.51.1-isaac** | Dentro da imagem `make isaac-run` — não é o stack T265 |
+
+Não misture um T265 com a imagem producer do Isaac cuVSLAM esperando suporte de primeira
+classe; o caminho Isaac tem como alvo estéreo D435i + IMU para Visual SLAM.
+
+Imagens de companion históricas na equipe também usaram librealsense **2.50.0** durante o
+bring-up inicial em ROS 2; prefira o override do SDK acima para qualquer coisa nova.
+
+## Parâmetros do ArduPilot (T265)
+
+A partir da página [Intel RealSense T265](https://ardupilot.org/copter/docs/common-vio-tracking-camera.html)
+do ArduPilot e das notas de bring-up da equipe:
+
+| Parâmetro | Valor típico | Finalidade |
+|-----------|---------------|---------|
+| `VISO_TYPE` | `2` | Backend Intel T265 |
+| `EK3_SRC1_POSXY` | `6` | Posição horizontal ExternalNav |
+| `EK3_SRC1_VELXY` | `6` ou ajustado | Velocidade horizontal ExternalNav (fornecida pelo T265) |
+| `EK3_SRC1_POSZ` | `1` (Baro) ou `6` | A equipe costumava preferir **baro para Z** porque a altura por visão era sensível a vibração; o caminho D435i atual usa vision Z por padrão — veja [Fonte de altura](../#fonte-de-altura) |
+| `EK3_SRC1_VELZ` | `6` | Velocidade vertical ExternalNav |
+| `EK3_SRC1_YAW` | `6` ou bússola | Yaw da visão vs bússola |
+| `GPS1_TYPE` | `0` | Opcional: desabilita o GPS indoor |
+| Serial para o companion | por exemplo `SERIAL2_PROTOCOL=2`, `SERIAL2_BAUD=921` | MAVLink para o RPi (porta depende da fiação) |
+
+Reinicie o FCU depois de mudar esses parâmetros. No ArduPilot sem fix de GPS, defina a
+**origem do EKF** antes dos modos de posição — mesmas regras de hoje
+([Origem do EKF](../#origem-do-ekf)).
+
+## Bring-up histórico (era ROS 2)
+
+Procedimento público resumido (LuckyBird + adaptação ROS 2 da equipe):
+
+1. Ligue a aeronave e o companion; confirme o T265 no USB3 e o serial companion↔FCU.
+2. No companion: confirme a câmera (`rs-enumerate-devices`).
+3. Suba o stack — tudo em um:
+   `ros2 launch vision_to_mavros t265_all_nodes_launch.py`
+   ou os três nós separadamente (launch T265 da realsense, MAVROS,
+   `t265_tf_to_mavros_launch.py`) como na parte 2 do LuckyBird.
+4. Verifique a taxa de `/mavros/vision_pose/pose` (~30 Hz) e o `VISION_POSITION_ESTIMATE`
+   no MAVLink Inspector da GCS.
+5. Defina a origem do EKF no mapa quando o ArduPilot não tiver uma origem derivada de GPS
+   ([Origem do EKF](../#origem-do-ekf)).
+6. **Verificação de escala:** levante o veículo ~**1 m** e o abaixe de novo (orientação do
+   ArduPilot / da equipe para a escala vertical do T265), depois mova manualmente e
+   confirme que o ícone da GCS acompanha.
+7. Primeiro voo: Stabilize/AltHold → movimento suave → Loiter com reversão imediata se o
+   tracking falhar — mesmo padrão do [Procedimento indoor](../#procedimento-indoor).
+
+O ROS 1 usava equivalentes do `roslaunch` (`rs_t265.launch`, `t265_tf_to_mavros.launch`,
+`t265_all_nodes.launch`); o grafo era o mesmo.
+
+## O que se manteve vs o que mudou
+
+**Ainda verdadeiro hoje**
+
+- ArduPilot: origem do EKF exigida quando nenhum GPS fornece um fix (a menos que a
+  restauração de origem gravada da 4.7+ esteja habilitada) — [Origem do EKF](../#origem-do-ekf).
+- Verificação de movimento manual / ícone da GCS antes do Loiter.
+- Cuidado com soft-mount e vibração.
+- Um único feeder de visão para o FCU.
+- Stabilize/AltHold antes de confiar no Loiter em um setup novo.
+
+**Mudou com o Nectar + cuVSLAM**
+
+- O producer roda no Jetson dentro do container Isaac (`nectar-vslam`), não como VIO no
+  próprio T265.
+- A bridge é in-tree (`vision_pose.launch.py` / `VisionPoseBridge` /
+  `MavrosVisionRelay`), não um pacote `vision_to_mavros` separado.
+- `VISO_TYPE=1` e o tópico de pose com covariância são o caminho padrão do ArduPilot.
+- O loop closure e a visualização da trajetória SLAM/VO são de primeira classe
+  ([Visualização](../#visualizacao)).
+- A velocidade opcional é derivada no wrapper do Isaac e habilitada por meio da flag
+  `send_speed:=true` ([Velocidade](../#velocidade-opcional)).
+
+## Referências
+
+- [ArduPilot: Intel RealSense T265](https://ardupilot.org/copter/docs/common-vio-tracking-camera.html)
+- [ArduPilot: ROS VIO tracking camera](https://ardupilot.org/dev/docs/ros-vio-tracking-camera.html)
+- Série T265 do LuckyBird — [parte 1](https://discuss.ardupilot.org/t/integration-of-ardupilot-and-vio-tracking-camera-part-1-getting-started-with-the-intel-realsense-t265-on-rasberry-pi-3b/43162), [parte 2](https://discuss.ardupilot.org/t/integration-of-ardupilot-and-vio-tracking-camera-part-2-complete-installation-and-indoor-non-gps-flights/43405)
+- [thien94/vision_to_mavros](https://github.com/thien94/vision_to_mavros) · [Black-Bee-Drones/vision_to_mavros](https://github.com/Black-Bee-Drones/vision_to_mavros)
+- [Instalação da RealSense (override para T265)](../../../../setup/realsense/)
+- [Docker RealSense / `:humble-t265`](../../../../setup/docker/)
+- [Conceitos — comparação de sistemas](../concepts/#dois-sistemas-que-usamos)

--- a/i18n/pt/modules/control/mavlink.md
+++ b/i18n/pt/modules/control/mavlink.md
@@ -1,0 +1,196 @@
+# Controle MAVLink Direto
+
+Um caminho de controle [pymavlink](https://mavlink.io/en/mavgen_python/) direto para veículos ArduPilot **e PX4**, para os casos em que a ponte [MAVROS](../mavros/) não está disponível, não é desejada, ou é insuficiente (stack de computador de bordo mais leve, plugins customizados, ou um único proprietário da porta serial do FCU).
+
+`MavlinkDrone` é o mesmo veículo ArduPilot que o [`MavrosDrone`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavros/drone.py), alcançado por um transporte diferente. Ambos são subclasses do núcleo [`ArduPilotDrone`](../ardupilot/) compartilhado, então **toda a lógica de voo/navegação é idêntica** — apenas a conectividade on-wire difere.
+
+`PymavlinkTransport` é **neutro em relação a firmware**: um [`MavlinkModeCodec`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavlink/modes.py) injetado isola a única diferença de firmware (encode/decode do modo de voo). `ArduPilotModeCodec` (padrão, `SET_MODE` + `mode_mapping()` do pymavlink) apoia o `MavlinkDrone`; [`Px4ModeCodec`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/mavlink_drone.py) (`MAV_CMD_DO_SET_MODE` com os modos `(main, sub)` do PX4) apoia o [`Px4MavlinkDrone`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/mavlink_drone.py). Telemetria, setpoints, arming, parâmetros e taxas de stream são compartilhados sem alteração.
+
+```mermaid
+classDiagram
+    class VehicleDrone {
+        <<abstract>>
+        +takeoff() land() move_to() move_to_gps() rtl()
+        +arm()* set_mode() set_param() get_altitude()
+    }
+    class ArduPilotDrone
+    class Px4Drone
+    class VehicleTransport {
+        <<abstract>>
+        +state local_pose vision_pose gps heading rel_alt rangefinder distance_sensors
+        +arm() set_mode() command_takeoff() set_param()
+        +send_velocity_target() send_local_target() send_global_target()
+    }
+    class MavrosTransport
+    class PymavlinkTransport
+    class MavlinkModeCodec {
+        <<abstract>>
+    }
+    class ArduPilotModeCodec
+    class Px4ModeCodec
+
+    VehicleDrone o-- VehicleTransport
+    VehicleDrone <|-- ArduPilotDrone
+    VehicleDrone <|-- Px4Drone
+    VehicleTransport <|.. MavrosTransport
+    VehicleTransport <|.. PymavlinkTransport
+    ArduPilotDrone <|-- MavrosDrone
+    ArduPilotDrone <|-- MavlinkDrone
+    Px4Drone <|-- Px4MavlinkDrone
+    MavlinkDrone ..> PymavlinkTransport : builds
+    Px4MavlinkDrone ..> PymavlinkTransport : builds
+    PymavlinkTransport o-- MavlinkConnection
+    PymavlinkTransport o-- MavlinkModeCodec
+    MavlinkModeCodec <|.. ArduPilotModeCodec
+    MavlinkModeCodec <|.. Px4ModeCodec
+```
+
+## Componentes
+
+### `MavlinkConnection`
+
+Wrapper fino em torno de `mavutil.mavlink_connection`, em [`connection.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavlink/connection.py). Abre um único endpoint MAVLink, faz o handshake de heartbeat para descobrir `target_system`/`target_component`, e expõe a conexão bruta via `.master`. Adiciona um **`send_lock`**: um único endpoint precisa ter um leitor de RX, mas pode ter muitos remetentes (setpoints, heartbeat, rangefinder, ponte de visão), e `mav.*_send` não é thread-safe, então todo remetente serializa por esse lock.
+
+### `PymavlinkTransport`
+
+[`transport.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavlink/transport.py) — a implementação de `VehicleTransport` que possui o link do FCU diretamente.
+
+- **RX**: um timer do ROS no node do drone drena `recv_match(blocking=False)` e despacha cada mensagem por uma tabela de handlers. Tipos decodificados: `HEARTBEAT`, `GLOBAL_POSITION_INT`, `LOCAL_POSITION_NED`, `ATTITUDE`, `RANGEFINDER`/`DISTANCE_SENSOR`, `PARAM_VALUE`, `COMMAND_ACK` e `STATUSTEXT`. Isso mantém o modelo de concorrência idêntico ao MAVROS — a telemetria é atualizada na thread do executor, e as chamadas bloqueantes de voo a leem na thread do usuário.
+- **TX**: um timer de heartbeat a 1 Hz anuncia o computador de bordo; comandos saem via `command_long`/`set_mode`/`param_set`; setpoints via `set_position_target_local_ned` / `set_position_target_global_int`.
+- **Frames**: o núcleo fala ENU/FLU; o transporte converte para o NED/FRD on-wire na saída e de volta para ENU na entrada (exatamente o que o MAVROS faz internamente).
+- **Streams**: em `start()`, ele solicita intervalos de mensagem via [`streams.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavlink/streams.py) (`MAV_CMD_SET_MESSAGE_INTERVAL`); um helper legado `REQUEST_DATA_STREAM` (`request_data_streams`) também é fornecido em `streams.py`, para firmwares mais antigos, mas não é chamado automaticamente.
+
+#### Exposição de STATUSTEXT
+
+O MAVROS repassa o [`STATUSTEXT`](https://mavlink.io/en/messages/common.html#STATUSTEXT) do FCU para `/rosout`; o transporte direto não tem esse relay, então `_on_statustext` loga o texto do FCU no logger ROS do drone, com uma severidade correspondente (`MAV_SEVERITY_ERROR` → `error`, `WARNING` → `warn`, senão `info`). Isso expõe o motivo real da rejeição de um comando — mais utilmente falhas de `PreArm: ...` — que de outra forma ficariam invisíveis sobre um link direto. Mensagens idênticas consecutivas são deduplicadas.
+
+#### Confirmação de parâmetro
+
+`set_param` limpa qualquer valor em cache, envia `PARAM_SET`, e então espera até **0,5 s** pelo eco `PARAM_VALUE` do FCU, verificando se o valor ecoado corresponde (dentro de uma tolerância) antes de retornar `True`/logar a confirmação. O ArduPilot ecoa um parâmetro conhecido em poucos milissegundos e permanece em silêncio para um parâmetro desconhecido, então o timeout curto mantém o probing de alias (4.6 `WPNAV_*` → 4.8 `WP_*`) responsivo sem falsos negativos em um link rápido. Diferente do resultado de serviço do MAVROS (que só confirma que a requisição foi aceita), isso confirma que o valor de fato foi aplicado.
+
+#### Sensores de distância
+
+Cada mensagem `DISTANCE_SENSOR` é decodificada em um `DistanceReading` e armazenada por id de sensor em um mapa copy-on-write, exposto como `distance_sensors` (e `get_distance(orientation)` no drone). O sensor voltado para baixo também atualiza `rangefinder`. Toda orientação reportada é coletada automaticamente, sem nenhuma configuração do lado do SDK além da configuração de rangefinder/proximidade no FCU. Veja o [README do núcleo do veículo](../vehicle/#sensores-de-distancia) para o modelo de dados.
+
+#### Taxas de stream
+
+[`streams.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavlink/streams.py) solicita estas taxas por mensagem em `start()` (sobrescrevível via `MavlinkConfig.stream_rates`). A orientação de Non-GPS do ArduPilot quer pose ≥ 4 Hz; os padrões solicitam mais, para que a navegação PID tenha feedback fresco.
+
+| Mensagem | Taxa (Hz) |
+| --- | --- |
+| `HEARTBEAT` | 1 |
+| `SYS_STATUS` | 2 |
+| `ATTITUDE` | 20 |
+| `GLOBAL_POSITION_INT` | 10 |
+| `LOCAL_POSITION_NED` | 20 |
+| `GPS_RAW_INT` | 5 |
+| `RANGEFINDER` | 10 |
+| `DISTANCE_SENSOR` | 10 |
+| `VFR_HUD` | 5 |
+| `HOME_POSITION` | 1 |
+
+Uma taxa `<= 0` desabilita um stream. `GPS_RAW_INT` e alguns outros são solicitados por completude, mesmo que a posição venha de `GLOBAL_POSITION_INT`/`LOCAL_POSITION_NED`.
+
+A regra de um único leitor de RX é o que permite que um `RangefinderPublisher` e uma `VisionPoseBridge` compartilhem a mesma `MavlinkConnection` com segurança — eles só *enviam*, por meio do lock.
+
+### Pose de visão (indoor)
+
+[`vision_bridge.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavlink/vision_bridge.py) — navegação externa para ambiente sem GPS. Com
+`pose_source=VISION`, `PymavlinkTransport` sempre preenche `vision_pose` a partir de
+`vision_pose_topic`, para o PID do computador de bordo. Quem envia
+[`VISION_POSITION_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE)
+para o FCU (o [Non-GPS Position Estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html) do ArduPilot
+quer ≥ 4 Hz) é controlado por `auto_vision_feed`:
+
+| `auto_vision_feed` | Feed do FCU | Pose do computador de bordo |
+| --- | --- | --- |
+| `False` (padrão) | `vision_pose_node backend:=mavlink` separado, em **outro** endpoint MAVLink | `VisionPoseSubscriber` |
+| `True` | `VisionPoseBridge` própria da missão (opcional `vision_send_speed` → `VisionSpeedBridge`) | mesma ponte, `on_pose` |
+
+Nunca rode os dois remetentes no mesmo endpoint. Pipeline ponta a ponta (produtor,
+backends, configuração do FCU): [Localization](localization/).
+
+**Qual tópico apontar** (`vision_pose_topic`):
+
+| Cenário | Tópico | Por quê |
+| --- | --- | --- |
+| Hardware real | Saída do VSLAM, `/visual_slam/tracking/vo_pose_covariance` (padrão) | Assina diretamente o estimador |
+| Simulação Gazebo (indoor) | igual | `gz_vision_source` republica o ground truth no tópico canônico (`MAVLINK_SITL_VISION_CONFIG`) |
+
+A taxa de repasse é igual à taxa de subscription. `vision_rate_hz` **não** está conectado — não confie nele para limitar a taxa.
+
+## Início rápido
+
+**Outdoor / SITL sobre TCP**:
+
+```python
+from nectar.control import DroneFactory, MavlinkConfig, PoseSource
+
+config = MavlinkConfig(connection_string="tcp:127.0.0.1:5760", expect_lidar=False)
+drone = DroneFactory.create("mavlink", config)
+
+drone.takeoff(altitude=2.0)
+drone.move_to(x=2.0, y=1.0, z=0.0, precision=0.2)
+drone.rtl(land=True)
+```
+
+**Hardware real via serial** (Jetson ↔ Pixhawk):
+
+```python
+config = MavlinkConfig(connection_string="/dev/ttyTHS1", baud=921600)
+drone = DroneFactory.create("mavlink", config)
+```
+
+**Indoor, baseado em visão** (feeder externo por padrão):
+
+```python
+config = MavlinkConfig(
+    pose_source=PoseSource.VISION,
+    connection_string="/dev/ttyUSB0",  # or a router UDP endpoint for the mission
+    vision_pose_topic="/visual_slam/tracking/vo_pose_covariance",
+)
+drone = DroneFactory.create("mavlink", config)
+```
+
+Presets prontos ([`config.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/config.py)): `MAVLINK_SITL_CONFIG` (tcp `5760`),
+`MAVLINK_SITL_GAZEBO_CONFIG` / `MAVLINK_SITL_VISION_CONFIG` (missão em SERIAL1 tcp `5762`;
+feeder indoor em SERIAL0 tcp `5760` quando `mavros:=false`).
+
+### Formato da connection string
+
+Diferente do `MavrosConfig` (`fcu_url` do MAVROS), `MavlinkConfig.connection_string` é **nativo do pymavlink**:
+
+| Forma | Exemplo |
+| --- | --- |
+| TCP | `tcp:127.0.0.1:5760` |
+| UDP listener | `udp:127.0.0.1:14551` |
+| UDP sender | `udpout:192.168.1.10:14550` |
+| Serial | `/dev/ttyUSB0` (+ `baud=`) |
+
+### Compartilhando a conexão com um rangefinder
+
+```python
+from nectar.sensors.rangefinder_publisher import RangefinderPublisher
+
+pub = RangefinderPublisher(sensor, drone.connection)  # shares the lock
+pub.start()
+```
+
+## Quando usar qual transporte
+
+| | `MavrosDrone` (`"mavros"`) | `MavlinkDrone` (`"mavlink"`) |
+| --- | --- | --- |
+| Link | exige um `mavros_node` em execução | possui o endpoint do FCU diretamente |
+| Dependências | stack ROS MAVROS | apenas pymavlink |
+| Feed de visão indoor | `vision_pose` → MAVROS | `vision_pose_node` externo (padrão) ou `auto_vision_feed=True` |
+| Melhor para | implantações ROS completas, ferramental MAVROS existente | stacks de computador de bordo mínimos, proprietário único da serial |
+
+Ambos expõem a mesma API `Drone` e as mesmas capacidades.
+
+## Referências
+
+- [Documentação do pymavlink](https://mavlink.io/en/mavgen_python/)
+- [Mensagens comuns do MAVLink](https://mavlink.io/en/messages/common.html)
+- [ArduPilot Copter commands in Guided mode](https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html)
+- [ArduPilot Non-GPS position estimation](https://ardupilot.org/dev/docs/mavlink-nongps-position-estimation.html)
+- [mavlink-router](https://github.com/mavlink-router/mavlink-router) — distribui (fan out) a serial do FCU para múltiplos endpoints

--- a/i18n/pt/modules/control/mavros.md
+++ b/i18n/pt/modules/control/mavros.md
@@ -1,0 +1,170 @@
+# Transporte MAVROS
+
+`MavrosTransport` conecta o [núcleo do veículo](../vehicle/) compartilhado a um [`mavros_node`](https://github.com/mavlink/mavros) em execução. Ele apoia o mesmo veículo sobre MAVROS para os dois firmwares (`MavrosDrone` para ArduPilot, `Px4MavrosDrone` para PX4) — o comportamento de voo agnóstico a firmware, a navegação, o takeoff/land, o GPS, o RTL e o PID são **compartilhados e documentados no [núcleo do veículo](../vehicle/)** (as especificidades de setpoint/parâmetro do ArduPilot estão em [ArduPilot](../ardupilot/)).
+
+> Para a API pública do `Drone`, os métodos de navegação, as referências, as fontes de altitude, a detecção de takeoff/land e a configuração de PID, veja o [README do núcleo do veículo](../vehicle/).
+
+## Papel
+
+[`MavrosTransport`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavros/transport.py) implementa a interface [`VehicleTransport`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/transport.py) contra o MAVROS:
+
+- **Telemetria** ← **subscriptions** do ROS. Cada callback converte uma mensagem `mavros_msgs`/`geometry_msgs`/`sensor_msgs` em um valor simples de `vehicle/types` e o armazena atomicamente.
+- **Comandos** → **service clients** do ROS (`/mavros/set_mode`, `/mavros/cmd/*`, `/mavros/param/set_parameters`).
+- **Setpoints** → **publishers** do ROS (`/mavros/setpoint_raw/local`, `/mavros/setpoint_position/global`).
+- A **conversão de frame** é feita pelo próprio MAVROS (ENU↔NED), então o transporte publica valores na convenção ROS diretamente.
+
+```mermaid
+classDiagram
+    class VehicleTransport {
+        <<abstract>>
+        +state local_pose vision_pose gps heading rel_alt rangefinder distance_sensors
+        +arm() set_mode() command_takeoff() command_land() set_param()
+        +send_velocity_target() send_local_target() send_global_target()
+    }
+    class MavrosTransport {
+        -_vehicle_state VehicleState
+        -_local_plain _vision_plain _gps_plain LocalPose/GeoPoint
+        +start() close() driver_command()
+        +send_command_long(command, *params) bool
+    }
+    VehicleTransport <|.. MavrosTransport
+    MavrosTransport ..> mavros_node : ROS topics/services
+```
+
+`MavrosDrone` é simplesmente `ArduPilotDrone` construído com um `MavrosTransport`, e `Px4MavrosDrone` é `Px4Drone` construído com o mesmo transporte (veja [`drone.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/mavros/drone.py) e [`../px4/mavros_drone.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/mavros_drone.py)).
+
+## Requisitos
+
+O MAVROS é uma dependência opcional (não faz parte da instalação padrão do SDK). Instale-o uma vez com `make drone-mavros` (ou `./scripts/setup.sh drone mavros`), que adiciona `ros-<distro>-mavros`/`-mavros-extras` e os datasets do GeographicLib.
+
+Um `mavros_node` precisa então estar fazendo a ponte com o FCU. O transporte pode iniciá-lo para você quando `MavrosConfig.start_driver=True`:
+
+```
+ros2 launch mavros apm.launch fcu_url:=<connection_string>
+```
+
+`MavrosConfig.connection_string` é um [`fcu_url`](https://github.com/mavlink/mavros/blob/ros2/mavros/README.md) do MAVROS (por exemplo, `serial:///dev/ttyUSB0:921600`, `tcp://127.0.0.1:5760`), **não** uma string do pymavlink. Veja o [transporte MAVLink](../mavlink/) para a alternativa de conexão direta.
+
+## Configuração
+
+```python
+import nectar
+from nectar.control import DroneFactory, MavrosConfig, PoseSource
+
+nectar.init()
+
+config = MavrosConfig(
+    pose_source=PoseSource.VISION,        # VISION (indoor) or GPS (outdoor)
+    expect_lidar=True,                    # wait for rangefinder at startup
+    connection_string="serial:///dev/ttyUSB0:921600",
+    apply_setpoint_params=False,          # True to push WPNAV/GUID params to the FCU on arm
+)
+drone = DroneFactory.create("mavros", config)
+```
+
+`MavrosConfig` expõe um nome de tópico para cada subscription (`state_topic`, `lidar_topic`, `local_position_topic`, `vision_topic`, `gps_topic`, `heading_topic`, `rel_alt_topic`), uma tupla opcional `distance_sensors` (veja [Sensores de Distância](#sensores-de-distancia)), além de `pid_config_file` / `setpoint_config_file` / `apply_setpoint_params` (consumidos pelo núcleo compartilhado). A `pose_source` seleciona o conjunto de subscriptions indoor vs. outdoor.
+
+**Presets de SITL** (em [`config.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/config.py)): `SITL_CONFIG`, `SITL_GPS_CONFIG`, `SITL_GAZEBO_CONFIG`, `SITL_VISION_CONFIG`.
+
+## Mapeamento de Telemetria
+
+Os callbacks de subscriber convertem mensagens ROS para os tipos simples do núcleo:
+
+| Tópico ROS | Tipo ROS | Tipo no núcleo | Armazenado como |
+|---|---|---|---|
+| `/mavros/state` | `mavros_msgs/State` | `VehicleState` | `state` |
+| `/mavros/local_position/pose` | `geometry_msgs/PoseStamped` | `LocalPose` | `local_pose` |
+| `/mavros/vision_pose/pose_cov` | `geometry_msgs/PoseWithCovarianceStamped` | `LocalPose` | `vision_pose` |
+| `/mavros/vision_pose/pose` | `geometry_msgs/PoseStamped` | `LocalPose` | `vision_pose` |
+| `/mavros/global_position/global` | `sensor_msgs/NavSatFix` | `GeoPoint` | `gps` |
+| `/mavros/global_position/rel_alt` | `std_msgs/Float64` | `float` | `rel_alt` |
+| `/mavros/global_position/compass_hdg` | `std_msgs/Float64` | `float` | `heading` |
+| `/mavros/rangefinder/rangefinder` | `sensor_msgs/Range` | `float` | `rangefinder` |
+
+`/mavros/state` é assinado com durabilidade `TRANSIENT_LOCAL`, de modo que o último estado em cache seja entregue na subscription (capturando de forma confiável mudanças de arm/modo). A subscription de visão é escolhida em runtime: um callback `PoseWithCovarianceStamped` quando o nome do tópico contém `pose_cov`, caso contrário um `PoseStamped` simples. Indoor (`pose_source=VISION`) assina o tópico de visão; outdoor assina GPS, rel-alt e heading da bússola.
+
+Os tópicos de comando (publishers) e os serviços do MAVROS estão listados abaixo.
+
+## Sensores de Distância {#sensores-de-distancia}
+
+`lidar_topic` alimenta o `rangefinder` voltado para baixo, usado para altitude. Para expor rangefinders adicionais ou setores de proximidade (`distance_sensors` / `get_distance(orientation)` no drone), dois lados precisam estar alinhados:
+
+1. O MAVROS precisa publicá-los. Seu plugin [`distance_sensor`](https://github.com/mavlink/mavros/blob/ros2/mavros_extras/src/plugins/distance_sensor.cpp) mapeia cada id `DISTANCE_SENSOR` do FCU para um tópico `sensor_msgs/Range`, por meio dos parâmetros por sensor do plugin.
+2. O SDK precisa assinar esses tópicos. `Range` não carrega id nem orientação, então declare cada um em `MavrosConfig.distance_sensors` para marcar as leituras recebidas:
+
+```python
+from nectar.control import MavrosConfig, DistanceSensorTopic, SensorOrientation
+
+config = MavrosConfig(
+    distance_sensors=(
+        DistanceSensorTopic("/mavros/distance_sensor/rangefinder_fwd", SensorOrientation.FORWARD, sensor_id=1),
+        DistanceSensorTopic("/mavros/distance_sensor/rangefinder_left", SensorOrientation.LEFT, sensor_id=2),
+    ),
+)
+```
+
+`sensor_type` é derivado de `Range.radiation_type`; `signal_quality` não está disponível via MAVROS e permanece `None`. O [transporte MAVLink](../mavlink/) direto não precisa de nada disso, lendo id e orientação diretamente de `DISTANCE_SENSOR`. Veja o [README do núcleo do veículo](../vehicle/#sensores-de-distancia) para o modelo de dados.
+
+## Tópicos e Serviços ROS2
+
+### Publishers
+
+| Tópico | Tipo | Finalidade |
+|-------|------|---------|
+| `/mavros/setpoint_raw/local` | PositionTarget | Setpoints de velocidade e posição local |
+| `/mavros/setpoint_position/global` | GeoPoseStamped | Setpoints de posição GPS (outdoor) |
+| `/mavros/setpoint_raw/global` | GlobalPositionTarget | Setpoints brutos de GPS (outdoor) |
+
+Setpoints locais usam uma bitmask de velocidade (velocidade + yaw-rate ativos) para `move_velocity`, e uma bitmask de posição (posição + yaw ativos) para alvos de posição local. O MAVROS traduz `PositionTarget` para [`SET_POSITION_TARGET_LOCAL_NED`](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED) (veja [`setpoint_mixin.hpp`](https://github.com/mavlink/mavros/blob/ros2/mavros/include/mavros/setpoint_mixin.hpp)).
+
+### Serviços
+
+| Serviço | Tipo | Finalidade |
+|---------|------|---------|
+| `/mavros/set_mode` | SetMode | Muda o modo de voo |
+| `/mavros/cmd/arming` | CommandBool | Arma/desarma os motores |
+| `/mavros/cmd/takeoff` | CommandTOL | Comando de takeoff |
+| `/mavros/cmd/land` | CommandTOL | Comando de land |
+| `/mavros/cmd/set_home` | CommandHome | Define a posição de home |
+| `/mavros/cmd/command` | CommandLong | Comandos MAVLink genéricos (`set_speed`, `do_servo`, disarm) |
+| `/mavros/param/set_parameters` | SetParameters | Define parâmetros do FCU |
+
+## Comportamento das Chamadas de Serviço
+
+Todas as chamadas de serviço passam por `BaseDrone._call_service`, que é segura contra deadlock: seguindo a [orientação de sync/async do ROS 2](https://docs.ros.org/en/humble/How-To-Guides/Sync-Vs-Async.html), ela chama `call_async` e bloqueia na future enquanto o executor do SDK continua girando (spinning) os callbacks em uma thread de fundo. Ela retorna o **objeto de resposta** (ou `None` em timeout/erro); só valida campos da resposta quando um `validator` é passado.
+
+O transporte interpreta as respostas assim:
+
+| Comando | Método | Condição de sucesso |
+|---|---|---|
+| set_mode, arm, takeoff, land, set_home, disarm | `bool(res)` | **Heurística de ACK de serviço** — uma resposta retornada conta como sucesso |
+| `COMMAND_LONG` genérico (`set_speed`, `do_servo`) | `send_command_long` | `bool(res) and res.success` |
+| `set_param` | — | todos os `results[].successful` |
+
+**Por que a heurística de ACK de serviço para arm/takeoff/land**: validar `res.success` / `res.result` nesses serviços produzia falsos negativos e retentativas desnecessárias, então o transporte trata uma resposta bem-formada do MAVROS como aceitação e deixa o núcleo do veículo confirmar o resultado pela telemetria: `arm()` faz poll de `is_armed`/modo, e takeoff/land usam a detecção de estabilização do [`FlightSequencer`](../vehicle/#decolagem-e-pouso). O `COMMAND_LONG` genérico não tem estado de acompanhamento para fazer poll, então ainda verifica `res.success`.
+
+### Códigos MAV_RESULT
+
+Os serviços de comando do MAVROS reportam o [MAV_RESULT](https://mavlink.io/en/messages/common.html#MAV_RESULT) do MAVLink no campo `result`: `0 ACCEPTED`, `1 TEMPORARILY_REJECTED`, `2 DENIED`, `3 UNSUPPORTED`, `4 FAILED`, `5 IN_PROGRESS`.
+
+## Visão Indoor
+
+Com o MAVROS, o EKF do FCU (EKF3 do ArduPilot / EKF2 do PX4) recebe navegação externa pelo próprio plugin de visão do MAVROS: uma fonte de pose externa publica em `/mavros/vision_pose/pose_cov` (ou `/pose`), e o MAVROS converte ENU→NED e envia [`VISION_POSITION_ESTIMATE`](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE) para o FCU. O transporte apenas **assina** o mesmo tópico para expor `vision_pose` para a navegação PID do lado do computador de bordo.
+
+- **D435i + Isaac ROS Visual SLAM** (atual): `D435i → isaac_ros_visual_slam → relay → /mavros/vision_pose/pose_cov` — [Localization](localization/)
+- **T265 + [vision_to_mavros](https://github.com/Black-Bee-Drones/vision_to_mavros)** (legado/fallback): `T265 VIO → /tf → vision_to_mavros (ENU alignment) → /mavros/vision_pose/pose` — [Legacy T265](localization/legacy.md)
+
+Os parâmetros de FCU por firmware (fontes, taxa, fonte de altura) e a origem do EKF estão
+documentados em [Localization → FCU setup](localization/#fcu-setup) /
+[EKF origin](localization/#ekf-origin). Teoria:
+[Concepts](localization/concepts.md). O
+[transporte MAVLink](../mavlink/) direto substitui esse relay do MAVROS por uma
+`VisionPoseBridge` embutida.
+
+## Referências
+
+- [MAVROS GitHub](https://github.com/mavlink/mavros) · [MAVROS ROS2 API](https://docs.ros.org/en/humble/p/mavros/) · [MAVROS Wiki](https://wiki.ros.org/mavros)
+- [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED) · [MAV_RESULT](https://mavlink.io/en/messages/common.html#MAV_RESULT) · [VISION_POSITION_ESTIMATE](https://mavlink.io/en/messages/common.html#VISION_POSITION_ESTIMATE)
+- [ROS 2 Sync vs Async Service Clients](https://docs.ros.org/en/humble/How-To-Guides/Sync-Vs-Async.html) · [ROS 2 Executors](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Executors.html)
+- [vision_to_mavros](https://github.com/Black-Bee-Drones/vision_to_mavros) · [Isaac ROS cuVSLAM with RealSense](https://nvidia-isaac-ros.github.io/concepts/visual_slam/cuvslam/tutorial_realsense.html)
+- Lógica de voo compartilhada: [Núcleo do veículo](../vehicle/) · Especificidades do ArduPilot: [ArduPilot](../ardupilot/)

--- a/i18n/pt/modules/control/obstacles.md
+++ b/i18n/pt/modules/control/obstacles.md
@@ -1,0 +1,697 @@
+# Módulo de Detecção de Obstáculos
+
+Detecção de obstáculos baseada em eventos, com um strategy pattern para comportamentos de
+desvio de obstáculos. Um detector reporta obstáculos, uma strategy decide como reagir, e o
+`ObstacleManager` os executa como parte da navegação — associe um a qualquer drone com
+`add_obstacle_detector`.
+
+## Resumo rápido
+
+```python
+from nectar.control import DepthObstacleDetector, strategies
+
+drone.add_obstacle_detector("depth", DepthObstacleDetector(), strategies.PauseStrategy())
+drone.enable_all_obstacle_detectors()
+
+drone.move_to(x=10.0, y=0.0, z=0.0)   # pauses while an obstacle is detected ahead
+```
+
+## Arquitetura
+
+```mermaid
+classDiagram
+    class ObstacleDetector {
+        <<protocol>>
+        +is_enabled bool
+        +enable()
+        +disable()
+        +update() ObstacleInfo
+        +reset()
+    }
+
+    class ObstacleInfo {
+        <<dataclass>>
+        +detected bool
+        +direction Optional~ObstacleDirection~
+        +distance Optional~float~
+    }
+
+    class ObstacleDirection {
+        <<enum>>
+        FRONT
+        BACK
+        LEFT
+        RIGHT
+        UP
+        DOWN
+    }
+
+    class AvoidanceStrategy {
+        <<abstract>>
+        +execute(drone, info) bool
+        +reset()*
+    }
+
+    class ObstacleHandler {
+        -_detector ObstacleDetector
+        -_strategy AvoidanceStrategy
+        -_node Node
+        -_config ObstacleHandlerConfig
+        -_timer Optional~Timer~
+        -_last_info ObstacleInfo
+        -_lock Lock
+        +detector ObstacleDetector
+        +strategy AvoidanceStrategy
+        +is_enabled bool
+        +last_info ObstacleInfo
+        +enable()
+        +disable()
+        +update() ObstacleInfo
+        +should_continue(drone) bool
+        +get_axis_modifiers() tuple~bool,bool,bool~
+        +reset()
+        +cleanup()
+        -_update_callback()
+    }
+
+    class ObstacleHandlerConfig {
+        <<dataclass>>
+        +enabled bool
+        +strategy Optional~AvoidanceStrategy~
+        +update_rate float
+    }
+
+    class ObstacleManager {
+        -_handlers dict~str,ObstacleHandler~
+        +handlers dict~str,ObstacleHandler~
+        +add(name, handler)
+        +remove(name) Optional~ObstacleHandler~
+        +get(name) Optional~ObstacleHandler~
+        +enable(name)
+        +disable(name)
+        +enable_all()
+        +disable_all()
+        +should_continue_navigation(drone) bool
+        +get_axis_control() tuple~bool,bool,bool~
+        +reset_all()
+        +cleanup()
+    }
+
+    class BaseObstacleDetector {
+        <<abstract>>
+        -_enabled bool
+        -_lock Lock
+        -_last_info ObstacleInfo
+        +is_enabled bool
+        +enable()
+        +disable()
+        +update() ObstacleInfo
+        +get_last_info() ObstacleInfo
+        +reset()
+        #_detect()* ObstacleInfo
+        #_on_enable()
+        #_on_disable()
+        #_on_reset()
+    }
+
+    class DepthObstacleDetector {
+        -_camera Optional~RealsenseCam~
+        -_image_handler Optional~ImageHandler~
+        -_detection_event Event
+        -_color_topic str
+        -_depth_topic str
+        -_min_distance_mm float
+        -_max_distance_mm float
+        -_cluster_eps float
+        -_cluster_min_samples int
+        -_min_cluster_pixels int
+        -_depth_threshold_mm float
+        +update() ObstacleInfo
+        -_detect() ObstacleInfo
+        -_on_enable()
+        -_on_disable()
+        -_on_reset()
+    }
+
+    class PauseStrategy {
+        -_paused bool
+        +execute(drone, info) bool
+        +reset()
+    }
+
+    class DisableAxisStrategy {
+        +disable_x bool
+        +disable_y bool
+        +disable_z bool
+        +execute(drone, info) bool
+        +reset()
+    }
+
+    class SequenceStrategy {
+        -_sequence_func Callable
+        -_executed bool
+        -_executing Event
+        +execute(drone, info) bool
+        +reset()
+    }
+
+    ObstacleDetector <|.. BaseObstacleDetector : implements
+    BaseObstacleDetector <|-- DepthObstacleDetector
+    AvoidanceStrategy <|-- PauseStrategy
+    AvoidanceStrategy <|-- DisableAxisStrategy
+    AvoidanceStrategy <|-- SequenceStrategy
+    ObstacleHandler *-- ObstacleDetector
+    ObstacleHandler *-- AvoidanceStrategy
+    ObstacleHandler o-- ObstacleHandlerConfig
+    ObstacleHandler ..> ObstacleInfo : uses
+    ObstacleManager o-- ObstacleHandler
+    ObstacleDetector ..> ObstacleInfo : returns
+    ObstacleInfo o-- ObstacleDirection
+```
+
+## Fluxo de Detecção em Tempo Real
+
+```mermaid
+sequenceDiagram
+    participant Nav as Navigation Loop<br/>(Main Thread)
+    participant Mgr as ObstacleManager
+    participant H as ObstacleHandler
+    participant T as ROS2 Timer<br/>(Background)
+    participant D as DepthDetector
+    participant Cam as RealSense Camera
+    participant S as Strategy
+
+    Note over T,Cam: Background Detection (10Hz)
+    loop Every 0.1s (Timer)
+        T->>H: _update_callback()
+        H->>D: update()
+        D->>Cam: get_depth_frame()
+        Cam-->>D: depth image
+        D->>D: DBSCAN clustering
+        D->>D: filter & classify
+        D-->>H: ObstacleInfo
+        H->>H: Lock & store
+    end
+
+    Note over Nav,S: Navigation Loop (100Hz)
+    loop Every 0.01s
+        Nav->>Mgr: should_continue_navigation(drone)
+        Mgr->>H: should_continue(drone)
+        H->>H: Lock & read last_info
+        H->>S: execute(drone, info)
+
+        alt Obstacle Detected
+            S->>S: PauseStrategy
+            S->>Nav: move_velocity(0,0,0,0)
+            S-->>H: False (pause)
+            H-->>Mgr: False
+            Mgr-->>Nav: False (skip iteration)
+        else Path Clear
+            S-->>H: True (continue)
+            H-->>Mgr: True
+            Mgr-->>Nav: True
+            Nav->>Nav: Compute PID
+            Nav->>Nav: move_velocity(vx,vy,vz,vyaw)
+        end
+    end
+```
+
+## Conceitos Centrais
+
+### Separação de Responsabilidades
+
+- **Detecção** (O quê): identifica obstáculos e retorna `ObstacleInfo`
+- **Strategy** (Como): define o comportamento de resposta
+- **Handler** (Quando): gerencia o timing e a integração
+- **Manager** (Onde): coordena múltiplos detectores em um drone
+
+### ObstacleInfo
+
+Estrutura de dados do resultado da detecção.
+
+```python
+@dataclass
+class ObstacleInfo:
+    detected: bool
+    direction: Optional[ObstacleDirection] = None  # FRONT, BACK, LEFT, RIGHT, UP, DOWN
+    distance: Optional[float] = None  # meters
+```
+
+### Protocolo ObstacleDetector
+
+Interface para detectores de obstáculos.
+
+```python
+class ObstacleDetector(Protocol):
+    @property
+    def is_enabled(self) -> bool: ...
+
+    def enable(self) -> None: ...
+    def disable(self) -> None: ...
+    def update(self) -> ObstacleInfo: ...
+    def reset(self) -> None: ...
+```
+
+## Detectores
+
+### Zonas de Detecção
+
+A direção é derivada da posição do cluster em relação ao centro da imagem (veja o
+flowchart abaixo e
+[`depth_camera.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/obstacles/depth_camera.py)):
+
+- Todos os clusters à esquerda do centro → `ObstacleDirection.RIGHT`
+- Todos os clusters à direita do centro → `ObstacleDirection.LEFT`
+- Clusters nos dois lados → `ObstacleDirection.FRONT`
+
+**Limiares de distância** (mm, salvo indicação contrária):
+
+| Parâmetro | Valor | Papel |
+|-----------|-------|-------|
+| Distância mínima | 100 | Ignora retornos mais próximos do que isso |
+| Distância máxima | 1500 | Limite do alcance de detecção |
+| Filtro de cluster | 1300 | Profundidade média máxima do cluster para contar como obstáculo |
+
+### DepthObstacleDetector
+
+Detecção baseada na câmera de profundidade RealSense D435i usando clustering DBSCAN.
+
+**Configuração**:
+
+```python
+from nectar.control.obstacles import DepthObstacleDetector
+
+detector = DepthObstacleDetector(
+    min_distance_mm=100,         # ignore returns closer than this
+    max_distance_mm=1500,        # maximum detection range
+    cluster_eps=20,              # DBSCAN epsilon
+    cluster_min_samples=20,      # DBSCAN minimum samples
+    min_cluster_pixels=50,       # minimum valid pixels to attempt clustering
+    depth_threshold_mm=1300,     # max cluster mean depth to count as obstacle
+    color_topic="/camera/color/image_raw",
+    depth_topic="/camera/depth/image_rect_raw",
+)
+```
+
+> **Nota:** o detector possui seu próprio `ImageHandler` da RealSense (e node ROS)
+> internamente — nenhum argumento `node` é passado.
+
+#### Processamento da câmera de profundidade
+
+```mermaid
+flowchart TD
+    Start([Depth Frame<br/>640x480 @ 30fps]) --> Convert[Convert to mm<br/>depth_mm = depth * 1000]
+    Convert --> Downsample[Downsample 10%<br/>64x48 for performance]
+    Downsample --> Filter{Filter Valid Depth}
+    Filter -->|100mm < depth < 1500mm| ValidMask[Create Valid Mask]
+    Filter -->|Outside range| Discard[Set to 0]
+
+    ValidMask --> Count{Count Valid Pixels}
+    Count -->|< 50 pixels| NoObstacle[Return: No Obstacle]
+    Count -->|≥ 50 pixels| ExtractPoints[Extract Point Cloud<br/>xs, ys, depths]
+
+    ExtractPoints --> DBSCAN[DBSCAN Clustering<br/>eps=20, min_samples=20]
+    DBSCAN --> Clusters{Found Clusters?}
+    Clusters -->|No clusters| NoObstacle
+    Clusters -->|Yes| FilterClusters
+
+    FilterClusters[Filter by Threshold<br/>mean_depth < 1300mm] --> ValidClusters{Valid Clusters?}
+    ValidClusters -->|None| NoObstacle
+    ValidClusters -->|Yes| AnalyzePosition
+
+    AnalyzePosition[Analyze Cluster Position<br/>vs Image Center] --> Direction{Determine Direction}
+
+    Direction -->|All clusters<br/>x_max < center| DirLeft[RIGHT]
+    Direction -->|All clusters<br/>x_min > center| DirRight[LEFT]
+    Direction -->|Clusters both sides| DirFront[FRONT]
+
+    DirLeft --> CalcDist[Calculate Distance<br/>avg depth of clusters]
+    DirRight --> CalcDist
+    DirFront --> CalcDist
+
+    CalcDist --> Return([Return ObstacleInfo<br/>detected=True, direction, distance])
+    NoObstacle --> ReturnFalse([Return ObstacleInfo<br/>detected=False])
+```
+
+### BaseObstacleDetector
+
+Classe base abstrata que fornece gerenciamento de estado thread-safe.
+
+```python
+from nectar.control.obstacles import BaseObstacleDetector
+
+class CustomDetector(BaseObstacleDetector):
+    def _detect(self) -> ObstacleInfo:
+        # Custom detection logic
+        return ObstacleInfo(detected=True, direction=ObstacleDirection.FRONT)
+
+    def _on_reset(self) -> None:
+        # Reset internal state (optional hook)
+        pass
+```
+
+## Strategies
+
+### Fluxo de Decisão da Strategy
+
+```mermaid
+flowchart TD
+    Start([drone.move_to<br/>x=10, y=0, z=0]) --> Nav{Navigation Loop}
+
+    Nav --> CheckObs{ObstacleManager:<br/>Check all detectors}
+
+    CheckObs -->|No obstacles| ComputePID[Compute PID<br/>vx, vy, vz, vyaw]
+    ComputePID --> SendVel[drone.move_velocity<br/>vx, vy, vz, vyaw]
+    SendVel --> CheckDist{Distance to<br/>target < precision?}
+
+    CheckObs -->|Obstacle detected| StrategyType{Which Strategy?}
+
+    StrategyType -->|PAUSE| Pause[Stop drone<br/>move_velocity<br/>0, 0, 0, 0]
+    Pause --> WaitClear{Path cleared?}
+    WaitClear -->|No| Pause
+    WaitClear -->|Yes| Nav
+
+    StrategyType -->|DISABLE_AXIS| DisableZ[Disable Z axis<br/>Continue XY only]
+    DisableZ --> ComputePID2[Compute PID<br/>vx, vy ONLY<br/>vz=0]
+    ComputePID2 --> SendVel
+
+    StrategyType -->|SEQUENCE| ExecuteSeq[Execute Sequence:<br/>Lateral → Forward → Return]
+    ExecuteSeq --> SeqComplete{Sequence<br/>complete?}
+    SeqComplete -->|No| ExecuteSeq
+    SeqComplete -->|Yes| Nav
+
+    CheckDist -->|No| Nav
+    CheckDist -->|Yes| Done([Target Reached])
+```
+
+### Resumo das Strategies
+
+| Strategy | Comportamento | Retorna | Caso de uso |
+|----------|----------|---------|----------|
+| **PauseStrategy** | `move_velocity(0,0,0,0)` até liberar | `False` enquanto detectado | Obstáculos dinâmicos (pessoas, drones) |
+| **DisableAxisStrategy** | Desabilita o controle do eixo especificado | `True` (continua) | Terrain following (lidar) |
+| **SequenceStrategy** | Executa uma manobra de evasão | `False` durante a execução | Obstáculos estáticos (paredes, árvores) |
+
+### Interface AvoidanceStrategy
+
+```python
+class AvoidanceStrategy(ABC):
+    @abstractmethod
+    def execute(self, drone: BaseDrone, info: ObstacleInfo) -> bool:
+        """
+        Execute avoidance behavior.
+
+        Returns:
+            True if navigation should continue, False to pause
+        """
+        pass
+
+    @abstractmethod
+    def reset(self) -> None:
+        pass
+```
+
+### PauseStrategy
+
+Para o drone quando um obstáculo é detectado, retoma quando liberado.
+
+```python
+from nectar.control.obstacles import strategies
+
+strategy = strategies.PauseStrategy()
+```
+
+**Comportamento**:
+
+```python
+def execute(self, drone, info):
+    if info.detected:
+        drone.move_velocity(0, 0, 0, 0)  # Stop
+        return False  # Don't continue navigation
+    else:
+        return True  # Resume navigation
+```
+
+**Caso de uso**: Obstáculos dinâmicos (pessoas, outros drones) que podem se afastar.
+
+### DisableAxisStrategy
+
+Desabilita o controle de eixos específicos durante a detecção de obstáculo.
+
+```python
+strategy = strategies.DisableAxisStrategy(
+    disable_x=False,
+    disable_y=False,
+    disable_z=True  # Disable altitude control
+)
+```
+
+**Comportamento**: Retorna `True` (continua a navegação) mas sinaliza quais eixos
+desabilitar via `get_axis_modifiers()`.
+
+**Caso de uso**: Terrain following com lidar (desabilita o PID de Z, deixa o ArduPilot
+controlar a altitude).
+
+### SequenceStrategy
+
+Executa uma sequência callable customizada quando um obstáculo é detectado.
+
+```python
+from functools import partial
+
+strategy = strategies.SequenceStrategy(
+    partial(
+        strategies.lateral_pass_return_sequence,
+        lateral_distance=1.0,
+        forward_distance=2.5,
+        precision=0.2
+    )
+)
+```
+
+**Comportamento**: Chama `sequence_func(drone, info)`, que executa `drone.move_to()`
+diretamente.
+
+**Sequências prontas**:
+
+| Sequência | Passos | Resultado |
+|----------|-------|--------|
+| `lateral_pass_return_sequence` | ① `y=lateral` → ② `x=forward` → ③ `y=-lateral` | Retorna à trajetória original |
+| `lateral_pass_sequence` | ① `y=lateral` → ② `x=forward` | Permanece deslocado |
+| `simple_lateral_sequence` | ① `y=lateral` | Passo lateral único |
+| `climb_over_sequence` | ① `z=+height` → ② `x=forward` → ③ `z=-height` | Contorno vertical |
+
+**Lógica de direção**: `LEFT` → move para a direita (`-y`), `RIGHT`/`FRONT` → move para a
+esquerda (`+y`)
+
+## Integração
+
+### ObstacleHandler
+
+Combina detector + strategy com timing.
+
+```python
+from nectar.control.obstacles import ObstacleHandler, ObstacleHandlerConfig
+
+handler = ObstacleHandler(
+    detector=DepthObstacleDetector(),
+    strategy=strategies.PauseStrategy(),
+    node=node,
+    config=ObstacleHandlerConfig(
+        enabled=True,
+        update_rate=0.1
+    )
+)
+```
+
+**Mecanismos de atualização**:
+
+1. **Baseado em timer** (padrão): um timer do ROS2 chama `_update_callback()` na taxa
+   especificada
+2. **Manual**: chame `handler.update()` explicitamente (defina `update_rate=0`)
+
+**Thread safety**: usa locks para o acesso ao estado (`_last_info`).
+
+### ObstacleManager
+
+Gerencia múltiplos handlers em um drone.
+
+```python
+manager = ObstacleManager()
+
+manager.add("depth", depth_handler)
+manager.add("lidar", lidar_handler)
+
+manager.enable("depth")
+manager.disable("lidar")
+
+# In navigation loop
+
+if not manager.should_continue_navigation(drone):
+    continue  # Strategy is handling obstacle
+
+disable_x, disable_y, disable_z = manager.get_axis_control()
+```
+
+**Integração com a navegação**:
+
+```python
+
+# In VehicleNavigator.navigate_pid()
+
+while True:
+    if not drone.obstacle_manager.should_continue_navigation(drone):
+        continue  # Pause or sequence executing
+
+    disable_x, disable_y, disable_z = drone.obstacle_manager.get_axis_control()
+
+    control_x = x is not None and not disable_x
+    control_y = y is not None and not disable_y
+    control_z = z is not None and not disable_z
+
+    # Continue with PID control
+```
+
+## API do Drone
+
+### Adicionando Detectores
+
+```python
+drone.add_obstacle_detector(
+    name: str,
+    detector: ObstacleDetector,
+    strategy: AvoidanceStrategy,
+    config: Optional[ObstacleHandlerConfig] = None
+)
+```
+
+**Exemplo**:
+
+```python
+detector = DepthObstacleDetector()
+strategy = strategies.PauseStrategy()
+config = ObstacleHandlerConfig(update_rate=0.15)  # 6.7 Hz
+
+drone.add_obstacle_detector("depth", detector, strategy, config)
+```
+
+### Controle
+
+```python
+drone.enable_obstacle_detector("depth")
+drone.disable_obstacle_detector("depth")
+drone.enable_all_obstacle_detectors()
+drone.disable_all_obstacle_detectors()
+drone.remove_obstacle_detector("depth")
+```
+
+## Exemplos de Uso
+
+### Evasão Lateral
+
+```python
+from functools import partial
+
+detector = DepthObstacleDetector()
+
+strategy = strategies.SequenceStrategy(
+    partial(
+        strategies.lateral_pass_return_sequence,
+        lateral_distance=1.5,
+        forward_distance=3.0
+    )
+)
+
+drone.add_obstacle_detector("depth", detector, strategy)
+drone.enable_obstacle_detector("depth")
+
+drone.takeoff(1.5)
+drone.move_to(x=10.0, y=0.0, z=0.0)  # Executes evasion when obstacle detected
+drone.land()
+```
+
+### Sequência Customizada
+
+```python
+def my_evasion(drone, info, climb_height=1.0):
+    """Climb over obstacle."""
+    drone.node.get_logger().info("Climbing over obstacle")
+    drone.move_to(z=climb_height, precision=0.2)
+    drone.move_to(x=3.0, precision=0.2)
+    drone.move_to(z=-climb_height, precision=0.2)
+
+strategy = strategies.SequenceStrategy(partial(my_evasion, climb_height=1.5))
+drone.add_obstacle_detector("depth", detector, strategy)
+```
+
+### Terrain Following
+
+```python
+
+# Custom lidar detector (not provided)
+
+lidar_detector = LidarObstacleDetector(node)
+
+strategy = strategies.DisableAxisStrategy(disable_z=True)
+
+drone.add_obstacle_detector("lidar", lidar_detector, strategy)
+drone.enable_obstacle_detector("lidar")
+
+# Z control disabled when lidar detects terrain variation
+
+drone.move_to(x=10.0, y=0.0, z=0.0)
+```
+
+### Múltiplos Detectores
+
+```python
+depth_detector = DepthObstacleDetector()
+ultrasonic_detector = UltrasonicDetector(node)  # Custom
+
+drone.add_obstacle_detector(
+    "depth", depth_detector,
+    strategies.SequenceStrategy(strategies.lateral_pass_return_sequence)
+)
+
+drone.add_obstacle_detector(
+    "ultrasonic", ultrasonic_detector,
+    strategies.PauseStrategy()
+)
+
+drone.enable_all_obstacle_detectors()
+```
+
+## Exemplo de Strategy Customizada
+
+```python
+from nectar.control.obstacles.strategies import AvoidanceStrategy
+
+class BackupStrategy(AvoidanceStrategy):
+    def __init__(self, backup_distance=1.0):
+        self.backup_distance = backup_distance
+        self._backing_up = False
+
+    def execute(self, drone, info):
+        if info.detected and not self._backing_up:
+            self._backing_up = True
+            drone.move_to(x=-self.backup_distance, precision=0.2)
+            self._backing_up = False
+            return False  # Don't continue until backup complete
+
+        return not info.detected
+
+    def reset(self):
+        self._backing_up = False
+
+drone.add_obstacle_detector("depth", detector, BackupStrategy(backup_distance=2.0))
+```
+
+## Thread Safety
+
+- **Detectores**: rodam em timers independentes do ROS2 (threads de fundo)
+- **Handlers**: usam locks para o acesso ao estado
+- **Strategies**: executam na thread de navegação (thread principal)
+- **Manager**: single-threaded (loop de navegação)
+
+**Sincronização**: os locks do handler previnem race conditions entre o callback do timer
+e o loop de navegação.

--- a/i18n/pt/modules/control/pid.md
+++ b/i18n/pt/modules/control/pid.md
@@ -1,0 +1,474 @@
+# Módulo do Controlador PID
+
+Controlador PID configurável com anti-windup, clamping de saída e ajuste (tuning) baseado
+em YAML, além de uma variante por eixo (`x`/`y`/`z`/`yaw`) para controle de posição.
+Usado pelos métodos de PID do navigator, e também utilizável de forma independente para
+qualquer malha de controle.
+
+## Resumo rápido
+
+```python
+from nectar.control.pid import PIDController
+
+pid = PIDController(kp=1.0, ki=0.1, kd=0.05, setpoint=2.0)
+output = pid.update(current_value)   # control output, clamped to output_limits
+```
+
+## Conceitos
+
+Um `PIDController` é configurado por um `PIDConfig` (carregável a partir de YAML); o
+`PositionPIDConfig` agrupa um `PIDConfig` por eixo para `x`/`y`/`z`/`yaw`.
+
+```mermaid
+classDiagram
+    class PIDController {
+        +kp float
+        +ki float
+        +kd float
+        +setpoint float
+        +output_limits tuple~float,float~
+        +integral_limits tuple~float,float~
+        +output float
+        -_integral float
+        -_last_error float
+        -_last_time Optional~float~
+        -_first_update bool
+        -_proportional float
+        -_derivative float
+        +update(current_value) float
+        +reset()
+        +set_setpoint(value)
+        +tune(kp, ki, kd)
+        +get_components() dict
+    }
+
+    class PIDConfig {
+        <<dataclass>>
+        +kp float
+        +ki float
+        +kd float
+        +setpoint float
+        +output_min float
+        +output_max float
+        +integral_min float
+        +integral_max float
+        +from_yaml(path)$ PIDConfig
+        +from_dict(data)$ PIDConfig
+        +to_dict() dict
+        +get_output_limits() tuple~float,float~
+        +get_integral_limits() tuple~float,float~
+    }
+
+    class PositionPIDConfig {
+        <<dataclass>>
+        +x PIDConfig
+        +y PIDConfig
+        +z PIDConfig
+        +yaw PIDConfig
+        +from_yaml(path) PositionPIDConfig
+        +to_dict() dict
+    }
+
+    PIDController ..> PIDConfig : configured by
+    PositionPIDConfig *-- PIDConfig
+```
+
+## PIDController
+
+Implementação de PID padrão com anti-windup e clamping de saída.
+
+### API
+
+```python
+from nectar.control.pid import PIDController
+
+pid = PIDController(
+    kp: float = 0.0,                      # Proportional gain
+    ki: float = 0.0,                      # Integral gain
+    kd: float = 0.0,                      # Derivative gain
+    setpoint: float = 0.0,                # Target value
+    output_limits: tuple = (-1.0, 1.0),   # Output clamp
+    integral_limits: tuple = (-1.0, 1.0), # Anti-windup
+    output_deadband: float = 0.0          # Symmetric output deadband (0 disables)
+)
+```
+
+### Malha de controle
+
+`PIDController.update()` implementa um PID em tempo discreto com anti-windup no termo
+integral e clamping na saída:
+
+$$
+e_k = r - y_k
+$$
+
+$$
+P_k = K_p \, e_k
+$$
+
+$$
+I_k = \mathrm{clamp}\!\left(K_i \sum_{i=0}^{k} e_i \, \Delta t,\; I_{\min},\, I_{\max}\right)
+$$
+
+$$
+D_k = K_d \frac{e_k - e_{k-1}}{\Delta t}
+$$
+
+$$
+u_k = \mathrm{clamp}(P_k + I_k + D_k,\; u_{\min},\, u_{\max})
+$$
+
+Onde \(r\) é o setpoint (`setpoint`), \(y_k\) é a medição atual, \(\Delta t\) é o tempo
+decorrido entre as chamadas (a partir de `time.time()`), e
+\(\mathrm{clamp}(x, a, b) = \min(\max(x, a), b)\).
+
+Um **deadband de saída** opcional (`output_deadband`) força \(u_k = 0\) quando
+\(|u_k| < \mathrm{deadband}\) após o clamping.
+
+```python
+control_output = pid.update(current_value: float) -> float
+```
+
+### Métodos
+
+```python
+pid.update(current_value)              # Returns control output
+pid.reset()                            # Clear integral, previous error
+pid.set_setpoint(value)                # Change target
+pid.tune(kp, ki, kd)                   # Update gains
+pid.get_components()                   # Returns proportional, integral, derivative, output
+```
+
+## PIDConfig
+
+Dataclass de configuração para PID de um único eixo.
+
+```python
+from nectar.control.pid import PIDConfig
+
+config = PIDConfig(
+    kp=0.5,
+    ki=0.0,
+    kd=0.0,
+    output_min=-0.42,
+    output_max=0.42,
+    integral_min=-0.5,
+    integral_max=0.5
+)
+```
+
+### Carregando a partir de YAML
+
+```yaml
+
+# pid_config.yaml
+
+kp: 0.5
+ki: 0.0
+kd: 0.0
+output_min: -0.42
+output_max: 0.42
+integral_min: -0.5
+integral_max: 0.5
+```
+
+```python
+config = PIDConfig.from_yaml("pid_config.yaml")
+```
+
+### Carregando a partir de um dicionário
+
+```python
+config = PIDConfig.from_dict({
+    "kp": 0.5,
+    "output_min": -0.42,
+    "output_max": 0.42
+})
+```
+
+**Valores padrão**: campos não especificados usam os padrões (ki=0.0, kd=0.0, etc.).
+
+## PositionPIDConfig
+
+Configuração multi-eixo para controle de posição (X, Y, Z, yaw).
+
+```python
+from nectar.control.pid import PositionPIDConfig, PIDConfig
+
+config = PositionPIDConfig(
+    x=PIDConfig(kp=0.5, output_min=-0.42, output_max=0.42),
+    y=PIDConfig(kp=0.5, output_min=-0.42, output_max=0.42),
+    z=PIDConfig(kp=0.22, output_min=-0.15, output_max=0.1),
+    yaw=PIDConfig(kp=0.5, ki=0.1, output_min=-0.2, output_max=0.2)
+)
+```
+
+### Formato YAML
+
+```yaml
+
+# position_config.yaml
+
+x:
+  kp: 0.5
+  ki: 0.0
+  kd: 0.0
+  output_min: -0.42
+  output_max: 0.42
+  integral_min: -0.5
+  integral_max: 0.5
+
+y:
+  kp: 0.5
+  output_min: -0.42
+  output_max: 0.42
+
+z:
+  kp: 0.22
+  output_min: -0.15
+  output_max: 0.1
+
+yaw:
+  kp: 0.5
+  ki: 0.1
+  output_min: -0.2
+  output_max: 0.2
+  integral_min: -0.05
+  integral_max: 0.05
+```
+
+```python
+config = PositionPIDConfig.from_yaml("position_config.yaml")
+```
+
+## Uso no Controle do Drone
+
+### Integração com ArduPilotDrone
+
+Controladores PID criados por eixo a partir da configuração:
+
+```python
+
+# In VehicleNavigator.navigate_pid()
+
+pid_x = self._create_pid("x")      # Creates from self._pid_config.x
+pid_y = self._create_pid("y")
+pid_z = self._create_pid("z")
+pid_yaw = self._create_pid("yaw")
+
+# Control loop
+
+while True:
+    dx, dy, dz, dyaw = self._compute_errors(target, yaw)
+
+    vx = pid_x.update(-dx)
+    vy = pid_y.update(-dy)
+    vz = pid_z.update(-dz)
+    vyaw = pid_yaw.update(-dyaw)
+
+    drone.move_velocity(vx, vy, vz, vyaw)
+```
+
+### Carregamento da configuração
+
+**Automático** — a config escolhe um preset por `is_indoor`:
+
+| Modo | Preset carregado |
+|------|---------------|
+| Indoor (vision) | `ardupilot/config/position_indoor.yaml` |
+| Outdoor (GPS) | `ardupilot/config/position_outdoor.yaml` |
+| SITL | `position_sim_indoor.yaml` / `position_sim_outdoor.yaml` |
+
+```python
+config = MavrosConfig(pose_source=PoseSource.VISION)
+drone = DroneFactory.create("mavros", config)
+```
+
+**Explícito**:
+
+```python
+config = MavrosConfig(
+    pose_source=PoseSource.VISION,
+    pid_config_file="/path/to/custom.yaml"
+)
+```
+
+**Em runtime**:
+
+```python
+drone.set_pid_config("/path/to/config.yaml")
+drone.set_pid_config(config_dict)
+drone.set_pid_config(PositionPIDConfig(...))
+```
+
+## Diretrizes de Ajuste (Tuning)
+
+### Ganho Proporcional (kp)
+
+Controla a magnitude da resposta.
+
+- **kp maior**: resposta mais rápida, overshoot potencial
+- **kp menor**: resposta mais lenta, mais estável
+
+- **Indoor**: 0.3-0.6 (a pose por visão é precisa)
+- **Outdoor**: 0.6-1.0 (o ruído do GPS exige um ganho maior)
+
+### Ganho Integral (ki)
+
+Elimina o erro em regime permanente.
+
+- **ki maior**: eliminação de erro mais rápida, instabilidade potencial
+- **ki menor**: convergência mais lenta, mais estável
+
+- **Típico**: 0.0-0.1 (frequentemente não é necessário para controle de posição)
+- **Yaw**: 0.05-0.15 (ajuda com a deriva da bússola)
+
+### Ganho Derivativo (kd)
+
+Amortece oscilações e overshoot.
+
+- **kd maior**: mais amortecimento, sensível a ruído
+- **kd menor**: menos amortecimento, resposta mais suave
+
+**Controle de posição**: geralmente 0.0 (os comandos de velocidade já fornecem
+amortecimento)
+
+### Limites de Saída
+
+Limites do comando de velocidade (m/s para posição, rad/s para yaw).
+
+- **Indoor**: ±0.4-0.6 m/s (seguro em espaço restrito)
+- **Outdoor**: ±0.8-1.5 m/s (mais agressivo permitido)
+- **Vertical**: ±0.15-0.8 m/s (assimétrico: subida mais lenta)
+
+### Limites Integrais
+
+Proteção anti-windup.
+
+- **Típico**: 10-20% dos limites de saída
+- **Propósito**: evitar que o termo integral acumule durante a saturação
+
+## Configurações Padrão
+
+### Indoor (baseado em visão)
+
+```yaml
+x:
+  kp: 0.5
+  output_min: -0.42
+  output_max: 0.42
+
+y:
+  kp: 0.5
+  output_min: -0.42
+  output_max: 0.42
+
+z:
+  kp: 0.22
+  output_min: -0.15
+  output_max: 0.1
+
+yaw:
+  kp: 0.5
+  ki: 0.1
+  output_min: -0.2
+  output_max: 0.2
+```
+
+**Racional**:
+
+- Velocidades menores por segurança indoor
+- Limites de Z assimétricos (subida mais lenta para evitar colisão com o teto)
+- O termo integral do yaw compensa a deriva da pose por visão
+
+### Outdoor (baseado em GPS)
+
+```yaml
+x:
+  kp: 0.8
+  output_min: -1.0
+  output_max: 1.0
+
+y:
+  kp: 0.8
+  output_min: -1.0
+  output_max: 1.0
+
+z:
+  kp: 0.5
+  output_min: -0.8
+  output_max: 0.8
+
+yaw:
+  kp: 0.5
+  ki: 0.1
+  output_min: -0.3
+  output_max: 0.3
+```
+
+**Racional**:
+
+- Ganhos maiores compensam a latência e o ruído do GPS
+- Limites de velocidade maiores para transições mais rápidas entre waypoints
+- Limites de Z simétricos (ambiente outdoor aberto)
+
+## Exemplos
+
+### Controle PID Básico
+
+```python
+from nectar.control.pid import PIDController
+
+altitude_pid = PIDController(
+    kp=0.5,
+    ki=0.1,
+    kd=0.0,
+    setpoint=10.0,
+    output_limits=(-0.5, 0.5)
+)
+
+while True:
+    current_altitude = get_altitude()
+    vz = altitude_pid.update(current_altitude)
+    set_velocity_z(vz)
+```
+
+### Controle de Posição com Configuração
+
+```python
+from nectar.control.pid import PositionPIDConfig
+
+config = PositionPIDConfig.from_yaml("ardupilot/config/position_outdoor.yaml")
+
+pid_x = PIDController(
+    kp=config.x.kp,
+    ki=config.x.ki,
+    kd=config.x.kd,
+    output_limits=config.x.get_output_limits(),
+    integral_limits=config.x.get_integral_limits()
+)
+```
+
+### Ajuste Durante o Voo
+
+```python
+
+# Start with conservative gains
+
+drone.set_pid_config({
+    "x": {"kp": 0.3, "output_min": -0.3, "output_max": 0.3},
+    "y": {"kp": 0.3, "output_min": -0.3, "output_max": 0.3},
+    "z": {"kp": 0.2, "output_min": -0.2, "output_max": 0.2}
+})
+
+drone.move_to(x=2.0, y=0.0, z=0.0)
+
+# Increase gains if response too slow
+
+drone.set_pid_config({
+    "x": {"kp": 0.6, "output_min": -0.5, "output_max": 0.5},
+    "y": {"kp": 0.6, "output_min": -0.5, "output_max": 0.5}
+})
+
+drone.move_to(x=-2.0, y=0.0, z=0.0)
+```

--- a/i18n/pt/modules/control/px4.md
+++ b/i18n/pt/modules/control/px4.md
@@ -1,0 +1,277 @@
+# Firmware PX4
+
+Suporte a [PX4](https://px4.io/) construído sobre o [núcleo do veículo](../vehicle/) compartilhado. `Px4Drone` implementa a semântica de voo específica do PX4; a navegação agnóstica a transporte, o PID, o sequencer e a API de movimento são herdados sem alteração de `VehicleDrone`.
+
+> Para a API pública do `Drone`, os métodos de navegação, as referências, as fontes de altitude e a detecção de takeoff/land, veja o [Núcleo do Veículo](../vehicle/). Esta página cobre apenas o que é específico do PX4.
+
+## Papel
+
+`Px4Drone` ([`drone.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/drone.py)) especializa o [`VehicleDrone`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/drone.py) para o PX4:
+
+- **Controle offboard**: o PX4 só aceita o modo `OFFBOARD` — e só arma nele — enquanto os setpoints são transmitidos a mais de 2 Hz, e ele sai do offboard se o stream parar por ~500 ms ([offboard do PX4](https://docs.px4.io/main/en/ros2/offboard_control.html)). Um timer ROS de fundo (o *pump de offboard*) republica o último setpoint comandado a `offboard_rate_hz` (padrão 20 Hz), para que o veículo permaneça em offboard entre comandos explícitos de movimento.
+- **Sequência de arme**: gera um setpoint de hold → transmite → troca para `OFFBOARD` → arma.
+- **Takeoff**: sobe até um setpoint de posição em offboard (sem mudança de modo), reaproveitando a detecção de estabilização baseada em velocidade do [`FlightSequencer`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/sequencer.py).
+- **Land / RTL**: modos `AUTO.LAND` / `AUTO.RTL` do PX4; altitude de RTL via `RTL_RETURN_ALT`, loiter-vs-land via `RTL_LAND_DELAY`.
+
+`Px4Drone` é agnóstico a transporte; é combinado com um de três backends, de modo que uma missão roda sem alteração em qualquer um deles:
+
+- `Px4MavrosDrone` (`px4`, [`mavros_drone.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/mavros_drone.py)) — `Px4Drone` sobre o [`MavrosTransport`](../mavros/), a mesma conectividade MAVROS que os drones ArduPilot usam, alcançada via `mavros px4.launch`.
+- `Px4MavlinkDrone` (`px4_mavlink`, [`mavlink_drone.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/mavlink_drone.py)) — `Px4Drone` sobre o [`PymavlinkTransport`](../mavlink/) neutro em relação a firmware, com um `Px4ModeCodec`: um link MAVLink direto, sem MAVROS. Espelha o drone `mavlink` do ArduPilot.
+- `Px4DdsDrone` (`px4_dds`, [`dds_drone.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/dds_drone.py)) — `Px4Drone` sobre o [`Px4DdsTransport`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/dds_transport.py), uORB nativo do PX4 sobre uXRCE-DDS (veja abaixo).
+
+O encode de modo de voo do PX4 para os backends MAVLink vive uma única vez em [`modes.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/modes.py) (`MODE_TO_PX4` + `px4_mode_name`), compartilhado por `Px4ModeCodec` e `Px4DdsTransport`.
+
+## Arquitetura
+
+```mermaid
+classDiagram
+    class VehicleDrone {
+        <<abstract>>
+        +takeoff() land() move_to() move_to_gps() move_velocity() rtl()
+        +arm()* capabilities*
+        #_rtl_native()* _change_speed()*
+        #_command_takeoff() _command_land() _ensure_offboard_ready() _emit_velocity()
+    }
+    class Px4Drone {
+        -_offboard_setpoint
+        -_pump_timer
+        +arm() capabilities
+        +_command_takeoff() _command_land() _rtl_native()
+        +_ensure_offboard_ready() _emit_velocity() publish_setpoint()
+        +_pump_tick() _seed_hold_setpoint()
+    }
+    class Px4MavrosDrone {
+        +from_config(config, executor)$
+    }
+    class Px4MavlinkDrone {
+        +connection MavlinkConnection
+        +from_config(config, executor)$
+    }
+    class Px4DdsDrone {
+        +from_config(config, executor)$
+    }
+    class VehicleTransport {
+        <<abstract>>
+    }
+    class MavrosTransport
+    class PymavlinkTransport
+    class Px4DdsTransport
+
+    VehicleDrone <|-- Px4Drone
+    Px4Drone <|-- Px4MavrosDrone
+    Px4Drone <|-- Px4MavlinkDrone
+    Px4Drone <|-- Px4DdsDrone
+    VehicleDrone o-- VehicleTransport
+    VehicleTransport <|.. MavrosTransport
+    VehicleTransport <|.. PymavlinkTransport
+    VehicleTransport <|.. Px4DdsTransport
+    Px4MavrosDrone ..> MavrosTransport : builds
+    Px4MavlinkDrone ..> PymavlinkTransport : builds
+    Px4DdsDrone ..> Px4DdsTransport : builds
+```
+
+## Modos de voo
+
+[Modos de voo](https://docs.px4.io/main/en/flight_modes_mc/) do PX4 usados por este SDK (strings `custom_mode` do MAVROS):
+
+| Modo | Uso |
+|------|-----|
+| `OFFBOARD` | Controle por setpoint do computador de bordo (move_to / move_velocity). Exigido para a navegação do SDK. |
+| `AUTO.LAND` | Pousa na posição atual (`land()`). |
+| `AUTO.RTL` | Retorno ao ponto de lançamento (`rtl(method=NATIVE)`). |
+
+Diferente do modo `GUIDED` único do ArduPilot, o PX4 separa o controle offboard dos modos autônomos de takeoff/land/RTL, e o offboard exige o stream contínuo de setpoint descrito acima.
+
+## Capacidades
+
+`Px4Drone.capabilities` é derivado a partir da `pose_source` configurada (veja [`capabilities.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/capabilities.py)): `PID_NAV`, `LOCAL_SETPOINT`, `VELOCITY_BODY`/`WORLD`/`TAKEOFF`, `ACTUATOR`, `GRIPPER`, `PARAMS`, `NATIVE_RTL`, `OBSTACLE_AVOIDANCE`, `RANGEFINDER`, `DISTANCE_SENSORS`, além de `GPS_NAV`/`GLOBAL_SETPOINT` (outdoor) ou `VISION_POSE` (indoor). O PX4 declara `ACTUATOR` (`DO_SET_ACTUATOR`) e `GRIPPER` (`DO_GRIPPER`) para payloads, mas não o caminho de PWM por canal `SERVO` (`do_servo`) do ArduPilot; veja [Atuadores de payload](#atuadores-de-payload-gripper).
+
+## Visão indoor / externa (EKF2)
+
+Para voo sem GPS, `pose_source=PoseSource.VISION` faz o SDK ler a pose local fundida do FCU, para navegação PID do lado do computador de bordo. A pose externa em si é alimentada ao FCU pela ponte separada de [localization](localization/) (`vision_pose.launch.py backend:=mavros|mavlink|dds`), que envia `VISION_POSITION_ESTIMATE` (ou `VehicleOdometry` no DDS). O EKF2 do PX4 funde isso quando `EKF2_EV_CTRL` / `EKF2_HGT_REF` estão definidos, o GNSS está desabilitado (`EKF2_GPS_CTRL=0`), e o stream está a 30–50 Hz (o PX4 rejeita taxas muito baixas — muito mais rígido que o ≥4 Hz do ArduPilot).
+
+**SITL:** `ENV=indoor` voa o `x500_nectar` na mesma arena `indoor_room_px4` compartilhada, com `gz_vision_source` espelhando os tópicos cuVSLAM de hardware (mesmo padrão do indoor do ArduPilot). Os parâmetros são carregados de `simulation/params/px4_indoor.env`. Veja [Localization → SITL](localization/#sitl).
+
+**Hardware:** os voos de competição até hoje são em ArduPilot; a tabela de parâmetros do PX4 é baseada na documentação do PX4 / no tutorial VSLAM-UAV, e está pronta para uma migração para Pixhawk — valide na sua aeronave antes do uso em competição. Conjunto completo de parâmetros e equivalentes no ArduPilot: [Localization → FCU setup](localization/#fcu-setup).
+
+## Configuração
+
+```python
+import nectar
+from nectar.control import DroneFactory, Px4MavrosConfig, PoseSource
+
+nectar.init()
+
+config = Px4MavrosConfig(
+    pose_source=PoseSource.GPS,                   # GPS (outdoor) or VISION (indoor)
+    connection_string="udp://:14540@127.0.0.1:14580",  # PX4 SITL offboard API
+    offboard_rate_hz=20.0,                        # setpoint stream rate (>2 Hz)
+)
+drone = DroneFactory.create("px4", config)
+```
+
+`Px4MavrosConfig` carrega os nomes de tópico do MAVROS (idênticos ao `MavrosConfig`), `connection_string` (um `fcu_url` do MAVROS), `offboard_rate_hz`, `mavros_launch` (padrão `px4.launch`), e os campos de config de setpoint `setpoint_config_file` / `apply_setpoint_params` (veja abaixo).
+
+**Presets de SITL** (em [`config.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/config.py)): `PX4_SITL_CONFIG`, `PX4_SITL_GAZEBO_CONFIG`, `PX4_SITL_VISION_CONFIG`, `PX4_MAVLINK_SITL_VISION_CONFIG`, `PX4_DDS_SITL_VISION_CONFIG`.
+
+## Configuração de setpoint (velocidade / aceleração)
+
+O análogo, no PX4, dos parâmetros WPNAV do ArduPilot é a família `MPC_*` do controlador de posição multicoptero. [`Px4SetpointConfig`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/setpoint_config.py) carrega limites SI de velocidade/aceleração/jerk e os mapeia para `MPC_*` (veja os [Diagramas de Controlador do PX4](https://docs.px4.io/main/en/flight_stack/controller_diagrams) e a [Referência de Parâmetros](https://docs.px4.io/main/en/advanced/parameter_reference)):
+
+| Campo | Parâmetro PX4 | Significado |
+|-------|-----------|---------|
+| `speed` | `MPC_XY_CRUISE` | Velocidade de cruzeiro horizontal |
+| `vel_max` | `MPC_XY_VEL_MAX` | Limite máximo de velocidade horizontal (elevado para ≥ `speed`) |
+| `speed_up` / `speed_down` | `MPC_Z_VEL_MAX_UP` / `MPC_Z_VEL_MAX_DN` | Velocidade de subida / descida |
+| `accel` | `MPC_ACC_HOR` | Aceleração horizontal |
+| `accel_up` / `accel_down` | `MPC_ACC_UP_MAX` / `MPC_ACC_DOWN_MAX` | Aceleração vertical |
+| `jerk` | `MPC_JERK_AUTO` | Limite de jerk de trajetória |
+| `yaw_rate` | `MPC_YAWRAUTO_MAX` | Taxa de yaw automática (graus/s) |
+| `takeoff_speed` | `MPC_TKO_SPEED` | Velocidade de subida no takeoff |
+
+Esses parâmetros governam os caminhos de setpoint **POSITION / POSITION_GLOBAL** e a subida de takeoff em offboard do PX4. O caminho padrão **PID / PID_EKF** não é afetado — nele o SDK computa a velocidade e o limite é o clamp de saída do PID por eixo (veja o [núcleo do veículo](../vehicle/#configuracao-de-pid)), idêntico ao ArduPilot.
+
+Definido via config (`apply_setpoint_params=True` envia os parâmetros ao FCU em `arm()`) ou em runtime; `set_speed` muda um único eixo em tempo real:
+
+```python
+from nectar.control import DroneFactory, Px4MavrosConfig, Px4SetpointConfig
+
+drone = DroneFactory.create("px4", Px4MavrosConfig(
+    setpoint_config_file="setpoint_outdoor.yaml", apply_setpoint_params=True,
+))
+drone.set_setpoint_config({"speed": 3.0, "accel": 2.5})  # push MPC_* to the FCU
+drone.set_speed(2.0, "horizontal")                        # live: MPC_XY_CRUISE/VEL_MAX
+```
+
+Presets embutidos vivem no [diretório `config/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/control/px4/config) (`setpoint_outdoor.yaml`, `setpoint_indoor.yaml`, e as variantes de SITL `setpoint_sim_*`).
+
+> **Limitação:** o backend nativo uXRCE-DDS (`px4_dds`) não consegue definir parâmetros, então `apply_setpoint_params` / `set_setpoint_config` / `set_speed` são no-ops nele — use o backend MAVROS ou MAVLink direto, ou defina os parâmetros `MPC_*` no QGC.
+
+## Atuadores de payload / gripper {#atuadores-de-payload-gripper}
+
+Para payloads (por exemplo, um gancho de liberação), use a API neutra em relação a firmware, em qualquer backend:
+
+```python
+drone.set_gripper(grab=False)        # MAV_CMD_DO_GRIPPER: release (grab=True closes)
+drone.set_actuator(index=1, value=1.0)  # MAV_CMD_DO_SET_ACTUATOR: normalized -1..1
+```
+
+O PX4 mapeia isso para as funções de saída `Gripper` e `Peripheral Actuator Set` configuradas em [Actuators](https://docs.px4.io/main/en/config/actuators.html) / [Servo Gripper](https://docs.px4.io/main/en/peripherals/gripper_servo.html). O `do_servo(channel, pwm)` por canal do ArduPilot não está disponível no PX4 (ele não declara a capacidade `SERVO`); `set_actuator` / `set_gripper` são os substitutos portáveis.
+
+## Requisitos
+
+Um `mavros_node` precisa estar fazendo a ponte com o FCU do PX4. O transporte o inicia para você quando `Px4MavrosConfig.start_driver=True`:
+
+```
+ros2 launch mavros px4.launch fcu_url:=<connection_string>
+```
+
+Para o SITL do PX4, a API MAVLink de offboard fica na UDP 14540 (`udp://:14540@127.0.0.1:14580`); em hardware, use o `fcu_url` serial/UDP apropriado.
+
+## Simulação
+
+SITL do PX4 com Gazebo (o próprio PX4 inicia o Gazebo), via a CLI unificada de simulação:
+
+**Terminal 1 — PX4 SITL + Gazebo** (mundo outdoor compartilhado do Nectar + `x500_nectar`, offboard na UDP 14540; sensores correspondentes `/front_camera/*`, `/down_camera`, e o lidar voltado para baixo em `/mavros/rangefinder/rangefinder`):
+
+```bash
+make sim-start FIRMWARE=px4 ENV=outdoor
+```
+
+**Terminal 2 — MAVROS + pontes de câmera**:
+
+```bash
+make sim-bridge FIRMWARE=px4 ENV=outdoor
+```
+
+**Rodar um script** (backend MAVROS):
+
+```bash
+python3 basic.py --drone px4
+```
+
+Para o backend pymavlink direto, retire o MAVROS no Terminal 2 e use o drone
+`px4_mavlink` (ele mesmo se conecta à UDP 14540; o rangefinder chega como
+`DISTANCE_SENSOR` do MAVLink, câmeras via `ros_gz_bridge`):
+
+```bash
+make sim-bridge FIRMWARE=px4 ENV=outdoor PROTOCOL=mavlink   # cameras only, no MAVROS
+python3 basic.py --drone px4_mavlink --connection udp:0.0.0.0:14540
+```
+
+`make sim-start FIRMWARE=px4 ENV=outdoor` voa o PX4 na mesma arena de
+`make sim-start FIRMWARE=ardupilot ENV=outdoor`, com os mesmos tópicos de sensor, então
+as missões são agnósticas a firmware. Instale uma vez com `make sim-install FIRMWARE=px4`.
+Veja o [guia de Simulação](../../simulation/) para a arquitetura de mundo compartilhado.
+
+## Uso
+
+```python
+import nectar
+from nectar.control import DroneFactory, PX4_SITL_GAZEBO_CONFIG
+
+nectar.init()
+drone = DroneFactory.create("px4", PX4_SITL_GAZEBO_CONFIG)
+
+drone.takeoff(altitude=3.0)
+drone.move_to(x=5.0, y=0.0, z=0.0, precision=0.3)
+drone.move_to_gps(latitude=-22.413, longitude=-45.449, altitude=15.0)
+drone.rtl(land=True)
+nectar.shutdown()
+```
+
+## Caminho nativo uXRCE-DDS (`px4_dds`)
+
+Um segundo transporte alcança o PX4 diretamente por sua [ponte uXRCE-DDS](https://docs.px4.io/main/en/ros2/user_guide.html), usando [`px4_msgs`](https://github.com/PX4/px4_msgs) — sem MAVROS. `Px4DdsDrone` é `Px4Drone` sobre um [`Px4DdsTransport`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/px4/dds_transport.py):
+
+- Telemetria em `/fmu/out/*` (`VehicleLocalPosition`, `VehicleStatus`, `VehicleGlobalPosition`), com a QoS `sensor_data` que o PX4 exige.
+- Comandos via `/fmu/in/vehicle_command` (`VehicleCommand`); setpoints via `/fmu/in/offboard_control_mode` + `/fmu/in/trajectory_setpoint`.
+- O NED/FRD do PX4 é convertido de/para o ENU/FLU do núcleo, no transporte.
+
+A visão externa indoor usa o mesmo link DDS: o backend `dds` de localization publica `px4_msgs/VehicleOdometry` em `/fmu/in/vehicle_visual_odometry` para o EKF2 (`ros2 launch nectar vision_pose.launch.py backend:=dds`). Veja [Localization](localization/#backends).
+
+Requisitos (uma vez) — compila o `px4_msgs` e o agent (contra o Fast-DDS do ROS):
+
+```bash
+make sim-install FIRMWARE=px4 ARGS=--native
+```
+
+Uso — 3 terminais (o SITL do PX4 inicia o cliente uXRCE-DDS por conta própria):
+
+**Terminal 1 — PX4 SITL + Gazebo**:
+
+```bash
+make sim-start FIRMWARE=px4 ENV=outdoor
+```
+
+**Terminal 2 — agent uXRCE-DDS** (`MicroXRCEAgent udp4 -p 8888`):
+
+```bash
+make sim-bridge FIRMWARE=px4 ENV=outdoor PROTOCOL=dds
+```
+
+**Rodar um script**:
+
+```bash
+python3 nectar/nectar/examples/control/basic.py --drone px4_dds --env outdoor
+```
+
+```python
+from nectar.control import DroneFactory, PX4_DDS_SITL_CONFIG
+drone = DroneFactory.create("px4_dds", PX4_DDS_SITL_CONFIG)
+```
+
+Notas / limitações:
+
+- **Tópicos versionados**: o PX4 versiona alguns tópicos uORB (por exemplo, `vehicle_local_position_v1`, `vehicle_status_v4`). `Px4DdsConfig` expõe `local_position_topic` / `status_topic` / `global_position_topic` (os padrões acompanham o `main` atual do PX4); sobrescreva-os para casar com um firmware diferente. `px4_msgs` precisa ser o branch que corresponde à sua release do PX4.
+- `set_param` não é encaminhado pela uXRCE-DDS por padrão (use o QGC ou o caminho MAVROS); `rtl(method=NATIVE)` nativo ainda troca para `AUTO.RTL`, mas não consegue enviar `RTL_RETURN_ALT`.
+- Setpoints globais (GPS) são apenas de frame local no caminho nativo; use um método PID ou o caminho MAVROS para `move_to_gps` com `POSITION_GLOBAL`.
+- Setups sem sudo: se o agent for instalado em um prefixo de usuário em vez de `/usr/local`, adicione o diretório de lib dele ao `LD_LIBRARY_PATH` (a instalação `--native` usa `sudo make install` + `ldconfig`, o que evita isso).
+
+## Referências
+
+- [PX4 User Guide](https://docs.px4.io/) · [Basic Concepts](https://docs.px4.io/main/en/getting_started/px4_basic_concepts.html)
+- [Flight Modes (Multicopter)](https://docs.px4.io/main/en/flight_modes_mc/) · [Basic Flying (MC)](https://docs.px4.io/main/en/flying/basic_flying_mc.html)
+- [ROS 2 User Guide](https://docs.px4.io/main/en/ros2/) · [ROS 2 Offboard Control](https://docs.px4.io/main/en/ros2/offboard_control.html)
+- [PX4 Simulation](https://docs.px4.io/main/en/simulation/) · [Gazebo Simulation](https://docs.px4.io/main/en/sim_gazebo_gz/)
+- Lógica de voo compartilhada: [Núcleo do veículo](../vehicle/) · Conectividade MAVROS: [Transporte MAVROS](../mavros/)

--- a/i18n/pt/modules/control/vehicle.md
+++ b/i18n/pt/modules/control/vehicle.md
@@ -1,0 +1,492 @@
+# Núcleo do Veículo
+
+Lógica de voo agnóstica a firmware, compartilhada por todo autopiloto da classe MAVLink no SDK. ArduPilot e PX4 são o **mesmo comportamento de veículo, alcançado por meio de semânticas de firmware e transportes diferentes** — toda a navegação, a detecção de takeoff/land, a matemática de GPS, o controle PID e a API de movimento vivem aqui uma única vez. As especializações de firmware ([ardupilot](../ardupilot/), [px4](../px4/)) implementam apenas as partes que diferem; os transportes ([mavros](../mavros/), [mavlink](../mavlink/)) implementam apenas a conectividade on-wire.
+
+> Este README é a referência do comportamento compartilhado — métodos de navegação, frames de referência, fontes de altitude, detecção de takeoff/land, tratamento de GPS/EGM96 e configuração de PID — e se aplica a todo veículo (tanto ArduPilot quanto PX4). As semânticas específicas de cada firmware estão em [ArduPilot](../ardupilot/) (GUIDED, WPNAV/GUID_OPTIONS, parâmetros nativos de RTL) e [PX4](../px4/) (OFFBOARD, nomes de modo, parâmetros de RTL).
+
+## Design
+
+Uma **ponte** (bridge) de dois eixos: uma classe de semântica de firmware (subclasse de `VehicleDrone`) é composta com um `VehicleTransport` de protocolo on-wire. O lado drone possui a orquestração de voo sobre tipos simples, sem ROS ([`types.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/types.py)); o lado transporte converte esses tipos de/para seu formato on-wire (tópicos/serviços ROS, MAVLink puro ou uXRCE-DDS). Assim, a mesma lógica de voo serve ArduPilot e PX4 sobre MAVROS ou um link direto, sem duplicação.
+
+```mermaid
+classDiagram
+    class VehicleDrone {
+        <<abstract>>
+        -_transport VehicleTransport
+        -_navigator VehicleNavigator
+        -_sequencer FlightSequencer
+        +takeoff() land() move_to() move_to_gps() move_velocity() rtl()
+        +set_speed() set_actuator() set_gripper() set_setpoint_config()
+        +arm()* _rtl_native()* _change_speed()* capabilities*
+        +_command_takeoff() _command_land() _ensure_offboard_ready()
+        +_emit_velocity() _prepare_position_setpoint() _load_firmware_config()
+    }
+    class ArduPilotDrone {
+        GUIDED arm, RTL_ALT, GUID_OPTIONS/WPNAV
+    }
+    class Px4Drone {
+        OFFBOARD + setpoint pump, AUTO.LAND/RTL, RTL_RETURN_ALT
+    }
+    class VehicleTransport {
+        <<abstract>>
+        +state local_pose vision_pose gps heading rel_alt rangefinder distance_sensors
+        +arm() set_mode() command_takeoff() command_land() set_param()
+        +send_velocity_target() send_local_target() send_global_target()
+    }
+    class MavrosTransport
+    class PymavlinkTransport
+
+    VehicleDrone <|-- ArduPilotDrone
+    VehicleDrone <|-- Px4Drone
+    VehicleDrone o-- VehicleTransport
+    VehicleTransport <|.. MavrosTransport
+    VehicleTransport <|.. PymavlinkTransport
+```
+
+## Módulos
+
+| Arquivo | Responsabilidade |
+| --- | --- |
+| `types.py` | Dataclasses simples (`Vec3`, `LocalPose`, `GeoPoint`, `Attitude`, `VehicleState`, `LocalTarget`, `GlobalTarget`, `TargetFrame`). Convenções ENU/radianos. Sem imports de ROS. |
+| `transport.py` | ABC `VehicleTransport`: propriedades de leitura de telemetria + métodos de escrita de comando/setpoint + ciclo de vida. |
+| `setpoint_config.py` | `SetpointConfig` base — limites SI de velocidade/aceleração/jerk, I/O compartilhado de YAML/dict e clamp de faixa; `to_fcu_params` por firmware (ArduPilot `WPNAV_*`, PX4 `MPC_*`). |
+| `drone.py` | `VehicleDrone(BaseDrone)` — comportamento de voo compartilhado + hooks de firmware. |
+| `navigator.py` | `VehicleNavigator` — loops de navegação por PID e por setpoint sobre alvos/poses simples. |
+| `target_computer.py` | Computação de alvo sem estado (offsets locais/GPS → `LocalTarget`/`GlobalTarget`). |
+| `gps_utils.py` | Correção do geoide EGM96, verificações geodésicas de chegada, construção de alvo global. |
+| `sequencer.py` | `FlightSequencer` — detecção de estabilização de takeoff/land baseada em velocidade. |
+
+## Hooks de firmware
+
+`VehicleDrone` mantém toda a orquestração e delega as partes específicas de firmware a hooks sobrescrevíveis:
+
+| Hook | Padrão | ArduPilot | PX4 |
+|------|---------|-----------|-----|
+| `arm()` | abstrato | GUIDED + parâmetros WPNAV (opcional) | OFFBOARD + pump de setpoint |
+| `_command_takeoff(alt)` | `command_takeoff` do transporte | comando de takeoff do FCU | setpoint de subida em offboard |
+| `_command_land()` | `command_land` do transporte | comando de land do FCU | `AUTO.LAND` |
+| `_rtl_native(alt, land)` | abstrato | `RTL_ALT`/`RTL_ALT_FINAL` + modo `RTL` | `RTL_RETURN_ALT`/`RTL_LAND_DELAY` + `AUTO.RTL` |
+| `_ensure_offboard_ready()` | no-op | no-op (GUIDED persiste) | (re)entra em OFFBOARD, mantém o pump vivo |
+| `_prepare_position_setpoint(p)` | no-op | sincroniza `WPNAV_RADIUS` | no-op |
+| `_emit_velocity(...)` | envio do transporte | envio do transporte | também armazena para o pump de offboard |
+| `_change_speed(v, axis)` | abstrato | `DO_CHANGE_SPEED` | parâmetro `MPC_XY_CRUISE`/`MPC_Z_VEL_MAX_*` |
+| `_load_firmware_config()` | carrega a config de setpoint | + contabilidade de raio | + inicia o pump de offboard |
+| `_apply_setpoint_config()` | `set_param` por parâmetro (+alias) | WPNAV cm/s + alias `WP_*` | `MPC_*` (SI) |
+| `capabilities` | abstrato | declara o conjunto do ArduPilot | declara o conjunto do PX4 |
+
+## Convenções
+
+- **Frames**: o núcleo é ENU (x=Leste, y=Norte, z=Cima) / FLU; os transportes convertem de/para o NED/FRD on-wire.
+- **Yaw**: radianos, ENU (0 = Leste, positivo no sentido anti-horário). O *heading* da bússola (graus, NED) é mantido separado para a matemática de corpo em GPS.
+- **Atomicidade**: as propriedades de telemetria retornam o valor mais recente por atribuição de objeto inteiro (atômica sob o GIL), então a thread de voo nunca vê uma pose parcialmente escrita.
+
+## Conexão e Prontidão
+
+`connect()` não retorna assim que o transporte inicia — ele espera (até um timeout) por um heartbeat vivo do FCU, definindo `_connected` somente quando o link estiver de pé. Depois de conectar:
+
+- `is_fcu_connected` — heartbeat do FCU presente (estado bruto do link).
+- `is_ready` — conectado **e** o driver/transporte está em execução; este é o portão que as chamadas de nível mais alto verificam antes de armar ou comandar.
+
+## Tipos de Altitude
+
+O FCU expõe [várias definições de altitude](https://ardupilot.org/copter/docs/common-understanding-altitude.html); o SDK escolhe entre elas com `AltitudeSource`:
+
+| Tipo | Descrição | Fonte | Uso no SDK |
+|------|-------------|--------|-----------|
+| **AGL** (Above Ground Level) | Distância até o solo diretamente abaixo | Rangefinder (lidar) | `AltitudeSource.LIDAR`, terrain following |
+| **Relativa** | Altitude acima de HOME/ORIGIN | EKF (baro + GPS) | `AltitudeSource.REL_ALT`, `move_to_gps` |
+| **AMSL** (Above Mean Sea Level) | Altitude acima do nível médio do mar | EKF + modelo de geoide | Setpoints globais |
+| **Elipsoide (WGS84)** | Altitude de GPS bruta acima do elipsoide WGS84 | Receptor GPS | `GeoPoint.altitude` bruto |
+| **Vision Z** | Z da pose de visão, relativo à origem de visão | VIO externo | `AltitudeSource.VISION`, navegação indoor |
+
+**AMSL vs Elipsoide**: receptores GPS emitem altitude acima do elipsoide WGS84, mas setpoints globais esperam AMSL. A diferença é a [altura do geoide](https://en.wikipedia.org/wiki/EGM96), corrigida por `GPSUtils` usando o modelo EGM96.
+
+**Surface Tracking**: com um [rangefinder voltado para baixo](https://ardupilot.org/copter/docs/common-rangefinder-landingpage.html) dentro do alcance, o FCU consegue manter AGL constante ([surface tracking do ArduPilot](https://ardupilot.org/copter/docs/terrain-following.html)). `AltitudeSource.LIDAR` implementa um conceito semelhante no nível do SDK, via controle PID.
+
+## Frames de Coordenadas
+
+O FCU usa **NED** (Norte-Leste-Baixo) / **FRD** (Frente-Direita-Baixo) internamente. O núcleo do SDK usa **ENU** (Leste-Norte-Cima) / **FLU** (Frente-Esquerda-Cima). O transporte realiza a conversão na saída/entrada — **o código do SDK sempre usa ENU/FLU**.
+
+| Frame | SDK (ENU/FLU) | FCU Interno (NED/FRD) | Origem |
+|-------|---------------|------------------------|--------|
+| **Mundo** | X=Leste, Y=Norte, Z=Cima | X=Norte, Y=Leste, Z=Baixo | Origem do EKF |
+| **Corpo** | X=Frente, Y=Esquerda, Z=Cima | X=Frente, Y=Direita, Z=Baixo | Centro do veículo |
+| **WGS84** | Latitude, Longitude, Altitude | Igual | Elipsoide de referência da Terra |
+
+O enum `MoveReference` do SDK mapeia para um `TargetFrame` on-wire:
+
+| MoveReference | TargetFrame | Significado da velocidade (entrada do SDK) |
+|---|---|---|
+| **BODY** | BODY (FRAME_BODY_NED) | vx=frente, vy=esquerda, vz=cima (relativo ao heading) |
+| **WORLD** | LOCAL (FRAME_LOCAL_NED) | vx=leste, vy=norte, vz=cima (direções absolutas) |
+| **TAKEOFF** | BODY (FRAME_BODY_NED) | Velocidades no heading de takeoff, rotacionadas para o frame de corpo atual |
+
+> **Nota:** o frame local do EKF precisa de uma origem — outdoor, o GPS geralmente a define;
+> indoor, sem fix de GPS, o ArduPilot precisa de uma origem manual (ou gravada
+> automaticamente em 4.7+) antes que comandos de pose local / `FRAME_LOCAL_NED`
+> funcionem. Detalhes:
+> [Localization → Origem do EKF](localization/#ekf-origin).
+
+## Sensores de Distância
+
+`rangefinder` / `AltitudeSource.LIDAR` expõe apenas o sensor voltado para baixo, usado para altitude. Todo rangefinder e setor de proximidade que o FCU reporta (uma mensagem `DISTANCE_SENSOR` por unidade) também fica disponível como telemetria bruta, para detecção de obstáculos, redundância ou verificação:
+
+- `drone.distance_sensors` — `dict[int, DistanceReading]` indexado pelo id do sensor MAVLink, contendo a leitura mais recente por sensor.
+- `drone.get_distance(orientation)` — o `DistanceReading` mais recente voltado para uma dada `SensorOrientation`, ou `None`.
+
+`SensorOrientation` espelha os valores de [MAV_SENSOR_ORIENTATION](https://mavlink.io/en/messages/common.html#MAV_SENSOR_ORIENTATION) usados para sensores de distância: `FORWARD`, os setores de yaw (`FORWARD_RIGHT`, `RIGHT`, `BACK_RIGHT`, `BACK`, `BACK_LEFT`, `LEFT`, `FORWARD_LEFT`), `UP`, `DOWN` e `OTHER`. Cada `DistanceReading` carrega `distance`, `orientation`, `min_distance` / `max_distance`, `sensor_id`, `sensor_type` ([MAV_DISTANCE_SENSOR](https://mavlink.io/en/messages/common.html#MAV_DISTANCE_SENSOR)), `signal_quality` (quando reportado), `raw_orientation` e um `timestamp` monotônico.
+
+A configuração do sensor é feita do lado do FCU (por exemplo, `RNGFNDx_*` do ArduPilot, [configuração de rangefinder](https://ardupilot.org/copter/docs/common-rangefinder-setup.html) e, para setores horizontais, `PRXx_*` [sensores de proximidade](https://ardupilot.org/copter/docs/common-proximity-landingpage.html)). O sensor voltado para baixo (`SensorOrientation.DOWN`) também atualiza `rangefinder`. O transporte MAVLink direto coleta todas as leituras automaticamente; o transporte MAVROS exige que elas sejam declaradas em config (veja o [README do MAVROS](../mavros/#sensores-de-distancia)).
+
+## Decolagem e Pouso
+
+A detecção de levantamento/toque no solo vive em [`FlightSequencer`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/sequencer.py). A detecção é **baseada em velocidade**: uma aeronave pairando ou no solo tem `|dz/dt| ≈ 0` mesmo quando o rangefinder/EKF/visão oscilam ±0,2–0,3 m por uma fração de segundo. Isso é agnóstico ao tamanho do drone — rastreia a taxa de variação, não a altitude absoluta — então funciona independentemente de onde o rangefinder lê zero (altura do corpo, offset de gancho/payload).
+
+### Decolagem
+
+```python
+drone.takeoff(altitude=1.5)  # defaults: max_retries=2, adjust_altitude=True, precision=0.12m, timeout=25s
+drone.takeoff(altitude=2.0, adjust_altitude=False)
+```
+
+**Sequência** (por tentativa):
+
+1. **Arme**: entra no modo offboard/guided do firmware e arma, verificando o estado do veículo a cada passo (GUIDED para ArduPilot, OFFBOARD para PX4 — veja os READMEs de firmware).
+2. **Aquecimento (spin-up)**: pequeno delay de segurança de hardware (`_SPIN_UP_DELAY`).
+3. **Posição de takeoff**: capturada apenas na primeira tentativa (usada por `MoveReference.TAKEOFF` e RTL).
+4. **Comando de takeoff**: `_command_takeoff(altitude)` (comando de takeoff do FCU no ArduPilot, um setpoint de subida em offboard no PX4).
+5. **Espera pelo levantamento + estabilização**: `wait_takeoff_settle(start_alt, start_alt + altitude, timeout)`. Sem sleep fixo.
+6. **Ajuste** (se `adjust_altitude=True` e fora do alvo por mais que `precision`): `move_to(z=altitude, reference=TAKEOFF, method=PID)`.
+
+**Detecção de estabilização** — a subida é declarada estabilizada quando **todas** as condições valem:
+
+- **Levantado**: a altitude subiu `_LIFTOFF_DELTA` acima de `start_alt`.
+- **Critério de proximidade ao alvo**: a altitude está em ou acima de `floor = target_alt - _settle_band`, onde `_settle_band = min(_SETTLE_ALT_TOLERANCE, _SETTLE_ALT_FRACTION × climb)`. Isso evita que um levantamento inicial lento (velocidade baixa, ainda perto do solo) seja confundido com um takeoff concluído. A faixa escala com a subida comandada, então voos curtos usam um critério rígido e subidas altas não são forçadas a acertar o alvo exatamente (o ajuste pós-estabilização refina o restante).
+- **Velocidade**: a velocidade vertical média sobre `_SETTLE_WINDOW` está abaixo de `_SETTLE_VELOCITY`.
+
+O progresso da subida (altitude, ganho, velocidade vertical) é logado a aproximadamente 1 Hz, para que um takeoff longo permaneça observável.
+
+**Atalhos**:
+
+- Já em voo (`is_airborne`): pula o fluxo e retorna sucesso.
+- Estabilizado, mas `height_gain < _LIFTOFF_DELTA` enquanto `is_airborne` reporta voo: aceita (tolerância a falha de sensor).
+- Levantamento nunca detectado após `timeout`: desarma e tenta de novo; na última tentativa, falha.
+
+**`is_airborne`** (usado pelo atalho de takeoff):
+
+1. Desarmado → não está em voo.
+2. Senão, `HEARTBEAT.system_status` do FCU quando é estado MAVLink real: o ArduCopter reporta `MAV_STATE_STANDBY` quando `land_complete` e `MAV_STATE_ACTIVE` quando em voo — este é o sinal primário.
+3. Senão, fallback de altitude (rangefinder / pose local / `rel_alt`) contra `_AIRBORNE_THRESHOLD` (1,0 m). Um critério absoluto mais rígido dispara falsos positivos em aeronaves no solo: altura de corpo do rangefinder, plataformas elevadas, ou Z de visão relativo a uma origem de takeoff mais baixa podem ficar perto de 0,5 m mesmo pousados.
+
+**Parâmetros ajustáveis** (constantes de classe em `FlightSequencer`):
+
+| Constante | Padrão | Significado |
+|---|---|---|
+| `_SPIN_UP_DELAY` | 2,7 s | Delay de segurança de hardware pós-arme, antes do comando de takeoff |
+| `_LIFTOFF_DELTA` | 0,08 m | Subida acima de `start_alt` para considerar levantado |
+| `_SETTLE_WINDOW` | 0,8 s | Janela móvel sobre a qual a velocidade vertical é calculada em média |
+| `_SETTLE_VELOCITY` | 0,25 m/s | Velocidade vertical abaixo da qual o hover é declarado estabilizado |
+| `_SETTLE_POLL` | 0,1 s | Intervalo de poll para os loops de estabilização/pouso |
+| `_SETTLE_LOG_INTERVAL` | 1,0 s | Throttle do log de progresso de subida |
+| `_SETTLE_ALT_TOLERANCE` | 0,5 m | Faixa máxima de estabilização abaixo do alvo |
+| `_SETTLE_ALT_FRACTION` | 0,3 | Fração da subida usada como faixa de estabilização |
+| `_AIRBORNE_THRESHOLD` | 0,9 m | Fallback de altitude para `is_airborne` quando o estado do FCU não está disponível |
+
+Se a detecção ainda expirar (lidar muito ruidoso, subida lenta que nunca para completamente), aumente `_SETTLE_VELOCITY` ou diminua `_SETTLE_WINDOW`. O ajuste de fim de takeoff ainda leva o drone a `precision`, então um limiar de velocidade permissivo não custa nada em precisão final de altitude.
+
+### Pouso
+
+```python
+drone.land()              # default timeout=60s
+drone.land(timeout=45.0)
+```
+
+**Sequência**:
+
+1. Captura `start_alt`.
+2. Envia `_command_land()` (comando de land do FCU no ArduPilot, `AUTO.LAND` no PX4).
+3. **Espera pelo toque no solo** (`wait_landed`): o drone desceu (`start_alt - alt > _LIFTOFF_DELTA` ou `alt < _LANDED_THRESHOLD`) **e** sua velocidade de descida sobre `_LAND_SETTLE_WINDOW` caiu abaixo de `_LAND_STOP_VELOCITY`, **ou** o FCU reporta `armed=False`.
+
+> **Nota:** `land()` retorna `True` no toque no solo sem esperar pelo delay de desarme do autopiloto, então quem chamou é desbloqueado assim que o drone está no solo. Verifique `drone.is_armed` para confirmar que os motores estão desligados.
+
+| Constante | Padrão | Significado |
+|---|---|---|
+| `_LANDED_THRESHOLD` | 0,3 m | Fallback absoluto de "já baixo" para o critério de descida |
+| `_LAND_SETTLE_WINDOW` | 1,2 s | Janela móvel para o cálculo de velocidade de descida |
+| `_LAND_STOP_VELOCITY` | 0,05 m/s | Taxa de descida abaixo da qual o toque no solo é declarado |
+
+| Sintoma | Ajuste |
+|---|---|
+| `Land timed out` em descida muito lenta (< 0,1 m/s) | reduza `_LAND_STOP_VELOCITY` (por exemplo, 0,03) |
+| Detecção dispara ainda em descida rápida | aumente `_LAND_STOP_VELOCITY` (por exemplo, 0,08) |
+| Lidar ruidoso no solo (prop wash) causa falsos negativos | aumente `_LAND_SETTLE_WINDOW` (por exemplo, 2,0) |
+| Drone real — quer detecção mais rápida | reduza `_LAND_SETTLE_WINDOW` (por exemplo, 0,8) |
+
+## Navegação
+
+A navegação vive em [`VehicleNavigator`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/navigator.py), mantendo as classes de drone focadas na interface de firmware/hardware, nos dados de sensor e na computação de alvo.
+
+`move_to` e `move_to_gps` aceitam `method: NavigationMethod` (padrões: `move_to` → `PID_EKF`, `move_to_gps` → `PID`). `rtl` aceita `method: RTLMethod` (padrão `NAVIGATE`, que usa `PID_EKF` internamente).
+
+### Matriz de Capacidades
+
+| Ponto de Entrada | PoseSource | Método | Referência | AltitudeSource | Notas |
+|------------|-----------|--------|-----------|----------------|-------|
+| `move_to` | VISION | PID | BODY, TAKEOFF | AUTO, VISION, LIDAR | Pose de visão bruta (PID de velocidade do SDK) |
+| `move_to` | VISION | PID_EKF | BODY, TAKEOFF | AUTO, VISION, LIDAR | **Padrão** — pose local do EKF (frame unificado) |
+| `move_to` | VISION | POSITION | BODY, TAKEOFF | N/A | Setpoint local |
+| `move_to` | VISION | POSITION_GLOBAL | — | — | Não suportado (sem GPS indoor) |
+| `move_to` | GPS | PID | BODY, TAKEOFF | AUTO, LIDAR, REL_ALT | GPS bruto (PID de velocidade do SDK) |
+| `move_to` | GPS | PID_EKF | BODY, TAKEOFF | AUTO, LIDAR, REL_ALT | **Padrão** — pose local do EKF (frame unificado) |
+| `move_to` | GPS | POSITION | BODY, TAKEOFF | N/A | Setpoint local |
+| `move_to` | GPS | POSITION_GLOBAL | BODY, TAKEOFF | N/A | Setpoint GPS com AMSL (longo alcance) |
+| `move_to` | qualquer | qualquer | WORLD | qualquer | Não suportado (lança `CapabilityNotSupportedError`) |
+| `move_to_gps` | GPS | PID | N/A | REL_ALT | Waypoint GPS, PID de GPS bruto (**padrão**) |
+| `move_to_gps` | GPS | PID_EKF | N/A | REL_ALT | Waypoint GPS, PID local do EKF |
+| `move_to_gps` | GPS | POSITION | — | — | Não suportado (entrada GPS precisa de saída global) |
+| `move_to_gps` | GPS | POSITION_GLOBAL | N/A | N/A | Setpoint GPS para o FCU |
+| `move_to_gps` | VISION | qualquer | N/A | qualquer | Não suportado |
+| `move_velocity` | qualquer | N/A | BODY, WORLD, TAKEOFF | N/A | Comando de velocidade direto |
+
+O PX4 compartilha essa matriz; o único desvio é `POSITION_GLOBAL` sobre o backend nativo uXRCE-DDS (`px4_dds`), onde setpoints globais são apenas de frame local — use um método PID ou o caminho MAVROS (veja [PX4](../px4/#caminho-nativo-uxrce-dds-px4_dds)).
+
+### Comportamento dos Parâmetros de `move_to`
+
+**Valores de eixo — `x`, `y`, `z`, `yaw`**: cada um pode ser um `float` ou `None`. O comportamento depende do método:
+
+| Valor | PID / PID_EKF | POSITION / POSITION_GLOBAL |
+|-------|---------------|----------------------------|
+| `float` | Ativo — o PID conduz esse eixo | Incluído no alvo do FCU |
+| `None` | **Desabilitado** — sem velocidade nesse eixo, excluído da verificação de chegada | Offset zero — mantém a posição/yaw atual nesse eixo |
+
+**Diferença chave**: com métodos PID, `None` de fato desabilita o eixo (sem velocidade, excluído da verificação de distância). Com métodos POSITION, o FCU recebe um alvo 3D+yaw completo e controla todos os eixos; `None` significa offset zero (um snapshot do valor atual no momento da chamada).
+
+> **Nota sobre a precisão de `None`**: com **PID**, um eixo desabilitado não é controlado — vento ou inércia podem causar drift sem correção. Com **POSITION**, o alvo para um eixo `None` é um snapshot da posição atual, que pode diferir ligeiramente de onde você quer estar. Para posicionamento multi-eixo preciso, especifique todos os eixos explicitamente.
+
+**Frames de referência — `reference`**:
+
+| Referência | Origem | Heading | Caso de uso |
+|-----------|--------|---------|----------|
+| `BODY` | Posição atual | Heading atual | "Mova 2m para frente de onde estou agora" |
+| `TAKEOFF` | Posição de takeoff | Heading de takeoff | "Vá até o ponto 3m para frente de onde decolei" |
+
+Com **BODY**, os offsets se encadeiam a partir da posição atual. Com **TAKEOFF**, os offsets são absolutos a partir da origem de takeoff; eixos `None` mantêm a posição atual nesse eixo (não a origem de takeoff). `move_to` não suporta `WORLD` e lança `CapabilityNotSupportedError`.
+
+```
+TAKEOFF reference, drone at (3, -2) in takeoff frame:
+
+move_to(x=0, y=None) → target (0, -2)   # takeoff-origin X, current Y preserved
+move_to(x=0, y=0)    → target (0, 0)    # full takeoff origin
+```
+
+#### Comportamento de Yaw + Posição (PID / PID_EKF)
+
+Quando `yaw` é especificado junto com um eixo de posição (`x` ou `y`), a navegação PID é **yaw primeiro**:
+
+1. **Fase 1 — Alinhamento de yaw**: rotaciona até o yaw alvo mantendo a posição (translação zero). Completa quando `|dyaw| ≤ 3°` (`YAW_THRESHOLD`).
+2. **Fase 2 — Translação**: move até o alvo mantendo o yaw. Tanto `x` quanto `y` são ativados, independentemente de qual foi especificado, porque depois da rotação o alvo no frame mundo pode se projetar em qualquer um dos eixos de corpo.
+
+O alvo de posição é computado no momento da chamada, na direção de heading original — a rotação de yaw altera apenas a orientação final. Com POSITION / POSITION_GLOBAL, yaw e posição são controlados simultaneamente pelo FCU (sem fase de yaw primeiro).
+
+### Exemplos de Navegação
+
+**Relativo ao corpo** (relativo à posição atual):
+
+```python
+drone.move_to(x=2.0, y=0.0, z=0.0)            # 2m forward
+drone.move_to(z=0.5)                           # 0.5m up (x/y disabled)
+drone.move_to(x=3.0, yaw=45.0)                 # rotate 45°, then 3m to target
+```
+
+**Relativo ao takeoff** (offsets absolutos a partir da origem de takeoff):
+
+```python
+drone.move_to(x=2.0, y=0.0, z=0.0, reference=MoveReference.TAKEOFF)
+drone.move_to(x=0.0, y=0.0, z=0.0, reference=MoveReference.TAKEOFF)  # back to takeoff
+```
+
+**Terrain following** (z = altura acima do solo):
+
+```python
+drone.move_to(x=2.0, z=0.3, altitude_source=AltitudeSource.LIDAR)   # fly at 0.3m AGL
+```
+
+**Método de navegação** (PID local do EKF, ou controle de posição do FCU):
+
+```python
+drone.move_to(x=2.0, method=NavigationMethod.PID_EKF)
+drone.move_to(x=2.0, y=1.0, method=NavigationMethod.POSITION)
+```
+
+**Waypoints GPS** (outdoor):
+
+```python
+drone.move_to_gps(latitude=-27.1234, longitude=-48.4567, altitude=15.0, precision=1.0)
+drone.move_to_gps(latitude=-27.1234, longitude=-48.4567, altitude=15.0,
+                  method=NavigationMethod.POSITION_GLOBAL)
+```
+
+**Velocidade**:
+
+```python
+drone.move_velocity(vx=0.5, reference=MoveReference.BODY)     # forward (heading-relative)
+drone.move_velocity(vx=0.5, reference=MoveReference.WORLD)    # east (ENU absolute)
+drone.move_velocity(vx=1.0, duration=2.0)                     # forward for 2s, then stop
+```
+
+### Comportamento da Fonte de Altitude
+
+| AltitudeSource | Sensor | Quando Usado | Computação de dz |
+|---------------|--------|-----------|----------------|
+| AUTO | Melhor disponível | Padrão para `move_to` | Distância de corpo baseada em posição |
+| LIDAR | Rangefinder | Terrain following, AGL preciso | `altitude_target - current_lidar` |
+| VISION | Z da pose de visão | Manutenção de altitude indoor | Distância de corpo baseada em posição |
+| REL_ALT | Altitude relativa de GPS | `move_to_gps` PID, outdoor | `altitude_target - current_rel_alt` |
+
+**Parâmetro de altitude `z` por referência**:
+
+| Referência | `z` | LIDAR | REL_ALT | AUTO / VISION |
+|-----------|-----|-------|---------|---------------|
+| BODY | `float` | `current_lidar + z` | `current_rel_alt + z` | dz baseado em posição |
+| BODY | `None` | Desabilitado | Desabilitado | Desabilitado (FCU mantém) |
+| TAKEOFF | `float` | `z` (AGL absoluto) | `z` (altitude relativa absoluta) | `takeoff_z + z` |
+| TAKEOFF | `None` | Desabilitado | Desabilitado | Desabilitado (mantém a atual) |
+
+**Limite do LIDAR**: limitado a 15 m (`LIDAR_ALTITUDE_LIMIT`); recorre ao cálculo baseado em posição se excedido.
+
+A posição de takeoff é armazenada no **início de `takeoff()`** (no solo, antes de subir). Para frames de visão/local, `takeoff_z ≈ 0`, então com AUTO/VISION + referência TAKEOFF, `z` é efetivamente a **altura absoluta acima do nível do solo de takeoff**. Depois de `takeoff(1.5)`, use `z=1.5` para manter a mesma altura — `z=0` significa "vá até o nível do solo".
+
+**Segurança contra colisão com o solo**: `move_to` rejeita valores de `z` que produziriam uma altitude alvo ≤ 0 (com TAKEOFF, `z ≤ 0`; com BODY, `current_altitude + z ≤ 0`). O eixo é definido como `None` (altitude desabilitada) e um aviso é logado; o drone ainda se move nos outros eixos.
+
+### Fluxo de Navegação
+
+```mermaid
+flowchart TD
+    A["move_to / move_to_gps"] --> B{"Method?"}
+    B -->|PID / PID_EKF| C["Compute PID target + resolve altitude target"]
+    B -->|POSITION / POSITION_GLOBAL| D["Compute setpoint target"]
+    C --> F["navigator.navigate_pid"]
+    D --> G["navigator.navigate_setpoint"]
+    F --> yawCheck{"yaw + position axes active?"}
+    yawCheck -->|Yes| yawPhase["Phase 1: align yaw (zero translation)"]
+    yawPhase --> yawDone{"|dyaw| ≤ 3°?"}
+    yawDone -->|No| yawPhase
+    yawDone -->|Yes| enableXY["Enable both x,y; reset yaw PID"]
+    enableXY --> H["Phase 2: PID loop (body-frame errors)"]
+    yawCheck -->|No| H
+    H --> L["PID to move_velocity"]
+    L --> conv{"distance ≤ precision AND |dyaw| ≤ 3°?"}
+    conv -->|No| H
+    conv -->|Yes| donePID["Target reached"]
+    G --> I["Setpoint loop: publish_setpoint + check_reached"]
+    I --> convSP{"reached AND |dyaw| ≤ 3°?"}
+    convSP -->|No| I
+    convSP -->|Yes| doneSP["Setpoint reached"]
+```
+
+### Navegação PID
+
+Controle baseado em velocidade com feedback em malha fechada via `navigate_pid()`:
+
+1. O drone computa a posição alvo (frame mundo, por referência) e resolve o alvo de altitude (por fonte de altitude).
+2. O navigator cria controladores PID por eixo a partir de `pid_config`.
+3. Se yaw + posição: alinha o yaw primeiro (Fase 1), depois habilita tanto x quanto y.
+4. Loop de posição (~100 Hz): computa os erros de posição e yaw no frame de corpo, sobrescreve o erro de altitude se um alvo de altitude estiver definido (LIDAR/REL_ALT), atualiza os PIDs, publica velocidade e verifica a chegada (`distance ≤ precision AND |dyaw| ≤ 3°`).
+
+**Zona morta**: a velocidade por eixo é zerada quando `|error| < precision / 2`, para evitar oscilação. **Eixos ativos**: apenas eixos não-`None` são controlados e contados na verificação de distância (a exceção de yaw+x/y acima se aplica).
+
+### Navegação por Setpoint (Posição)
+
+Publicação direta de setpoint via `navigate_setpoint()`. O FCU recebe um alvo completo (posição + yaw) e controla todos os eixos simultaneamente — sem fase de yaw primeiro.
+
+- **Local** (`LocalTarget`): publica um setpoint local NED; verifica a distância euclidiana usando a pose local do EKF.
+- **Global** (`GlobalTarget`): publica um setpoint global AMSL; verifica a distância geodésica usando GPS + altitude relativa.
+
+Ambos verificam se o yaw alvo foi alcançado (dentro de `YAW_THRESHOLD = 3°`) antes de declarar chegada.
+
+Como um firmware roteia um setpoint publicado para seus controladores de bordo é específico de cada firmware: a seleção `AC_PosControl`/`AC_WPNav` do modo GUIDED do ArduPilot e os parâmetros `WPNAV_*` estão em [ArduPilot](../ardupilot/#controladores-de-posicao-do-modo-guided-do-ardupilot); o pump de setpoint OFFBOARD contínuo do PX4 está em [PX4](../px4/).
+
+### Transformações de Frame de Referência
+
+| API | BODY | WORLD | TAKEOFF |
+|-----|------|-------|---------|
+| `move_velocity()` | sim | sim | sim |
+| `move_to()` | sim | não | sim |
+
+- **BODY** — relativo à posição/orientação atual. `move_to` rotaciona o offset para coordenadas de mundo pelo yaw atual antes de somá-lo à posição atual.
+- **WORLD** — direções ENU absolutas, independentes do heading (apenas `move_velocity`; `move_to` lança `CapabilityNotSupportedError`). Funciona indoor (visão + origem do EKF) e outdoor (GPS).
+- **TAKEOFF** — relativo à posição/orientação de takeoff. Exige que a posição de takeoff tenha sido definida via `takeoff()` ou `set_takeoff_position()`.
+
+## RTL
+
+`rtl()` usa por padrão `RTLMethod.NAVIGATE` (caminho PID do SDK até home). Use `RTLMethod.NATIVE` para o modo RTL próprio do FCU.
+
+```python
+drone.rtl(altitude=5.0, method=RTLMethod.NAVIGATE, land=True)   # climb, fly to takeoff via PID, land
+drone.rtl(method=RTLMethod.NATIVE)                              # FCU RTL, auto-land
+```
+
+- **NAVIGATE**: opcionalmente sobe/desce até `altitude`, navega até a posição de takeoff (`x=0, y=0, z=0, reference=TAKEOFF`, `PID_EKF`), depois pousa se `land=True`. Este caminho é idêntico entre firmwares.
+- **NATIVE**: troca o FCU para seu próprio modo de retorno ao ponto de lançamento; o nome do modo e os parâmetros de altitude/loiter são específicos de firmware — veja [ArduPilot](../ardupilot/#rtl) (`RTL`, `RTL_ALT`/`RTL_ALT_FINAL`) e [PX4](../px4/) (`AUTO.RTL`, `RTL_RETURN_ALT`/`RTL_LAND_DELAY`).
+
+## Utilitários de GPS
+
+[`GPSUtils`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/control/vehicle/gps_utils.py) fornece métodos estáticos para navegação outdoor, usados pelo navigator e pelo drone.
+
+### Correção Geoidal EGM96
+
+A altitude de GPS (elipsoide WGS84) difere de AMSL pela altura do geoide. Setpoints globais esperam AMSL. `GPSUtils` usa o [modelo de geoide EGM96](https://en.wikipedia.org/wiki/EGM96) (grade de 5′, interpolação cúbica) para converter:
+
+```
+AMSL = GPS_ellipsoid_altitude - geoid_height + relative_altitude
+```
+
+> **Nota:** o dataset EGM96 precisa estar instalado (fornecido pela [GeographicLib](https://geographiclib.sourceforge.io/), lido de `/usr/share/GeographicLib/geoids/egm96-5.pgm`).
+
+### API
+
+```python
+from nectar.control.vehicle.gps_utils import GPSUtils
+
+GPSUtils.geoid_height(latitude, longitude)                     # EGM96 geoid height (m)
+
+GPSUtils.create_global_target(                                 # AMSL-corrected GlobalTarget
+    latitude, longitude, altitude_rel, heading, initial_altitude
+)
+
+reached, distance, alt_diff = GPSUtils.check_reached(          # geodesic arrival check
+    cur_lat, cur_lon, cur_alt, tgt_lat, tgt_lon, tgt_alt,
+    precision_radius=0.5, alt_threshold=0.5,
+)
+
+east, north = GPSUtils.local_offset(                           # equirectangular E/N offset (m)
+    cur_lat, cur_lon, tgt_lat, tgt_lon,
+)
+```
+
+`create_global_target` armazena o yaw em radianos ENU (convertido a partir do `heading` em NED) para corresponder à convenção do frame local. `local_offset` é uma aproximação equirretangular do offset leste/norte em metros; a chegada é sempre decidida pela distância geodésica de `check_reached`.
+
+## Configuração de PID
+
+`VehicleDrone` carrega um `PositionPIDConfig` (`PIDConfig` por eixo `x/y/z/yaw`) na construção. Se `pid_config_file` estiver definido, ele é carregado de lá; caso contrário, os presets embutidos por firmware (`position_indoor.yaml` / `position_outdoor.yaml`, sob o `config/` de cada firmware — [presets do ArduPilot](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/control/ardupilot/config) ou [presets do PX4](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/control/px4/config)) são selecionados por `is_indoor`. Os presets de SITL vêm como `position_sim_indoor.yaml` / `position_sim_outdoor.yaml` — aponte `pid_config_file` para eles ao voar no simulador. Atualize em runtime a partir de um caminho de arquivo, dict ou objeto:
+
+```python
+drone.set_pid_config("/path/to/config.yaml")
+drone.set_pid_config({"x": {"kp": 0.8, "output_min": -1.0, "output_max": 1.0}})
+```
+
+Os internos do controlador (ganhos, clamps de saída, tratamento integral) vivem no [módulo PID](pid.md).
+
+## Transportes
+
+O mesmo veículo é alcançado por transportes intercambiáveis, todos implementando a ABC `VehicleTransport`:
+
+- [Transporte MAVROS](../mavros/) — `MavrosTransport`: subscriptions → telemetria, service clients → comandos, publishers → setpoints. Exige um `mavros_node` em execução. Compartilhado por ArduPilot e PX4.
+- [Transporte MAVLink direto](../mavlink/) — `PymavlinkTransport`: possui o link do FCU diretamente (decodificação por timer de RX, `mav.*_send` direto), ponte de visão embutida. Neutro em relação a firmware, por meio de um codec de modo injetado.
+- [Transporte PX4 uXRCE-DDS](../px4/) — `Px4DdsTransport`: uORB nativo do PX4 pela ponte uXRCE-DDS (`px4_msgs`), sem MAVROS.
+
+## Referências
+
+- [Mensagens comuns do MAVLink](https://mavlink.io/en/messages/common.html) · [MAV_FRAME](https://mavlink.io/en/messages/common.html#MAV_FRAME) · [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)
+- [Understanding Altitude](https://ardupilot.org/copter/docs/common-understanding-altitude.html) · [EGM96](https://en.wikipedia.org/wiki/EGM96) · [GeographicLib](https://geographiclib.sourceforge.io/)
+- Especificidades de firmware: [ArduPilot](../ardupilot/) · [PX4](../px4/) · Ajuste de PID: [PID](pid.md)

--- a/i18n/pt/modules/examples/ai.md
+++ b/i18n/pt/modules/examples/ai.md
@@ -1,0 +1,196 @@
+# Exemplos do Módulo AI
+
+Implementações de referência para detecção de objetos e segmentação baseadas em deep
+learning, em cada um dos frameworks suportados.
+
+| Exemplo | Script | O que faz |
+|---------|--------|--------------|
+| **Stream de Detector** | `detector_example.py` | Detecção de objetos em tempo real a partir de um stream de câmera, com integração ROS 2 |
+| **Stream de Classificador** | `classifier_example.py` | Classificação de imagem em tempo real a partir de um stream de câmera, com integração ROS 2 |
+| **Batch Detector** | `batch_detector.py` | Processamento offline de diretórios de imagens ou arquivos de vídeo |
+| **Sequence Inference** | `sequence_inference.py` | Detecção + segmentação multi-modelo sobre um diretório de imagens ou vídeo, com saída em MP4 anotado |
+
+## Frameworks Suportados
+
+| Framework | Modelos | Exemplo |
+|-----------|--------|---------|
+| **Ultralytics** | YOLOv8/11/26 detect, seg, cls | `yolov8n.pt`, `yolo26n-cls.pt` |
+| **Transformers** | DETR, ViT, … | `facebook/detr-resnet-50`, `google/vit-base-patch16-224` |
+| **RF-DETR** | RF-DETR Nano/Small/Medium/Large | `rfdetr-medium` |
+
+---
+
+## Stream de Detecção em Tempo Real
+
+Detecção em stream de câmera usando `Detector` + `ImageHandler`.
+
+### Uso
+
+| Caso | Comando |
+|------|---------|
+| Padrão (webcam + YOLO, GPU automática) | `python3 detector_example.py` |
+| Framework explícito (DETR) | `python3 detector_example.py --model facebook/detr-resnet-50 --framework transformers` |
+| YOLO personalizado a partir do HuggingFace | `python3 detector_example.py --model "blackbeedrones/cbr-25-base:yolov11n.pt"` |
+| Modelo local, sem interface, republicado como tópico ROS | `python3 detector_example.py --model /path/to/model.pt --no-show --publish --topic /inference/compressed` |
+
+Modelos privados do HuggingFace: passe `--hf-token hf_...` ou defina
+`export HF_TOKEN=hf_...`. Selecione o dispositivo de computação com
+`--device {auto,cpu,cuda,0,1}` (padrão `auto`).
+
+### Argumentos
+
+| Flag | Padrão | Descrição |
+|------|---------|-------------|
+| `--model` | `yolov8n.pt` | Caminho do modelo ou repositório HuggingFace |
+| `--framework` | "" | Framework explícito: `ultralytics`, `transformers`, `rfdetr` (vazio = detecção automática) |
+| `--confidence` | `0.25` | Limiar de confiança de detecção |
+| `--camera-source` | `webcam` | Identificador da fonte de câmera |
+| `--no-show` | off | Desabilita a janela de detecção (por padrão ela é exibida) |
+| `--annotator-type` | `color` | Estilo de anotação: `box`, `round_box`, `color` |
+| `--show-labels` / `--show-confidence` / `--show-class` | on | Ativa/desativa os campos do overlay |
+| `--device` | `auto` | Dispositivo: `auto`, `cpu`, `cuda`, `0`, `1` |
+| `--hf-token` | "" | Token de API do HuggingFace (ou variável de ambiente `HF_TOKEN`) |
+| `--publish` / `--topic` / `--jpeg-quality` | off / `/inference/compressed` / `80` | Republica os frames anotados como um tópico de imagem comprimida |
+
+### Estilos de Anotação
+
+| Estilo | Renderização |
+|-------|-----------|
+| `box` | Contorno de retângulo |
+| `round_box` | Retângulo com cantos arredondados |
+| `color` | Região preenchida com overlay de alpha |
+
+### Overlay de Estatísticas
+
+O stream exibe estatísticas em tempo real:
+
+- **Framework**: framework de detecção em uso
+- **FPS**: frames por segundo (baseado no tempo de inferência)
+- **Detections**: contagem de detecções no frame atual
+- **Total**: detecções acumuladas
+
+---
+
+## Batch Detector
+
+Script standalone para processamento offline de sequências de imagens ou arquivos de vídeo.
+
+### Uso
+
+**Diretório de imagens ou arquivo de vídeo** (framework detectado automaticamente;
+`--input` aceita qualquer um dos dois):
+
+```bash
+python3 batch_detector.py \
+    --input /path/to/images \
+    --output-dir ./results
+```
+
+**Framework explícito** (`ultralytics`, `transformers` ou `rfdetr`):
+
+```bash
+python3 batch_detector.py \
+    --input /path/to/images \
+    --model-source facebook/detr-resnet-50 \
+    --framework transformers \
+    --output-dir ./results
+```
+
+**Modelo HuggingFace**
+
+```bash
+python3 batch_detector.py \
+    --input /path/to/images \
+    --model-source "blackbeedrones/cbr-25-base:yolov11n.pt" \
+    --output-dir ./results
+```
+
+**Opções completas**
+
+```bash
+python3 batch_detector.py \
+    --input /path/to/video.mp4 \
+    --output-dir ./results \
+    --model-source yolov8n.pt \
+    --framework ultralytics \
+    --confidence 0.5 \
+    --device cuda \
+    --annotator-type round_box \
+    --fps 30
+```
+
+### Argumentos
+
+| Argumento | Tipo | Padrão | Descrição |
+|----------|------|---------|-------------|
+| `--input` | string | obrigatório | Diretório de imagens ou arquivo de vídeo |
+| `--output-dir` | string | obrigatório | Diretório de saída para os resultados |
+| `--model-source` | string | `yolov8n.pt` | Caminho do modelo ou formato HuggingFace |
+| `--framework` | string | "" | Framework: `ultralytics`, `transformers`, `rfdetr` (vazio = automático) |
+| `--confidence` | float | 0.5 | Limiar de confiança de detecção |
+| `--device` | string | auto | Dispositivo de computação |
+| `--annotator-type` | string | box | Estilo de anotação |
+| `--hide-labels` | flag | false | Esconde os rótulos de detecção |
+| `--hide-confidence` | flag | false | Esconde os scores de confiança |
+| `--fps` | int | 30 | FPS do vídeo de saída (somente para imagens) |
+
+### Estrutura de Saída
+
+```
+output-dir/
+├── detection_video.mp4    # Annotated video with all frames
+├── frames/                # Individual annotated frames
+│   ├── frame_0000.jpg
+│   ├── frame_0001.jpg
+│   └── ...
+└── extracted_frames/      # (video input only) Original frames
+    ├── frame_000000.jpg
+    └── ...
+```
+
+### Processamento de Vídeo
+
+Para entrada em vídeo, o batch detector:
+
+1. Extrai todos os frames para um diretório temporário
+2. Processa cada frame com o modelo selecionado
+3. Reconstrói o vídeo no FPS original
+4. Salva os frames anotados individualmente
+
+---
+
+## Sequence Inference
+
+Roda um ou mais modelos (detecção e/ou segmentação) sobre um diretório de imagens ou vídeo e
+grava um MP4 anotado (mais JPGs por frame). Adicione o sufixo `@detection` / `@segmentation`
+a um modelo para sobrescrever a detecção automática da tarefa.
+
+**Um único modelo de detecção sobre uma pasta de imagens**
+
+```bash
+python3 sequence_inference.py --input ./frames --output-dir ./out --models yolov8n.pt
+```
+
+**Detecção + segmentação, confiança por classe, paleta personalizada**
+
+```bash
+python3 sequence_inference.py --input clip.mp4 --output-dir ./out \
+    --models cbr.pt@detection seg.pt@segmentation \
+    --conf 0.25 --class-conf "rose=0.47,sphere=0.70" --palette contrast
+```
+
+| Flag | Padrão | Descrição |
+|------|---------|-------------|
+| `--input` | obrigatório | Diretório de imagens ou arquivo de vídeo |
+| `--output-dir` | obrigatório | Diretório raiz de saída |
+| `--models` | obrigatório | Uma ou mais fontes de modelo (sufixo `@detection`/`@segmentation` opcional) |
+| `--conf` | `0.25` | Limiar de confiança padrão/fallback |
+| `--class-conf` | nenhum | Sobrescritas de confiança por classe, por exemplo `rose=0.47,sphere=0.70` |
+| `--iou` | `0.5` | Limiar de IoU (NMS de segmentação) |
+| `--device` | `auto` | Dispositivo de computação |
+| `--fps` | `15.0` | FPS de saída para entradas de diretório de imagens |
+| `--no-save-frames` | off | Mantém somente o MP4 |
+| `--hf-token` | `HF_TOKEN` | Token do HuggingFace |
+
+Estilo de anotação: `--palette`, `--colors`, `--box-thickness`, `--text-scale`,
+`--mask-opacity`, `--no-mask-outline` (veja `--help`).

--- a/i18n/pt/modules/examples/control.md
+++ b/i18n/pt/modules/examples/control.md
@@ -1,0 +1,176 @@
+# Exemplos do Módulo Control
+
+Exemplos de voo para cada drone e transporte suportados, de uma decolagem básica a um REPL
+de navegação interativa. Rode qualquer script com `python3 <script>.py [flags]` a partir
+deste diretório (esses scripts não são instalados como executáveis ROS 2). Eles usam
+`start_driver=False` por padrão, então inicie primeiro o driver, a bridge ou o simulador
+correspondente.
+
+| Script | O que faz | Flags principais |
+|--------|--------------|-----------|
+| `basic.py` | Decolagem, padrões de velocity/hover/position, pouso | `--drone {mavros,mavlink,px4,px4_mavlink,px4_dds,bebop,crazyflie}` · `--env {outdoor,indoor}` · `--mode {velocity,hover,position}` · `--connection` (mavlink/px4_mavlink) · `--height --side --velocity --precision --hover-time --cf-name --backend` |
+| `sensors.py` | Monitora dados de GPS/vision/local | `--source gps\|vision` |
+| `pid_simulation.py` | Simulação de controlador PID | `--kp --ki --plot` |
+| `navigation.py` | Suíte de teste de navegação ArduPilot/PX4 | `--drone {mavros,mavlink,px4}` · `--mode {indoor,outdoor}` · `--connection` · `--strategy --test --distance` (veja abaixo) |
+| `interactive_navigation.py` | REPL interativo — digite waypoints em tempo real | `--drone {mavros,mavlink,px4,px4_mavlink,px4_dds}` · `--mode {indoor,outdoor}` · `--connection --strategy --altitude --no-takeoff` |
+| `servo_test.py` | REPL interativo — testador de servo/PWM pré-voo via `MAV_CMD_DO_SET_SERVO` | `--channel --hold --release` |
+| `obstacles.py` | Navegação com desvio de obstáculos por câmera de profundidade (RealSense) | rode diretamente: `python3 obstacles.py` |
+
+> Fonte de pose vs. padrão de voo: em `basic.py`, `--env {outdoor,indoor}` seleciona a **fonte de pose** (outdoor = GPS, indoor = vision — combine com o `ENV=` do simulador) e `--mode` seleciona o **padrão de voo** (`velocity`/`hover`/`position`). Em `navigation.py` / `interactive_navigation.py`, `--mode {indoor,outdoor}` seleciona a fonte de pose. `--connection` sobrescreve a string de conexão para os drones com pymavlink direto `--drone mavlink` (ArduPilot, por exemplo `tcp:127.0.0.1:5762`) e `--drone px4_mavlink` (PX4, por exemplo `udp:0.0.0.0:14540`); `--drone px4` (MAVROS) usa um `fcu_url` como `udp://:14540@127.0.0.1:14580`.
+
+## Voo Básico
+
+`basic.py` arma, decola até `--height`, voa um padrão `--mode` e pousa. Invocações comuns:
+
+| Caso | Comando |
+|------|---------|
+| ArduPilot / MAVROS, quadrado de velocity (outdoor GPS, padrão) | `python3 basic.py --drone mavros --height 2.0` |
+| ArduPilot / MAVROS, quadrado de position indoor (pose por vision) | `python3 basic.py --drone mavros --env indoor --mode position --height 2.0` |
+| Crazyflie, hover em simulação | `python3 basic.py --drone crazyflie --mode hover --height 0.5 --backend sim --hover-time 10` |
+| Crazyflie, quadrado de position (lados de 0,6 m) | `python3 basic.py --drone crazyflie --mode position --height 0.5 --side 0.6` |
+| Crazyflie, quadrado de velocity | `python3 basic.py --drone crazyflie --mode velocity --height 0.4 --velocity 0.2 --side 0.5` |
+| Bebop, quadrado de velocity | `python3 basic.py --drone bebop --mode velocity` |
+| PX4 / MAVROS | `python3 basic.py --drone px4 --height 2.0` |
+| PX4 / MAVLink direto | `python3 basic.py --drone px4_mavlink --connection udp:0.0.0.0:14540 --height 2.0` |
+| PX4 / uXRCE-DDS nativo | `python3 basic.py --drone px4_dds --height 2.0` |
+
+Resultado esperado: o drone arma, sobe até `--height`, voa o padrão selecionado (um quadrado para `velocity`/`position`, uma espera cronometrada para `hover`) e então pousa e desarma.
+
+Para PX4 em simulação, inicie primeiro o simulador correspondente: `make sim-start FIRMWARE=px4 ENV=outdoor` mais `make sim-bridge FIRMWARE=px4 ENV=outdoor` (adicione `PROTOCOL=mavlink` para `px4_mavlink`, `PROTOCOL=dds` para `px4_dds`, que roda o MicroXRCEAgent).
+
+### Modos
+
+| Modo | Descrição |
+|------|-------------|
+| `velocity` (padrão) | Decolagem, voa um quadrado com comandos de velocity, pousa |
+| `hover` | Decolagem, mantém a posição por `--hover-time` segundos, pousa |
+| `position` | Decolagem, voa um quadrado com comandos `move_to`, pousa |
+
+## Monitoramento de Sensores
+
+```bash
+python3 sensors.py --source gps
+python3 sensors.py --source vision
+```
+
+## Simulação de PID
+
+```bash
+python3 pid_simulation.py
+python3 pid_simulation.py --setpoint 30 --kp 0.8 --ki 0.2
+python3 pid_simulation.py --plot
+```
+
+## Navegação
+
+ArduPilot ou PX4 — `--drone mavros|mavlink|px4` (padrão `mavros`). `--mode indoor` usa a fonte de pose por vision, `--mode outdoor` (padrão) usa GPS.
+
+| Caso | Comando |
+|------|---------|
+| Voo outdoor completo (estratégia PID padrão) | `python3 navigation.py --mode outdoor` |
+| Indoor (pose por vision) sobre MAVROS | `python3 navigation.py --mode indoor --test body` |
+| MAVLink direto contra a porta secundária do SITL (5762) | `python3 navigation.py --drone mavlink --connection tcp:127.0.0.1:5762 --test body` |
+| Posição local do EKF em vez de GPS bruto | `python3 navigation.py --strategy pid-ekf` |
+| Setpoint local (o FCU trata o controle de posição) | `python3 navigation.py --strategy position --test body` |
+| Setpoint GPS global (waypoints de longo alcance) | `python3 navigation.py --mode outdoor --test gps --strategy position-global` |
+| Teste com o drone na mão (sem decolagem) | `python3 navigation.py --no-takeoff --test body` |
+| Distância personalizada, testes selecionados, log em CSV, repete 3x | `python3 navigation.py --test body takeoff-ref --distance 3.0 --csv runs.csv --loop 3` |
+
+### Testes (`--test`, um ou mais; padrão `all`)
+
+`body`, `takeoff-ref`, `altitude`, `velocity`, `gps`, `figure8`, `rectangle`, `cube-xyz`, `cube`, `gps-rectangle`. Os testes de GPS (`gps`, `gps-rectangle`) exigem `--mode outdoor`.
+
+### Outros argumentos
+
+| Arg | Padrão | Finalidade |
+|-----|---------|---------|
+| `--altitude` | `2.0` | Altitude de decolagem (m), ignorado com `--no-takeoff` |
+| `--no-takeoff` | off | Define GUIDED + posição de takeoff sem armar (teste com o drone na mão) |
+| `--distance` | `2.0` | Distância de navegação por waypoint (m) |
+| `--precision` | `0.2` | Raio de precisão de chegada (m) |
+| `--timeout` | `30.0` | Timeout por waypoint (s) |
+| `--csv FILE` | nenhum | Anexa os resultados de cada trecho a um CSV (criado se não existir) |
+| `--loop [N]` | nenhum | Repete os testes selecionados N vezes; `--loop` sem valor roda até Ctrl+C |
+
+## Navegação Interativa
+
+| Caso | Comando |
+|------|---------|
+| Outdoor, PID padrão | `python3 interactive_navigation.py --mode outdoor` |
+| Transporte MAVLink direto | `python3 interactive_navigation.py --drone mavlink --mode outdoor` |
+| Outdoor, EKF, altitude de 3 m | `python3 interactive_navigation.py --mode outdoor --strategy pid-ekf --altitude 3.0` |
+| Com o drone na mão (sem armar/decolar) | `python3 interactive_navigation.py --no-takeoff` |
+
+Uma vez rodando, digite waypoints no prompt `nav>`:
+
+```
+nav> 2 0           # 2m forward
+nav> 0 3 0         # 3m left, hold altitude
+nav> -2 -3 0       # back
+nav> set ref takeoff
+nav> 5 0 0         # 5m forward from takeoff origin
+nav> 0 0 0         # return to takeoff
+nav> set method pid-ekf
+nav> 3 2            # now uses PID_EKF
+nav> gps -22.413 -45.449 15
+nav> status         # show drone state + settings
+nav> land
+```
+
+### Estratégias de Navegação
+
+| Estratégia | Descrição |
+|----------|-------------|
+| `pid` (padrão) | Controle de velocidade PID usando sensores brutos (vision/GPS) |
+| `pid-ekf` | Controle de velocidade PID usando a posição local do EKF |
+| `position` | Setpoint de posição local via `setpoint_raw/local` |
+| `position-global` | Setpoint GPS global (somente outdoor, longo alcance) |
+
+## Desvio de Obstáculos
+
+```bash
+python3 obstacles.py
+```
+
+Conecta um `DepthObstacleDetector` (RealSense D435i) com uma `SequenceStrategy`
+(passagem lateral e retorno) e roda um `move_to` com desvio de obstáculos. Exige uma câmera
+de profundidade conectada; veja [Obstacles](../control/obstacles.md) para os detectores e
+estratégias.
+
+## Teste de Servo / PWM
+
+Aciona `MavrosDrone.do_servo` (`MAV_CMD_DO_SET_SERVO`, 183) a partir de um REPL para que você
+possa verificar o canal AUX OUT correto e os extremos de PWM (por exemplo, hold/release de um
+hook) na bancada. O script nunca arma o drone e nunca decola — mantenha as hélices retiradas.
+
+**Padrões** — canal 3 (FCU ch 11 = AUX OUT 3), hold 1000 us, release 2000 us; MAVROS já em execução:
+
+```bash
+python3 servo_test.py
+```
+
+**Canal e presets personalizados**
+
+```bash
+python3 servo_test.py --channel 4 --hold 1100 --release 1900
+```
+
+No prompt `servo>`:
+
+```
+servo> 1500              # send PWM 1500 to current channel
+servo> ch 3               # switch to AUX OUT 3 (FCU ch 11)
+servo> hold               # send 'hold' preset
+servo> release            # send 'release' preset
+servo> sweep 1000 2000 100 0.3
+servo> cycle 3 0.8        # toggle hold<->release 3 times, 0.8s apart
+servo> set hold 1100      # update presets at runtime
+servo> status             # channel, last PWM, FCU state
+```
+
+`do_servo(N, pwm)` mapeia para o número de servo `N + 8` do FCU, então `ch 3` aciona o AUX OUT
+3 em um FCU no estilo Pixhawk (o Copter recomenda AUX OUT 1-4 para servos de hobby a 50 Hz;
+evite MAIN OUT 1-8, que rodam a 400 Hz). Se uma escrita retornar `OK` mas o servo não se
+mover, verifique a chave de segurança e se `SERVOx_FUNCTION = 0` no ArduPilot. Veja
+[common-servo](https://ardupilot.org/copter/docs/common-servo.html) e
+[MAV_CMD_DO_SET_SERVO](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_SERVO).

--- a/i18n/pt/modules/examples/index.md
+++ b/i18n/pt/modules/examples/index.md
@@ -1,0 +1,28 @@
+# Exemplos
+
+Scripts executáveis que vivem junto ao código em `nectar/nectar/examples/`, agrupados pelo
+módulo que exercitam. Cada um é pequeno, autocontido, e feito para ser lido tanto quanto
+executado — comece por aqui para ver como os módulos são usados e combinados na prática.
+
+| Grupo | O que cobre |
+|-------|----------------|
+| [Control](control.md) | Takeoff/land, voo por velocidade e posição, suítes de teste de navegação, REPL interativo, PID, servo/PWM, navegação com desvio de obstáculos |
+| [Vision](vision.md) | Drivers de câmera, medição de profundidade, tracking do T265, optical flow, coleta de fotos para dataset |
+| [AI](ai.md) | Stream de detecção em tempo real, processamento em lote de imagem/vídeo, detecção + segmentação multi-modelo |
+| [Sensors](sensors.md) | Bancada de teste do rangefinder TF-Luna → ponte MAVLink |
+
+## Como rodar
+
+Todo exemplo usa `argparse`. Rode a partir do repositório com:
+
+```bash
+python3 nectar/nectar/examples/<group>/<script>.py [flags]
+```
+
+Alguns scripts também são instalados como executáveis ROS 2 (veja a página de cada grupo
+para saber quais): `ros2 run nectar <script>.py -- [flags]`. Os exemplos de control **não**
+são instalados — use somente `python3`.
+
+Os exemplos de control usam `start_driver=False` por padrão — inicie o driver/bridge (ou o
+simulador) ao qual a missão se conecta primeiro, em seu próprio terminal. Veja
+[Voar um drone](../../get-started/control.md) para o fluxo de simulação e hardware.

--- a/i18n/pt/modules/examples/sensors.md
+++ b/i18n/pt/modules/examples/sensors.md
@@ -1,0 +1,83 @@
+# Exemplos do Módulo Sensors
+
+Teste na bancada os pipelines de sensores do computador de bordo antes de conectá-los a uma
+missão.
+
+| Script | O que faz |
+|--------|--------------|
+| `rangefinder_example.py` | Teste de bancada do pipeline TF-Luna → filtro → `DISTANCE_SENSOR` do MAVLink (sem ROS) |
+
+## Argumentos
+
+| Flag | Padrão | Descrição |
+|------|---------|-------------|
+| `--port` | `/dev/ttyUSB0` | Porta serial do TF-Luna |
+| `--baud` | `115200` | Baud rate do TF-Luna |
+| `--mavlink` | `udp:127.0.0.1:14551` | String de conexão MAVLink (UDP/TCP/serial) |
+| `--mavlink-baud` | `921600` | Baud serial para endpoints MAVLink (ignorado para UDP/TCP) |
+| `--filter` | `none` | `none` ou `obstacle_mask` |
+| `--obstacle-height` | `0.0` | Altura do obstáculo (m); `<= 0` estima automaticamente |
+| `--max-change` | `0.30` | Limiar de variação abrupta do mascaramento de obstáculo (m) |
+| `--avg-window` | `10` | Janela de média do mascaramento de obstáculo (amostras) |
+| `--estimate-lock-s` | `0.2` | Tempo para travar a altura auto-estimada (s) |
+| `--timeout-s` | `5.0` | Timeout de leitura do sensor (s) |
+| `--rate` | `50.0` | Taxa de publicação (Hz) |
+| `--duration` | `0.0` | Tempo de execução (s); `0` = até Ctrl-C |
+
+## Teste de bancada
+
+**Passthrough bruto** (roda até Ctrl-C):
+
+```bash
+python3 rangefinder_example.py \
+    --port /dev/ttyUSB0 \
+    --mavlink udp:127.0.0.1:14551
+```
+
+**Auto-detecção da altura do obstáculo** (missão do hook e similares; não precisa de
+conhecimento prévio):
+
+```bash
+python3 rangefinder_example.py \
+    --port /dev/ttyUSB0 \
+    --mavlink udp:127.0.0.1:14551 \
+    --filter obstacle_mask \
+    --duration 60
+```
+
+**Override de altura fixa** (SITL, fixtures conhecidas; trava em 1,7 m):
+
+```bash
+python3 rangefinder_example.py \
+    --port /dev/ttyUSB0 \
+    --mavlink udp:127.0.0.1:14551 \
+    --filter obstacle_mask \
+    --obstacle-height 1.7 \
+    --duration 60
+```
+
+Resultado esperado: o script imprime amostras de distância filtradas a `--rate` Hz e as
+transmite como `DISTANCE_SENSOR` do MAVLink; o tópico de rangefinder do FCU (abaixo) espelha
+os valores.
+
+Enquanto o script está rodando, em outro terminal, faça o echo do tópico de rangefinder do
+FCU para confirmar que o stream mascarado está chegando ao EKF via MAVROS:
+
+```bash
+ros2 topic echo /mavros/rangefinder/rangefinder
+```
+
+Coloque um objeto de altura conhecida sob o sensor; o valor do tópico deve saltar
+aproximadamente pela altura do objeto e se recuperar quando ele for removido.
+
+Para implantações ROS, use o ponto de entrada `rangefinder_node.py` em vez disso:
+
+```bash
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551 \
+    -p filter:=obstacle_mask
+```
+
+Veja [Sensors](../sensors.md) para a lista completa de parâmetros, os passos de
+configuração do ArduPilot e a solução de problemas.

--- a/i18n/pt/modules/examples/vision.md
+++ b/i18n/pt/modules/examples/vision.md
@@ -1,0 +1,255 @@
+# Exemplos do Módulo Vision
+
+Exemplos funcionais dos drivers de câmera e do processamento de imagem do módulo Vision.
+
+| Exemplo | Script | O que faz |
+|---------|--------|--------------|
+| **Captura de Câmera** | `camera_example.py` | Suporte a múltiplas câmeras com opções de configuração |
+| **Visualização de Profundidade** | `depth_example.py` | Medição de profundidade com câmera RGB-D e exibição de colormap |
+| **Tracking do T265** | `t265_example.py` | Pose/odometria do RealSense T265 (SDK direto ou ROS) |
+| **Optical Flow** | `optical_flow_example.py` | Visualização de optical flow esparso/denso |
+| **Coleta de Fotos** | `collect_photos.py` | Salva frames em intervalos para criação de dataset |
+
+Todos os scripts usam flags de `argparse` (não `--ros-args -p`). Rode com
+`python3 <script>.py [flags]`. Alguns scripts também são instalados como executáveis ROS 2
+(`ros2 run nectar <script>.py -- [flags]`): `camera_example.py`, `depth_example.py`,
+`t265_example.py`, `collect_photos.py`. Use `python3` para `optical_flow_example.py` (não
+instalado como executável).
+
+## Exemplo de Câmera
+
+Captura de câmera usando `ImageHandler` com backends configuráveis.
+
+### Uso
+
+Rode com a webcam padrão, ou passe qualquer `--camera-type` de
+[Tipos de Câmera Suportados](#tipos-de-camera-suportados); adicione `--no-show` para rodar
+sem interface.
+
+```bash
+python3 camera_example.py
+python3 camera_example.py --camera-type realsense
+```
+
+### Argumentos
+
+| Flag | Padrão | Descrição |
+|------|---------|-------------|
+| `--camera-type` | `webcam` | Fonte da câmera: `webcam`, `imx219`, `realsense`, `realsense_ros`, `oakd`, `c920`, `ros` |
+| `--no-show` | off | Desabilita a janela de exibição do OpenCV |
+
+### Tipos de Câmera Suportados {#tipos-de-camera-suportados}
+
+| Tipo | Driver | Configuração |
+|------|--------|---------------|
+| `webcam` | `OpenCVCam` | 1280x720 @ 30fps, dispositivo 0 |
+| `realsense` | `RealsenseCam` | 1280x720 RGB+Depth @ 30fps |
+| `realsense_ros` | `ROSDepthCam` | Via tópicos ROS de color + depth |
+| `oakd` | `OakdCam` | Configurações padrão do OAK-D |
+| `c920` | `C920Cam` | Perfil 1 (1280x720) |
+| `imx219` | `IMX219Cam` | 1280x720 @ 30fps, flip 180° |
+| `ros` | `ROSCam` | `/camera/color/image_raw/compressed` |
+
+---
+
+## Exemplo de Profundidade
+
+Demonstra o uso de câmera de profundidade com medição de distância interativa.
+
+### Uso
+
+| Fonte | Comando |
+|--------|---------|
+| RealSense (SDK pyrealsense2 direto) | `python3 depth_example.py --camera realsense` |
+| RealSense via tópicos ROS | `python3 depth_example.py --camera realsense_ros` |
+| OAK-D | `python3 depth_example.py --camera oakd` |
+
+### Funcionalidades
+
+- **Exibição RGB**: imagem de cor com mira no pixel selecionado
+- **Colormap de Profundidade**: visualização com colormap Plasma (faixa de 0,1 m - 3,0 m)
+- **Seleção Interativa**: clique na imagem de cor para selecionar o ponto de medição
+- **Exibição de Distância**: distância em tempo real, em metros, no pixel selecionado
+
+### Controles de Teclado
+
+| Tecla | Ação |
+|-----|--------|
+| `q` | Encerra a aplicação |
+| Clique do mouse | Seleciona o pixel para medição de distância |
+
+---
+
+## Tracking do T265
+
+Pose/odometria da câmera de tracking RealSense T265, pelo SDK direto ou por tópicos ROS.
+
+Roda em modo SDK direto por padrão; veja os argumentos abaixo para o modo ROS e a opção de
+profundidade.
+
+```bash
+python3 t265_example.py
+python3 t265_example.py --mode ros
+```
+
+| Flag | Padrão | Descrição |
+|------|---------|-------------|
+| `--mode` | `direct` | `direct` (pyrealsense2) ou `ros` (tópicos ROS) |
+| `--no-depth` | off | Desabilita o caminho de profundidade/fisheye |
+
+---
+
+## Optical Flow
+
+Optical flow esparso (Lucas-Kanade) ou denso (Farneback). Com `--focal`/`--altitude` também
+decodifica a taxa angular (rad/s) e a velocidade horizontal (m/s), como o pipeline
+OPTICAL_FLOW do ArduPilot.
+
+| Caso | Comando |
+|------|---------|
+| Webcam, Farneback denso (padrão) | `python3 optical_flow_example.py` |
+| RealSense, Lucas-Kanade esparso | `python3 optical_flow_example.py --source realsense --method lucas_kanade` |
+| Qualquer tópico de imagem ROS | `python3 optical_flow_example.py --source /camera/image_raw` |
+| Decodifica taxa angular + velocidade horizontal | `python3 optical_flow_example.py --focal 500 --altitude 1.5` |
+| Sem interface (headless) | `python3 optical_flow_example.py --no-show` |
+
+| Flag | Padrão | Descrição |
+|------|---------|-------------|
+| `--source` | `webcam` | Chave da câmera (`webcam`, `realsense`, `oakd`, `c920`, `imx219`), um tópico ROS (`/...`), ou o caminho de um arquivo de imagem/vídeo |
+| `--method` | `farneback` | `farneback` (denso) ou `lucas_kanade` (esparso) |
+| `--focal` | `0` | Distância focal da câmera em px (`0` pula a decodificação de rad/s e m/s) |
+| `--altitude` | `0` | Altura da câmera em m (`0` pula a decodificação de m/s) |
+| `--no-show` | off | Desabilita a janela de preview |
+
+---
+
+## Coleta de Fotos
+
+Captura frames em um intervalo configurável e os salva em uma estrutura de diretórios
+organizada. Útil para construir datasets de treinamento — voe o drone via rádio (RC) ou pela
+interface do Nectar enquanto este nó grava os frames.
+
+### Uso
+
+| Caso | Comando |
+|------|---------|
+| Padrão (webcam, 1 foto/s, pasta com timestamp) | `python3 collect_photos.py` |
+| Diretório de saída e intervalo personalizados (2 fotos/s) | `python3 collect_photos.py --output-dir hook_photos --capture-interval 0.5` |
+| Execução nomeada para uma sessão de voo | `python3 collect_photos.py --output-dir hook_photos --run-name flight_01_low_alt` |
+| RealSense com janela de preview | `python3 collect_photos.py --camera-type realsense --show` |
+| Webcam em alta resolução, PNG, máximo de 500 fotos | `python3 collect_photos.py --width 1920 --height 1080 --image-format png --max-photos 500` |
+
+### Argumentos
+
+| Flag | Padrão | Descrição |
+|------|---------|-------------|
+| `--camera-type` | `webcam` | Fonte da câmera (mesmo conjunto de `camera_example.py`) |
+| `--output-dir` | `collected_photos` | Diretório de saída base sob `~/` |
+| `--run-name` | *(timestamp)* | Nome da subpasta desta execução |
+| `--capture-interval` | `1.0` | Segundos entre capturas |
+| `--image-format` | `jpg` | Formato de saída: `jpg` ou `png` |
+| `--jpeg-quality` | `90` | Qualidade JPEG de 0 a 100 |
+| `--show` | off | Exibe a janela de preview do OpenCV em tempo real |
+| `--max-photos` | `0` | Para depois de N fotos (`0` = ilimitado) |
+| `--width` / `--height` / `--fps` | `1280` / `720` / `30` | Configurações de captura |
+| `--publish` / `--publish-topic` / `--publish-scale` | off / `collect_photos/compressed` / `0.5` | Republica os frames capturados como um tópico de imagem comprimida |
+
+### Estrutura de Saída
+
+```
+~/hook_photos/
+├── flight_01_low_alt/
+│   ├── frame_00001.jpg
+│   ├── frame_00002.jpg
+│   └── ...
+├── flight_02_high_alt/
+│   ├── frame_00001.jpg
+│   └── ...
+└── 20260416_143022/          # auto-named when run_name is empty
+    └── ...
+```
+
+---
+
+## Solução de Problemas
+
+### Câmera Não Encontrada
+
+```
+ValueError: Unknown camera source type: xyz
+```
+
+Verifique os tipos de câmera registrados:
+
+```python
+from nectar.vision.camera import CameraFactory
+
+# Registered: webcam, opencv, realsense, t265, oakd, c920, imx219, ros, ros_depth, file
+
+```
+
+### Erro de Importação do RealSense
+
+```
+RuntimeError: pyrealsense2 is not installed
+```
+
+Instale o librealsense e o realsense-ros (builda o pyrealsense2 correspondente a partir do
+código-fonte):
+
+```bash
+make realsense
+
+# T265 (Humble only): LIBREALSENSE_VERSION=v2.53.1 REALSENSE_ROS_TAG=4.51.1 make realsense
+
+```
+
+Ou use o modo de tópico ROS (`realsense_ros` / `ros_depth`) com o `realsense2_camera` já em
+execução.
+
+### Erro de Importação do OAK-D
+
+```
+ModuleNotFoundError: No module named 'depthai'
+```
+
+Instale o DepthAI:
+
+```bash
+pip install depthai
+```
+
+### FPS Baixo / Frames Perdidos
+
+Ajuste as configurações de buffer e threading:
+
+```python
+config = OpenCVConfig(
+    buffer_size=2,    # Increase if dropping frames
+    threaded=True,    # Enable background capture
+)
+```
+
+### Exibição Não Funciona
+
+```
+cv2.error: The function is not implemented
+```
+
+Build headless do OpenCV. Opções:
+
+- Instale `opencv-python` em vez de `opencv-python-headless`
+- Desabilite a exibição: `show_result=None`
+
+---
+
+## Dependências
+
+| Pacote | Finalidade |
+|---------|---------|
+| `opencv-python` | Captura de câmera, processamento de imagem |
+| `numpy` | Operações com arrays |
+| `rclpy` | Cliente Python do ROS 2 |
+| `cv_bridge` | Conversão de imagem do ROS |
+| `pyrealsense2` | SDK do RealSense (opcional) |
+| `depthai` | SDK do OAK-D (opcional) |

--- a/i18n/pt/modules/interface.md
+++ b/i18n/pt/modules/interface.md
@@ -1,0 +1,310 @@
+# Módulo de Interface
+
+Interface gráfica baseada em Qt6/PySide6 para controle de drones, visão computacional e ferramentas de sistema do ROS2.
+
+<div align="center" markdown>
+
+![Nectar SDK Interface](https://raw.githubusercontent.com/Black-Bee-Drones/nectar-sdk/main/assets/ui_app.png)
+
+*GUI do Nectar SDK - Control, Vision e ferramentas ROS2 em uma única interface*
+
+</div>
+
+## Início rápido
+
+```python
+from nectar.interface import main
+
+# Launch the GUI
+
+main()
+```
+
+Ou pela linha de comando:
+
+```bash
+ros2 run nectar app.py
+```
+
+## Funcionalidades
+
+### Aba Control
+
+Interface de controle de drones com controle de velocidade por teclado e navegação por posição.
+
+**Fluxo de conexão**:
+
+1. **Select Firmware + Link**: Escolha o firmware (ArduPilot, PX4, Bebop, Crazyflie) e, para ArduPilot/PX4, o transporte (MAVROS, MAVLink, ou DDS). O painel de configuração se adapta à seleção.
+2. **Connect Driver**: Inicia o processo de driver em segundo plano — MAVROS (`apm.launch` / `px4.launch`), o servidor do Crazyflie, o driver do Bebop, ou `MicroXRCEAgent` para PX4 DDS. Links MAVLink diretos (ArduPilot/PX4) abrem o link do FCU dentro da própria instância, então este passo é pulado.
+3. **Initialize Instance**: Cria o objeto do drone com a configuração selecionada no painel.
+4. **Ready**: Controles de voo habilitados.
+
+**Indicadores de status**:
+
+- **Driver**: processo de driver / agent do ROS2 em execução
+- **Instance**: objeto do drone inicializado
+- **FCU**: controlador de voo conectado (veículos com FCU)
+- **Armed**: estado de armamento dos motores (veículos com FCU / Crazyflie)
+
+**Controle de velocidade**:
+
+- **Teclado**: W/S (cima/baixo), A/D (yaw), setas (frente/trás/esquerda/direita)
+- **Sliders**: Ajustam a velocidade máxima por eixo (Vx, Vy, Vz, Vyaw)
+- **Reference Frame**: Body, World, ou Takeoff
+
+**Controle de posição** (veículos com FCU e Crazyflie):
+
+- Navega até a posição alvo com offsets de X, Y, Z, Yaw
+- Frames de referência: Body ou Takeoff
+- Precisão e timeout configuráveis
+
+**Backends** (Firmware + Link):
+
+| Firmware / Link | Chave | Notas |
+|-----------------|-----|-------|
+| ArduPilot / MAVROS | `mavros` | Controle completo do ArduPilot (arm, takeoff, land, velocidade, posição, telemetria) pela ponte MAVROS |
+| ArduPilot / MAVLink | `mavlink` | Mesmo controle por um link pymavlink direto (sem MAVROS); defina a connection string e, para voo indoor, o preset do tópico de vision-pose (`/visual_slam/tracking/vo_pose_covariance`) |
+| PX4 / MAVROS | `px4` | Streaming de setpoint OFFBOARD; a conexão usa por padrão o endpoint offboard do PX4 (`udp://:14540@127.0.0.1:14580` para SITL) |
+| PX4 / MAVLink | `px4_mavlink` | Link pymavlink direto (sem MAVROS); padrão `udp:0.0.0.0:14540` |
+| PX4 / DDS | `px4_dds` | uXRCE-DDS nativo. **Connect Driver** inicia o `MicroXRCEAgent` na porta UDP configurada (padrão 8888); um agent iniciado em outro lugar (por exemplo, `make sim-bridge FIRMWARE=px4 PROTOCOL=dds`) é detectado automaticamente. A prontidão é o aparecimento dos tópicos `/fmu/*` do PX4, não um processo ou nome de sessão |
+| Bebop | `bebop` | Controle básico (takeoff, land, velocidade, flips) |
+| Crazyflie | `crazyflie` | Takeoff, land, velocidade e posição a bordo (`goTo`) |
+
+Os painéis de MAVROS e MAVLink são compartilhados entre ArduPilot e PX4 e se adaptam ao firmware: o padrão de conexão muda para o endpoint offboard do PX4, e as listas de presets de PID e setpoint são carregadas do [config do PX4](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/control/px4/config) em vez do [config do ArduPilot](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/nectar/control/ardupilot/config) (ambos incluem os presets SITL `*_sim_*`). O config de setpoint expõe os limites de velocidade/aceleração de cada firmware — `WPNAV`/`GUID_OPTIONS` do ArduPilot ou `MPC_*` do PX4 — com **Apply setpoint params to FCU** aplicando-os no momento do arm. O painel uXRCE-DDS (`px4_dds`) expõe a fonte de pose, a porta UDP do agent (padrão 8888), o namespace e o preset de PID — mas sem controles de setpoint/apply-setpoint, já que os parâmetros do PX4 não são transportados pelo uXRCE-DDS.
+
+### Aba Vision
+
+Processamento de visão computacional em tempo real com múltiplas fontes de câmera e filtros.
+
+**Fontes de câmera**: Webcam, RealSense, T265, OAK-D, C920, IMX219, tópico ROS, profundidade ROS, arquivo
+
+**Categorias de filtro**:
+
+- **Color**: Filtragem de cor HSV com calibração
+- **Edge**: Detecção de bordas Canny, contornos
+- **Blur/Transform**: Blur gaussiano, sharpen, rotação, resize
+- **Morphology**: Erosão, dilatação, threshold adaptativo, equalização de histograma
+- **Effects**: Pencil sketch, estilização, cartoonify, linhas/círculos de Hough, optical flow
+- **AI**: Tracking de mãos (MediaPipe), face mesh (MediaPipe)
+- **Markers**: Detecção ArUco (17 tipos de dicionário)
+
+**Estimativa de profundidade** (câmeras de profundidade):
+
+- Medição de distância em tempo real
+- Visualização de profundidade colorizada
+- Medição por clique (click-to-measure)
+
+### Aba ROS
+
+Ferramentas de introspecção e interação com o sistema ROS2.
+
+**Topics**:
+
+- Navegar, subscrever e publicar mensagens
+- Visualização de mensagens em tempo real
+- Detecção automática de configurações de QoS
+
+**Services**:
+
+- Navegar e chamar services
+- Tratamento customizado de request/response
+
+**Parameters**:
+
+- Visualizar e modificar parâmetros de nó
+- Atualizações em tempo real
+
+**Plot**:
+
+- Plotagem em tempo real de campos numéricos
+- Múltiplos plots, pause/resume
+- Exportação para CSV
+
+## Arquitetura
+
+### Estrutura de alto nível
+
+```mermaid
+classDiagram
+    class NectarApp {
+        QMainWindow root
+        owns tabs + ROSExecutor
+    }
+
+    class ROSExecutor {
+        +node Node
+        +start(node_name) bool
+        +shutdown()
+    }
+
+    class ControlTab {
+        +set_node(node)
+        +cleanup()
+    }
+
+    class VisionTab {
+        +set_node(node)
+        +cleanup()
+    }
+
+    class ROSTab {
+        +set_node(node)
+        +cleanup()
+    }
+
+    NectarApp *-- ROSExecutor
+    NectarApp *-- ControlTab
+    NectarApp *-- VisionTab
+    NectarApp *-- ROSTab
+```
+
+### Modelo de threads
+
+```mermaid
+flowchart TB
+    subgraph MainThread["Main Thread (Qt Event Loop)"]
+        UI[UI Updates]
+        Timers[QTimers]
+    end
+
+    subgraph ROSThread["ROS2 Thread"]
+        Executor[MultiThreadedExecutor]
+        Callbacks[ROS Callbacks]
+    end
+
+    subgraph WorkerThreads["Worker Threads"]
+        Workers[DriverWorker, MoveToWorker, etc.]
+    end
+
+    UI --> |"Start"| WorkerThreads
+    WorkerThreads --> |"Signals"| UI
+    ROSThread --> |"Signals"| UI
+```
+
+**Pontos-chave**:
+
+- O executor do ROS2 roda em uma thread separada
+- Operações bloqueantes (start do driver, navegação) usam worker threads
+- Comandos de velocidade são enviados via QTimer (intervalo de 50ms)
+- Todas as atualizações de UI acontecem na thread principal
+
+## Para desenvolvedores
+
+### Widgets
+
+Componentes de UI reutilizáveis disponíveis em `nectar.interface.widgets`:
+
+| Widget | Finalidade |
+|--------|-------------|
+| `Card` | Container elevado com cantos arredondados |
+| `StatusIndicator` | Ponto de status com label (active/inactive/warning/error) |
+| `LabeledSlider` | Slider vertical com label e exibição de valor |
+| `CollapsibleSection` | Seção expansível/recolhível |
+| `VideoDisplay` | Exibição de frame OpenCV com suporte a clique |
+| `ImageViewer` | Exibição de vídeo com label de informação |
+| `DualVideoDisplay` | Exibição de RGB e profundidade |
+| `DroneConfigPanel` | UI de configuração do drone |
+| `DetectionConfigPanel` | Configuração do modelo de detecção de objetos |
+| `MessageFieldEditor` | Editor de campos de mensagem ROS |
+| `ParameterReconfigureWidget` | Editor de parâmetros do ROS2 |
+
+**Exemplo**:
+
+```python
+from nectar.interface import Card, StatusIndicator, LabeledSlider
+
+card = Card()
+card.add_widget(StatusIndicator("Status", "active"))
+card.add_widget(LabeledSlider("Speed", 0.0, 1.0, 0.5))
+```
+
+### ROSExecutor
+
+Gerencia o nó e o executor do ROS2 em uma thread de fundo:
+
+```python
+from nectar.interface import ROSExecutor
+
+executor = ROSExecutor()
+executor.start("my_node")
+node = executor.node  # Access ROS2 node
+executor.shutdown()
+```
+
+**Signals**:
+
+- `status_changed(bool)`: Status de conexão do ROS2
+- `error_occurred(str)`: Erros do ROS2
+
+### Worker Threads
+
+Operações de longa duração usam workers `QThread` para evitar congelamento da UI:
+
+- **DriverWorker**: Inicia/para processos de driver do ROS2
+- **DroneInstanceWorker**: Inicializa objetos de drone
+- **MoveToWorker**: Navegação por posição (loop PID bloqueante)
+- **FlightActionWorker**: Chamadas de serviço (arm, takeoff, land)
+- **CameraInitWorker**: Inicialização de câmera
+
+**Padrão**:
+
+```python
+worker = MyWorker()
+worker_thread = QThread()
+worker.moveToThread(worker_thread)
+worker.finished.connect(worker_thread.quit)
+worker_thread.started.connect(worker.run)
+worker_thread.start()
+```
+
+### Chamadas de serviço
+
+As chamadas de serviço do ROS 2 usam um padrão assíncrono para evitar deadlocks. `BaseDrone._call_service` dispara `call_async`, e então bloqueia a thread chamadora em um `threading.Event` que é sinalizado pelo done-callback do future — o executor compartilhado (a thread de spin de fundo do SDK ou o `ROSExecutor` da GUI) leva o future à conclusão em sua própria thread:
+
+```python
+future = client.call_async(request)
+done = threading.Event()
+future.add_done_callback(lambda _f: done.set())
+done.wait(timeout=...)        # calling thread blocks; the executor thread completes the future
+result = future.result()
+```
+
+Chamadas de voo bloqueantes (takeoff, move_to, …) fazem polling da própria conclusão com `_wait_until(predicate, timeout)` (um loop de `time.sleep(0.05)`), contando com esse mesmo executor de fundo para continuar entregando os callbacks de telemetria.
+
+### Layout
+
+- `app.py` — janela principal `NectarApp`; `ros_executor.py` — integração ROS 2/Qt; `theme.py` — estilo e cores
+- `tabs/` — `control_tab.py` (controle de drone), `vision_tab.py` (câmera e filtros), `ros_tab.py` (ferramentas ROS 2)
+- `widgets/` — componentes reutilizáveis: `drone_config.py`, `detection_panel.py`, `message_editor.py`, `param_reconfigure.py`
+
+### Temas
+
+Cores definidas em `theme.py`:
+
+```python
+from nectar.interface import COLORS
+
+COLORS.background      # #0A0E14
+COLORS.surface         # #12171E
+COLORS.accent          # #F5A623 (amber)
+COLORS.success         # #34C759 (green)
+COLORS.error           # #FF453A (red)
+
+# ... see theme.py for full list
+
+```
+
+## Solução de problemas
+
+**UI congela**: Garanta que operações bloqueantes usem worker threads (não a thread principal)
+
+**Timeouts de serviço**: Verifique se o driver está em execução e se o FCU está conectado
+
+**Sem telemetria**: Verifique a conexão do driver e se a configuração do sensor corresponde à configuração do FCU
+
+**Câmera não funciona**: Verifique as permissões do dispositivo e os nomes dos tópicos ROS
+
+## Referências
+
+- [Qt for Python](https://doc.qt.io/qtforpython-6/)
+- [ROS2 Executors](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Executors.html)

--- a/i18n/pt/modules/interfaces.md
+++ b/i18n/pt/modules/interfaces.md
@@ -1,0 +1,147 @@
+# Nectar Interfaces
+
+Definições de mensagens ROS2 customizadas para o Nectar SDK.
+
+## Visão geral
+
+Este pacote fornece tipos de mensagem ROS2 customizados usados pelos módulos de vision e control para publicar resultados de detecção e dados de sensores.
+
+## Mensagens
+
+### ArucoTransforms
+
+Dados de estimativa de pose de marcadores ArUco.
+
+**Arquivo:** `msg/ArucoTransforms.msg`
+
+```
+int32 id
+geometry_msgs/Vector3 translation
+std_msgs/Float64 yaw
+```
+
+| Campo | Tipo | Descrição |
+|-------|------|-------------|
+| `id` | `int32` | ID do marcador detectado |
+| `translation` | `geometry_msgs/Vector3` | Posição 3D relativa à câmera (metros) |
+| `yaw` | `std_msgs/Float64` | Ângulo de rotação do marcador (graus, 0-360) |
+
+**Publicado por:** `ArucoNode` · **Tópico:** `/aruco/pose_estimate`
+
+---
+
+### LineInfo
+
+Informação de estado da detecção de linha.
+
+**Arquivo:** `msg/LineInfo.msg`
+
+```
+float64 center_x
+float64 center_y
+float64 angle
+float64 width
+float64 height
+```
+
+| Campo | Tipo | Descrição |
+|-------|------|-------------|
+| `center_x` | `float64` | Coordenada X do centro da linha (pixels) |
+| `center_y` | `float64` | Coordenada Y do centro da linha (pixels) |
+| `angle` | `float64` | Ângulo da linha (graus, -90 a +90) |
+| `width` | `float64` | Largura média da linha (pixels) |
+| `height` | `float64` | Altura média da linha (pixels) |
+
+**Publicado por:** `LineDetectionNode` · **Tópico:** `line_state/{color}` (por exemplo, `line_state/blue`)
+
+---
+
+### PhotoInfo
+
+Metadados de foto com coordenadas.
+
+**Arquivo:** `msg/PhotoInfo.msg`
+
+```
+float64[] coordinates
+string photo_num
+```
+
+| Campo | Tipo | Descrição |
+|-------|------|-------------|
+| `coordinates` | `float64[]` | Array de valores de coordenadas |
+| `photo_num` | `string` | Identificador/número da foto |
+
+---
+
+## Dependências
+
+| Pacote | Descrição |
+|---------|-------------|
+| `geometry_msgs` | Tipos de mensagem geométricos padrão do ROS2 (Vector3) |
+| `std_msgs` | Tipos de mensagem padrão do ROS2 (Float64) |
+| `rosidl_default_generators` | Geração de código IDL do ROS2 |
+
+## Build
+
+O pacote é buildado automaticamente com o workspace:
+
+```bash
+cd ~/ros2_ws
+colcon build --packages-select nectar_interfaces
+source install/setup.bash
+```
+
+Verifique:
+
+```bash
+ros2 interface list | grep nectar_interfaces
+ros2 interface show nectar_interfaces/msg/ArucoTransforms
+```
+
+## Uso
+
+**Python** — importar, publicar e subscrever:
+
+```python
+from nectar_interfaces.msg import ArucoTransforms, LineInfo, PhotoInfo
+from geometry_msgs.msg import Vector3
+from std_msgs.msg import Float64
+
+# Publisher
+
+pub = node.create_publisher(ArucoTransforms, '/aruco/pose_estimate', 10)
+msg = ArucoTransforms()
+msg.id = 42
+msg.translation = Vector3(x=0.5, y=0.1, z=1.2)
+msg.yaw = Float64(data=45.0)
+pub.publish(msg)
+
+# Subscriber
+
+def on_aruco(msg: ArucoTransforms):
+    print(f"Marker {msg.id} at ({msg.translation.x:.2f}, {msg.translation.y:.2f}, {msg.translation.z:.2f}) m")
+
+node.create_subscription(ArucoTransforms, '/aruco/pose_estimate', on_aruco, 10)
+```
+
+**C++**:
+
+```cpp
+#include "nectar_interfaces/msg/aruco_transforms.hpp"
+
+auto pub = node->create_publisher<nectar_interfaces::msg::ArucoTransforms>(
+    "/aruco/pose_estimate", 10);
+```
+
+## Módulos relacionados
+
+- [Vision Module](vision/) — drivers de câmera e algoritmos que publicam essas mensagens
+- [Vision Nodes](vision/nodes/) — nós ROS 2 que usam essas interfaces
+
+## Referências
+
+- [Tutorial de interfaces do ROS2](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Custom-ROS2-Interfaces.html)
+- [Definição de mensagens do ROS2](https://docs.ros.org/en/humble/Concepts/About-ROS-Interfaces.html)
+- [geometry_msgs](https://docs.ros.org/en/humble/p/geometry_msgs/)
+- [std_msgs](https://docs.ros.org/en/humble/p/std_msgs/)

--- a/i18n/pt/modules/sensors.md
+++ b/i18n/pt/modules/sensors.md
@@ -1,0 +1,365 @@
+# Módulo de Sensores
+
+Drivers de sensores do lado do companion computer e filtros de valor, além de um nó ROS2 pronto para uso que faz a ponte de um rangefinder serial para o `DISTANCE_SENSOR` do MAVLink, de modo que um FCU ArduPilot/PX4 possa consumi-lo como seu rangefinder primário.
+
+O módulo é composition-first: um `DistanceSensor` (driver) e um `DistanceFilter` opcional são conectados a um `RangefinderPublisher` que envia amostras filtradas para uma `MavlinkConnection`. Cada peça é utilizável de forma independente.
+
+## Por que isso existe
+
+Quando um LiDAR voltado para baixo é a fonte de altitude do EKF (`EK3_SRC1_POSZ = Rangefinder`), voar sobre um obstáculo fixo (por exemplo, uma esfera em uma mangueira) causa uma queda abrupta na leitura do rangefinder que o ArduPilot interpreta como o veículo descendo. O controlador de posição sobe para compensar, elevando o drone acima da altitude alvo. Conectar o LiDAR ao computador de bordo em vez de ao FCU permite mascarar essas quedas abruptas antes que o EKF chegue a vê-las.
+
+O ArduPilot não tem um parâmetro nativo para rejeitar mudanças abruptas no rangefinder — o filtro precisa viver antes do FCU (upstream). Veja a [documentação de terrain following do ArduPilot](https://ardupilot.org/copter/docs/terrain-following.html) e o [`AP_RangeFinder_Benewake_CAN.h`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_CAN.h).
+
+## Arquitetura
+
+```mermaid
+classDiagram
+    class DistanceSensor {
+        <<protocol>>
+        +read() Optional~float~
+        +close()
+    }
+
+    class DistanceFilter {
+        <<protocol>>
+        +process(raw) Optional~float~
+        +reset()
+    }
+
+    class TFLuna {
+        -_ser Serial
+        -_buffer bytearray
+        -_min_strength int
+        +read() Optional~float~
+        +close()
+        -_parse_one_frame() Optional~float~
+    }
+
+    class ObstacleMaskFilter {
+        -_fixed_height Optional~float~
+        -_max_change_m float
+        -_estimate_lock_s float
+        -_timeout_s Optional~float~
+        -_window deque
+        -_over_obstacle bool
+        -_entry_raw Optional~float~
+        -_entry_time Optional~float~
+        -_pre_baseline Optional~float~
+        -_locked bool
+        +is_masking bool
+        +estimated_height_m Optional~float~
+        +process(raw) Optional~float~
+        +reset()
+    }
+
+    class RangefinderPublisher {
+        -_sensor DistanceSensor
+        -_connection MavlinkConnection
+        -_filter Optional~DistanceFilter~
+        -_sensor_id int
+        -_sensor_type int
+        -_orientation int
+        -_min_cm int
+        -_max_cm int
+        -_covariance int
+        -_period float
+        -_stop_event Event
+        -_thread Optional~Thread~
+        +is_running bool
+        +start()
+        +stop(timeout)
+        -_loop()
+        -_send(distance_m)
+    }
+
+    class MavlinkConnection {
+        -_source_system int
+        -_source_component int
+        -_heartbeat_timeout float
+        +master Optional~mavfile~
+        +is_connected bool
+        +connect(device, baud)
+        +close()
+        -_await_heartbeat()
+    }
+
+    class RangefinderNode {
+        -_sensor TFLuna
+        -_connection MavlinkConnection
+        -_publisher RangefinderPublisher
+        +__init__()
+        +destroy_node()
+        -_build_pipeline()
+        -_build_filter()
+    }
+
+    DistanceSensor <|.. TFLuna
+    DistanceFilter <|.. ObstacleMaskFilter
+    RangefinderPublisher o-- DistanceSensor
+    RangefinderPublisher o-- DistanceFilter
+    RangefinderPublisher o-- MavlinkConnection
+    RangefinderNode *-- RangefinderPublisher
+```
+
+## Fluxo de dados
+
+```mermaid
+flowchart LR
+    HW["TF-Luna UART"] --> TFLuna
+    TFLuna -->|"raw m"| Filter["ObstacleMaskFilter (optional)"]
+    Filter -->|"masked m"| Pub["RangefinderPublisher"]
+    Pub -->|"DISTANCE_SENSOR (132)"| Conn["MavlinkConnection"]
+    Conn -->|"MAVLink UDP/Serial"| FCU["Pixhawk RNGFND1_TYPE=10"]
+    FCU -->|"EKF Z fusion"| Ctrl["AC_PosControl"]
+    FCU -->|"RANGEFINDER (173)"| MAVROS
+    MAVROS -->|"/mavros/rangefinder/rangefinder"| Mission["MavrosDrone + missions (unchanged)"]
+```
+
+## Componentes
+
+### `DistanceSensor` e `DistanceFilter` (Protocols)
+
+Interfaces estruturais leves em [`base.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/sensors/base.py). As implementações só precisam corresponder ao formato; nenhuma herança é exigida (segue a mesma convenção de `Drone` e `ObstacleDetector` em `nectar/control`).
+
+```python
+class DistanceSensor(Protocol):
+    def read(self) -> Optional[float]: ...
+    def close(self) -> None: ...
+
+class DistanceFilter(Protocol):
+    def process(self, raw_distance: float) -> Optional[float]: ...
+    def reset(self) -> None: ...
+```
+
+### `TFLuna`
+
+Driver serial do Benewake TF-Luna em [`benewake/tfluna.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/sensors/benewake/tfluna.py). Faz o parse do frame UART padrão de 9 bytes (`0x59 0x59 ...`), valida o checksum e a força do sinal, e devolve a última leitura válida a cada `read()`. Não bloqueante: timeout de serial pequeno, drena `in_waiting` a cada chamada, devolve `None` quando nenhum frame novo está pronto.
+
+```python
+from nectar.sensors import TFLuna
+
+sensor = TFLuna(port="/dev/ttyUSB0", baudrate=115200)
+distance_m = sensor.read()  # float | None
+sensor.close()
+```
+
+Referência de hardware: [página do produto TF-Luna](https://en.benewake.com/TFLuna/index.html) e [Data Download](https://en.benewake.com/DataDownload/index.aspx?pid=20&lcid=21) (datasheet, manual do usuário, notas de aplicação para Pixhawk).
+
+> A faixa de especificação é 0,20 - 8,00 m. Na prática o sensor devolve leituras válidas até aproximadamente 0,05 - 0,08 m, por isso `min_distance_m` tem padrão `0.05`. Mantenha `RNGFND1_MIN_CM = 20` no FCU conforme a especificação do fabricante — o `DISTANCE_SENSOR.min_distance` reportado pelo SDK e o gating do ArduPilot são independentes de propósito.
+
+### `ObstacleMaskFilter`
+
+Filtro de rangefinder com estado em [`filters/obstacle_mask.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/sensors/filters/obstacle_mask.py). Detecta uma queda abrupta, mascara as leituras durante a passagem sobre o obstáculo e se recupera quando a leitura volta à baseline anterior à entrada. A altura do obstáculo é **auto-estimada por padrão** a partir da magnitude da queda na entrada (`pre_baseline - entry_raw`), então as missões não precisam conhecer as dimensões do obstáculo de antemão. Passe `obstacle_height_m` explicitamente para travar a estimativa em um valor fixo.
+
+#### Máquina de estados
+
+```mermaid
+stateDiagram-v2
+    [*] --> Passthrough
+    Passthrough --> Passthrough: "raw >= baseline - max_change"
+    Passthrough --> Refining: "drop detected: snapshot pre_baseline, entry_raw = raw"
+    Refining --> Refining: "t < estimate_lock_s, refine entry_raw if raw smaller"
+    Refining --> Locked: "t >= estimate_lock_s, freeze height"
+    Refining --> Passthrough: "raw > entry_raw + max_change OR t > timeout_s"
+    Locked --> Locked: "return raw + height"
+    Locked --> Passthrough: "raw > entry_raw + max_change OR t > timeout_s"
+```
+
+Algoritmo:
+
+- Mantém uma média móvel sobre as últimas `avg_window` leituras enquanto não está mascarando.
+- Entra no estado mascarado quando `raw < baseline - max_change_m`. Salva `pre_baseline` e `entry_raw`.
+- Nos primeiros `estimate_lock_s` após a entrada (padrão 0,2 s): refina `entry_raw` sempre que chega um raw menor, de modo que a leitura mais profunda do feixe seja capturada enquanto o obstáculo é totalmente cruzado. Depois dessa janela, a altura é congelada.
+- Enquanto mascarando: devolve `raw + (pre_baseline - entry_raw)` (ou o override fixo).
+- Sai quando `raw > entry_raw + max_change_m`, ou após `timeout_s` (reset de segurança).
+
+#### Passo a passo (auto-detecção)
+
+```
+t=0.0s   hover at 3.40 m AGL    raw=3.40  masked=3.40  state=Passthrough
+t=1.0s   enter sphere column    raw=1.70  masked=3.40  state=Refining (h=1.70)
+t=1.05s  beam settles on top    raw=1.65  masked=3.40  state=Refining (h=1.75)
+t=1.20s  estimate locks         h=1.75 frozen          state=Locked
+t=2..5s  descend over sphere    raw=0.30  masked=2.05  state=Locked
+t=5.1s   exit sphere column     raw=3.20  masked=3.20  state=Passthrough
+```
+
+Enquanto refina em altitude constante, a saída mascarada permanece em `pre_baseline` porque `raw + (pre_baseline - entry_raw)` colapsa para `pre_baseline` sempre que `entry_raw` é atualizado para o raw atual. Depois que a altura é travada, o stream mascarado acompanha linearmente qualquer descida do drone, então a configuração `EK3_SRC1_POSZ=Rangefinder` do FCU se comporta corretamente durante toda a missão, sem qualquer conhecimento prévio das dimensões do obstáculo.
+
+**Auto-detecção** (recomendado — altura aprendida a cada travessia):
+
+```python
+from nectar.sensors import ObstacleMaskFilter
+
+f = ObstacleMaskFilter(
+    max_change_m=0.30,       # entry/exit hysteresis (also caps physically reachable descent rate)
+    avg_window=10,           # samples for the entry baseline
+    estimate_lock_s=0.2,     # how long to refine the height after entry
+    timeout_s=5.0,           # force-reset if stuck masked too long
+)
+```
+
+**Override de altura fixa** (por exemplo, para SITL ou fixtures conhecidas):
+
+```python
+f_fixed = ObstacleMaskFilter(obstacle_height_m=1.7)
+```
+
+Depois leia as amostras filtradas e o estado:
+
+```python
+filtered = f.process(raw)    # float (current sample masked or passed through)
+f.is_masking                 # bool
+f.estimated_height_m         # float | None (current estimate while masking)
+f.reset()                    # clear all state (e.g. on mode change)
+```
+
+### `RangefinderPublisher`
+
+Peça de composição em [`rangefinder_publisher.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/sensors/rangefinder_publisher.py). Possui uma thread de fundo que lê o sensor em uma taxa configurável, aplica o filtro opcional e envia o `DISTANCE_SENSOR` do MAVLink (id 132) pela conexão.
+
+```python
+from nectar.control import MavlinkConnection
+from nectar.sensors import (
+    ObstacleMaskFilter,
+    RangefinderPublisher,
+    TFLuna,
+)
+from pymavlink import mavutil
+
+sensor = TFLuna(port="/dev/ttyUSB0")
+conn = MavlinkConnection()
+conn.connect("udp:127.0.0.1:14551")
+
+publisher = RangefinderPublisher(
+    sensor=sensor,
+    connection=conn,
+    sensor_id=0,
+    sensor_type=mavutil.mavlink.MAV_DISTANCE_SENSOR_LASER,
+    orientation=mavutil.mavlink.MAV_SENSOR_ROTATION_PITCH_270,  # downward
+    min_distance_m=0.05,
+    max_distance_m=8.0,
+    rate_hz=50.0,
+    filter=ObstacleMaskFilter(),  # auto-detect; pass obstacle_height_m=X to lock
+)
+
+publisher.start()
+
+# ... mission runs ...
+
+publisher.stop()
+sensor.close()
+conn.close()
+```
+
+`filter=None` publica as leituras brutas.
+
+### `RangefinderNode`
+
+Ponto de entrada ROS2 em [`nodes/rangefinder_node.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/sensors/nodes/rangefinder_node.py). Declara cada configuração como um parâmetro ROS, de modo que o ajuste por missão viva no arquivo de launch em vez de no código da missão.
+
+**Passthrough bruto** (sem filtro):
+
+```bash
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551
+```
+
+**Auto-detecção** (missão Hook e similares; não precisa de `obstacle_height_m`):
+
+```bash
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551 \
+    -p filter:=obstacle_mask
+```
+
+**Override de altura fixa** (SITL, fixtures conhecidas):
+
+```bash
+ros2 run nectar rangefinder_node.py --ros-args \
+    -p serial_port:=/dev/ttyUSB0 \
+    -p mavlink_url:=udp:127.0.0.1:14551 \
+    -p filter:=obstacle_mask \
+    -p obstacle_height_m:=1.7
+```
+
+#### Parâmetros
+
+- `serial_port` (string, padrão `/dev/ttyUSB0`) — caminho do dispositivo TF-Luna.
+- `baudrate` (int, padrão `115200`) — baud rate do TF-Luna.
+- `mavlink_url` (string, padrão `udp:127.0.0.1:14551`) — endpoint pymavlink para o FCU. Use um fan-out UDP (por exemplo, mavlink-router) se o MAVROS já possuir a linha serial do FCU.
+- `mavlink_baud` (int, padrão `921600`) — Usado somente para endpoints seriais.
+- `source_system` (int, padrão `1`) — ID de sistema MAVLink que este companion apresenta.
+- `source_component` (int, padrão `191`) — `MAV_COMP_ID_ONBOARD_COMPUTER`.
+- `heartbeat_timeout_s` (float, padrão `30.0`) — Espera máxima pelo primeiro heartbeat do FCU.
+- `sensor_id` (int 0-7, padrão `0`) — Mapeia para o slot `RNGFND<id+1>_*` do ArduPilot.
+- `orientation` (int, padrão `25`) — enum `MAV_SENSOR_ORIENTATION` (`25` = `PITCH_270`, voltado para baixo).
+- `min_distance_m` / `max_distance_m` (float, padrão `0.05` / `8.0`) — Alcance do sensor, enviado como parte do `DISTANCE_SENSOR`.
+- `covariance_cm` (int 0-254, padrão `0`) — `0` significa "usar os padrões do FCU".
+- `rate_hz` (float, padrão `50.0`) — Taxa de publicação.
+- `filter` (string, padrão `none`) — `none` ou `obstacle_mask`.
+- `obstacle_height_m` (float, padrão `0.0`) — Override de altura do obstáculo em metros. `<= 0` habilita a auto-detecção (o padrão recomendado). Encaminhado para `ObstacleMaskFilter` somente quando `filter=obstacle_mask`.
+- `max_change_m`, `avg_window`, `estimate_lock_s`, `timeout_s` — Encaminhados para `ObstacleMaskFilter` quando `filter=obstacle_mask`. Use `timeout_s <= 0` para desabilitar o reset de segurança; `estimate_lock_s` é ignorado no modo de altura fixa.
+
+## Configuração do ArduPilot (uma vez)
+
+Configure no FCU via Mission Planner / editor de parâmetros:
+
+- `RNGFND1_TYPE = 10` (MAVLink)
+- `RNGFND1_MIN_CM = 20`, `RNGFND1_MAX_CM = 800` (especificação do fabricante do TF-Luna; veja o [datasheet](https://en.benewake.com/DataDownload/index.aspx?pid=20&lcid=21))
+- `RNGFND1_ORIENT = 25` (Down)
+- Desconecte fisicamente o UART do TF-Luna do Pixhawk, de modo que a única fonte de rangefinder seja o stream MAVLink filtrado.
+- Mantenha `EK3_SRC1_POSZ = Rangefinder` e `EK3_RNG_USE_HGT = -1` se essa for sua configuração atual; o filtro de mascaramento é o que torna essa combinação segura em obstáculos conhecidos.
+
+O Jetson e o MAVROS precisam de acesso ao stream MAVLink do FCU. O padrão de uso é rodar [mavlink-router](https://github.com/mavlink-router/mavlink-router) (ou equivalente) no Jetson para distribuir (fan out) o link serial do FCU tanto para o MAVROS quanto para o endpoint UDP deste nó.
+
+## DISTANCE_SENSOR vs RANGEFINDER
+
+São duas mensagens MAVLink diferentes, com direções opostas:
+
+- [`DISTANCE_SENSOR` (id 132)](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR): companion → FCU. O que este nó envia. Carrega metadados do sensor (id, tipo, orientação, min/max).
+- [`RANGEFINDER` (id 173, ardupilotmega)](https://github.com/mavlink/c_library_v1/blob/master/ardupilotmega/mavlink_msg_rangefinder.h): FCU → GCS, telemetria. O que o MAVROS lê para publicar `/mavros/rangefinder/rangefinder`.
+
+Este nó só emite `DISTANCE_SENSOR`. O fluxo de `RANGEFINDER` é tratado pelo ArduPilot e pelo MAVROS sem nenhum código deste módulo.
+
+## Validação
+
+Bancada (sem voo):
+
+```bash
+ros2 run nectar rangefinder_node.py --ros-args -p mavlink_url:=udp:127.0.0.1:14551
+ros2 topic echo /mavros/rangefinder/rangefinder
+```
+
+Coloque um objeto de altura conhecida sob o sensor enquanto observa o tópico. A leitura deve saltar pelo offset mascarado e se recuperar quando o objeto for removido.
+
+Standalone (sem ROS): veja o [exemplo standalone de rangefinder](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/examples/sensors/rangefinder_example.py).
+
+## Limitações conhecidas do modo de auto-detecção
+
+- **O caso inverso (subida abrupta) não é mascarado.** O filtro só dispara em quedas. Voar para fora de uma mesa ou penhasco faz o raw subir abruptamente; este filtro não faz nada a respeito.
+- **Ligar o sensor diretamente sobre um obstáculo contamina a baseline.** A média móvel precisa de pelo menos algumas amostras de solo plano antes da primeira travessia. Solução alternativa: decole, voe até um solo livre por pelo menos `avg_window` amostras, e então prossiga.
+- **Obstáculos empilhados ou consecutivos**: o filtro sai e volta a entrar por obstáculo, o que é o comportamento correto. Cada entrada reestima a altura a partir da nova queda.
+- **Obstáculo largo, com subida gradual (inclinação > `max_change_m / sample_period`)**: não é detectado como obstáculo porque não há queda abrupta. Isso é intencional — mudanças lentas de elevação parecem terreno, não um obstáculo.
+
+## Solução de problemas
+
+- **`No FCU heartbeat received within 30s`**: o pymavlink não consegue alcançar o FCU. Verifique `mavlink_url`, se o mavlink-router está em execução e se a porta UDP corresponde. Verifique com `mavproxy.py --master=udp:127.0.0.1:14551`.
+- **O MAVROS ainda mostra a leitura bruta**: confirme `RNGFND1_TYPE = 10` no FCU e que o UART direto está fisicamente desconectado. O FCU prefere o sensor cabeado diretamente quando ambos estão presentes.
+- **O filtro mascara durante uma descida legítima**: `max_change_m` está muito rígido. Aumente-o, ou reduza `avg_window` para que a baseline acompanhe a descida mais rápido.
+- **Altura auto-estimada é pequena demais** (o drone ainda sobe um pouco ao cruzar o obstáculo): a janela de travamento expirou antes que o feixe alcançasse o ponto mais profundo. Aumente `estimate_lock_s` (por exemplo, 0,4 s), ou trave a altura com `obstacle_height_m`.
+- **Altura auto-estimada é grande demais** (o drone desce ao entrar na região mascarada): amostra de entrada ruidosa. Aumente `avg_window` para que a pre-baseline fique mais estável, ou trave a altura com `obstacle_height_m`.
+- **Preso em estado mascarado**: reduza `timeout_s` (padrão 5,0 s) ou defina um valor apenas um pouco maior que a maior travessia de obstáculo esperada na missão.
+- **TF-Luna devolve `None` constantemente**: verifique o baud (padrão 115200), a fiação, e se nenhum outro processo está retendo a porta serial. Aumente o argumento de construtor `min_strength` de `TFLuna(...)` (não é um parâmetro ROS) se você suspeitar que o sensor está lendo por meio de reflexões de baixa confiança.
+
+## Referências
+
+- [Página do produto Benewake TF-Luna](https://en.benewake.com/TFLuna/index.html) e [Data Download](https://en.benewake.com/DataDownload/index.aspx?pid=20&lcid=21) (datasheet, manual do usuário, notas de aplicação Pixhawk)
+- [Página de rangefinder do ArduPilot](https://ardupilot.org/copter/docs/common-rangefinder-landingpage.html)
+- [Terrain following do ArduPilot](https://ardupilot.org/copter/docs/terrain-following.html)
+- [Configuração Benewake do ArduPilot](https://ardupilot.org/copter/docs/common-benewake-tf02-lidar.html)
+- [`AP_RangeFinder.h`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_RangeFinder/AP_RangeFinder.h)
+- [Mensagem MAVLink `DISTANCE_SENSOR`](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR)
+- [Documentação do pymavlink](https://mavlink.io/en/mavgen_python/)

--- a/i18n/pt/modules/simulation.md
+++ b/i18n/pt/modules/simulation.md
@@ -1,0 +1,437 @@
+# Módulo de Simulação
+
+Simulação ArduPilot SITL + Gazebo Harmonic para desenvolvimento e testes do Nectar, sobre qualquer um dos dois transportes (MAVROS ou MAVLink direto).
+
+## Como funciona
+
+O [SITL](https://ardupilot.org/dev/docs/sitl-simulator-software-in-the-loop.html) do ArduPilot roda o firmware ArduCopter completo na máquina host. O [Gazebo Harmonic](https://gazebosim.org/docs/harmonic) fornece a simulação de física e sensores. O [ArduPilotPlugin](https://github.com/ArduPilot/ardupilot_gazebo) faz a ponte da física do Gazebo para o SITL via JSON sobre UDP (porta 9002). O SITL expõe dois endpoints MAVLink: TCP `5760` (SERIAL0, para o [MAVROS](https://github.com/mavlink/mavros)) e TCP `5762` (SERIAL1, para um cliente pymavlink direto / `MavlinkDrone`) — assim os dois transportes podem rodar contra o mesmo simulador. O [ros_gz_bridge](https://github.com/ros-gz/ros_gz) converte os dados de sensores do Gazebo em mensagens ROS 2.
+
+```mermaid
+flowchart LR
+    subgraph sitl [ArduPilot SITL]
+        ArduCopter["arducopter binary"]
+    end
+
+    subgraph gazebo [Gazebo Harmonic]
+        Physics["Physics + Sensors"]
+        ArduPlugin["ArduPilotPlugin"]
+        GUI["GUI: 3D + ImageDisplay + TopicEcho"]
+    end
+
+    subgraph bridge [ros_gz_bridge]
+        SensorBridge["Cameras + Lidar"]
+        PoseBridge["Pose bridge (indoor)"]
+    end
+
+    subgraph ros2 [ROS 2]
+        MAVROS["MAVROS"]
+        VisionSource["gz_vision_source (indoor)"]
+        VisionNode["vision_pose_node (mavros)"]
+        SDK["Nectar SDK / MavrosDrone | MavlinkDrone"]
+    end
+
+    ArduPlugin -->|"JSON UDP:9002"| ArduCopter
+    ArduCopter -->|"TCP:5760 (MAVROS)"| MAVROS
+    ArduCopter -->|"TCP:5762 (direct MAVLink)"| SDK
+    Physics --> SensorBridge
+    SensorBridge --> SDK
+    PoseBridge --> VisionSource
+    VisionSource -->|"/visual_slam/tracking/vo_pose_covariance"| VisionNode
+    VisionSource -->|"/visual_slam/tracking/vo_pose_covariance"| SDK
+    VisionNode -->|"/mavros/vision_pose/pose_cov"| MAVROS
+    MAVROS --> SDK
+```
+
+## Dois ambientes
+
+### Outdoor (GPS)
+
+- World: `outdoor_field.sdf` -- campo aberto com zona de obstáculo em x=13..18, portão para atravessar (fly-through gate)
+- GPS via plugin `gz-sim-navsat-system` com coordenadas WGS84 (Canberra por padrão)
+- Parâmetros ArduPilot: `copter.parm` + `gazebo.parm` (rangefinder habilitado)
+- Preset de config: `SITL_GAZEBO_CONFIG` (PoseSource.GPS)
+
+### Indoor (Vision)
+
+- World: `indoor_room.sdf` — sala de 20x20x12m, drone em x=-5
+- Sem GPS; EKF3 ExternalNav pelas mesmas pontes de visão do hardware
+  (detalhes: [localization README — SITL](control/localization/#sitl))
+- Parâmetros: `copter.parm` + `gazebo.parm` + `indoor.parm`
+- Config: `SITL_VISION_CONFIG` (PoseSource.VISION)
+
+## Sensores simulados
+
+| Sensor real             | Sensor Gazebo        | Tópico (ROS 2)                                                              | Notas                                             |
+| ----------------------- | -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------- |
+| RealSense D435i (front) | `rgbd_camera`        | `/front_camera/image`, `/front_camera/depth_image`, `/front_camera/points` | 640x480, RGB + depth + point cloud                |
+| Arducam (down)          | `camera`             | `/down_camera`                                                             | 640x480 RGB, voltada para baixo                      |
+| TFLuna lidar (down)     | Sonar simulado do SITL | `/mavros/rangefinder/rangefinder`                                          | `RNGFND1_TYPE=1`, distância ao solo pela física    |
+| TFLuna lidar (down)     | `gpu_lidar`          | `/lidar/range`                                                             | LaserScan direto via Gazebo, rangefinder de 1 amostra |
+
+A tabela acima é o world do ArduPilot. Nos dois firmwares o SDK lê o
+rangefinder voltado para baixo em `/mavros/rangefinder/rangefinder`: o ArduPilot o deriva
+do sonar do SITL, enquanto o PX4 funde o `gpu_lidar` gz do `x500_nectar` em um
+`distance_sensor` e o transmite como `DISTANCE_SENSOR` do MAVLink (veja
+`simulation/config/px4_config_sitl.yaml`). O ArduPilot também expõe o
+LaserScan bruto do Gazebo `gpu_lidar` em `/lidar/range`.
+
+## GUI do Gazebo
+
+Os dois SDFs de world incluem plugins de GUI integrados (sem janelas extras necessárias):
+
+- Painéis **ImageDisplay** para RGB frontal, profundidade frontal e câmera inferior (começam recolhidos, clique para expandir)
+- **TopicEcho** para visualizar qualquer tópico do transporte do Gazebo em tempo real
+- **WorldStats** mostrando tempo de simulação, tempo real, RTF
+
+## Instalação
+
+**ArduPilot** — clona `~/ardupilot` + builda o ArduCopter SITL, depois instala Gazebo Harmonic + ArduPilotPlugin + ros_gz_bridge:
+
+```bash
+make sim-install FIRMWARE=ardupilot
+```
+
+**PX4** — clona `~/PX4-Autopilot` + builda px4_sitl + Gazebo, e cria symlinks dos assets compartilhados do Nectar (`x500_nectar`, `outdoor_field_scenery`, `outdoor_field_px4`) na árvore do PX4. Acrescente `ARGS=--native` para o caminho uXRCE-DDS:
+
+```bash
+make sim-install FIRMWARE=px4
+```
+
+**Ambos**:
+
+```bash
+make sim-install FIRMWARE=all
+```
+
+Depois recarregue seu shell: `source ~/.bashrc`.
+
+## Uso
+
+Um padrão para os dois firmwares. A divisão em dois terminais é inevitável (o
+SITL do autopilot e a stack ROS são processos separados), então é simétrica:
+
+- **Terminal 1 — `sim-start`**: o simulador (SITL do ArduPilot; para PX4, também o Gazebo).
+- **Terminal 2 — `sim-bridge`**: a stack ROS (Gazebo + pontes para ArduPilot; para PX4, MAVROS, MicroXRCE-DDS, ou somente câmera, dependendo de `PROTOCOL`).
+
+Escolha o cenário com três variáveis (padrões `ardupilot` / `outdoor` /
+`mavlink`, então `make sim-start` + `make sim-bridge` puros = ArduPilot outdoor sobre
+MAVLink direto). `ENV` precisa coincidir entre os dois terminais.
+
+- `FIRMWARE` = `ardupilot` | `px4`
+- `ENV` = `outdoor` | `indoor`
+- `PROTOCOL` = `mavlink` (pymavlink direto, **padrão**) | `mavros`. Para PX4, `dds` seleciona o agent uXRCE-DDS nativo.
+
+| Cenário                          | Terminal 1                                      | Terminal 2                                                        | Config de missão                                       |
+| --------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| ArduPilot outdoor, MAVLink direto | `make sim-start FIRMWARE=ardupilot ENV=outdoor` | `make sim-bridge FIRMWARE=ardupilot ENV=outdoor`                  | `MavlinkDrone` / `MAVLINK_SITL_GAZEBO_CONFIG` |
+| ArduPilot outdoor, MAVROS         | (mesmo Terminal 1)                               | `make sim-bridge FIRMWARE=ardupilot ENV=outdoor PROTOCOL=mavros`  | `MavrosDrone` / `SITL_GAZEBO_CONFIG` |
+| ArduPilot indoor, MAVLink direto  | `make sim-start FIRMWARE=ardupilot ENV=indoor`  | `make sim-bridge FIRMWARE=ardupilot ENV=indoor`                   | `MavlinkDrone` / `MAVLINK_SITL_VISION_CONFIG`        |
+| ArduPilot indoor, MAVROS          | (mesmo Terminal 1)                               | `make sim-bridge FIRMWARE=ardupilot ENV=indoor PROTOCOL=mavros`   | `MavrosDrone` / `SITL_VISION_CONFIG`                 |
+| PX4 outdoor, MAVLink direto       | `make sim-start FIRMWARE=px4 ENV=outdoor`       | `make sim-bridge FIRMWARE=px4 ENV=outdoor`                        | `Px4MavlinkDrone` / `PX4_MAVLINK_SITL_GAZEBO_CONFIG` |
+| PX4 outdoor, MAVROS               | (mesmo Terminal 1)                               | `make sim-bridge FIRMWARE=px4 ENV=outdoor PROTOCOL=mavros`        | `Px4MavrosDrone` / `PX4_SITL_GAZEBO_CONFIG`          |
+| PX4 outdoor, uXRCE-DDS            | (mesmo Terminal 1)                               | `make sim-bridge FIRMWARE=px4 ENV=outdoor PROTOCOL=dds`           | `Px4DdsDrone` / `PX4_DDS_SITL_CONFIG`            |
+| PX4 indoor, MAVLink direto        | `make sim-start FIRMWARE=px4 ENV=indoor`        | `make sim-bridge FIRMWARE=px4 ENV=indoor`                         | `Px4MavlinkDrone` / `PX4_MAVLINK_SITL_VISION_CONFIG` |
+| PX4 indoor, MAVROS (external-nav) | (mesmo Terminal 1)                               | `make sim-bridge FIRMWARE=px4 ENV=indoor PROTOCOL=mavros`         | `Px4MavrosDrone` / `PX4_SITL_VISION_CONFIG`          |
+| PX4 indoor, uXRCE-DDS             | (mesmo Terminal 1)                               | `make sim-bridge FIRMWARE=px4 ENV=indoor PROTOCOL=dds`            | `Px4DdsDrone` / `PX4_DDS_SITL_VISION_CONFIG`         |
+
+- **ArduPilot**: O Terminal 1 roda a física do SITL; o Terminal 2 inicia o Gazebo + `ros_gz_bridge`. Com `PROTOCOL=mavlink` (padrão), o `vision_pose_node` inicia no SERIAL0 (tcp `5760`) indoors; a missão usa o SERIAL1 (tcp `5762`). Ative o venv do nectar (`nectar-activate`) antes do Terminal 2 para que o pymavlink esteja disponível — caso contrário o feeder termina e a porta `5762` fica fechada. `PROTOCOL=mavros` acrescenta o MAVROS no SERIAL0, além do `vision_pose_node`.
+- **As connection strings diferem por transporte**: o MAVROS usa uma URL (`tcp://host:port`, `udp://...`); o `MavlinkDrone` (pymavlink) de MAVLink direto usa uma string simples (`tcp:127.0.0.1:5762`, `udp:host:port`, ou um caminho serial como `/dev/ttyUSB0`). A forma `tcp://` também é aceita pelo `MavlinkDrone` e é normalizada.
+- **PX4**: O Terminal 1 (`start_px4.sh`) roda o PX4 **e** seu Gazebo. O Terminal 2 roda as pontes. A API offboard é UDP `14540`. O `PROTOCOL=mavlink` indoor usa um feed de responsabilidade da missão (`auto_vision_feed` em `PX4_MAVLINK_SITL_VISION_CONFIG`) porque o SITL expõe um único endpoint offboard.
+- **PX4 uXRCE-DDS** (`PROTOCOL=dds`): o Terminal 2 roda o `MicroXRCEAgent` (udp4 :8888); outdoor deixa o agent em foreground. Indoor também inicia `px4_sitl.launch.py vision:=true backend:=dds` para que GT→VSLAM→`VehicleOdometry` alcance o EKF2. Configuração única: `make sim-install FIRMWARE=px4 ARGS=--native` (builda `px4_msgs` + o agent). O `px4_msgs` precisa corresponder ao firmware do PX4 (os tópicos são versionados, por exemplo `vehicle_status_v4`).
+- **Indoor**: os dois firmwares usam `gz_vision_source` → pontes de visão (veja
+  [localization SITL](control/localization/#sitl)).
+- Encaminhe argumentos extras de launch/script com `ARGS=...`, por exemplo um toggle avulso de mavros ou o world de teste de rangefinder:
+
+```bash
+make sim-bridge FIRMWARE=ardupilot ARGS="world:=rangefinder_test.sdf mavros:=false"
+```
+
+- **Arenas de missão customizadas (recomendado):** pacotes de competição distribuem **somente scenery** (`model.config` + `model.sdf` + meshes). O Nectar compõe a stack do veículo (plugins, iris, câmeras, lidar). `ENV` seleciona ExternalNav indoor vs GPS outdoor; o mapa e o spawn são argumentos de launch:
+
+```bash
+make sim-start  FIRMWARE=ardupilot ENV=indoor
+make sim-bridge FIRMWARE=ardupilot ENV=indoor \
+  ARGS='scenery:=model://my_arena spawn_pose:="-5 0 0.195 0 0 0" resource_path:=/path/to/pkg/simulation/models'
+```
+
+| Argumento | Papel |
+|-----|------|
+| `world:=outdoor\|indoor` | Compõe a partir do template de veículo do Nectar (+ scenery de estoque se `scenery` estiver vazio) |
+| `scenery:=model://name` | Substitui o scenery de estoque por um modelo de missão |
+| `spawn_pose:="x y z r p y"` | Pose do iris (graus); vazio = padrão do template |
+| `resource_path:=a:b` | Diretórios extras no `GZ_SIM_RESOURCE_PATH` (`simulation/models` da missão) |
+| `world:=/abs/path.sdf` | Escape hatch: world customizado completo (precisa embutir drone/sensores você mesmo). Passe `vision:=true` para ExternalNav indoor — worlds por caminho **não** habilitam vision automaticamente. |
+
+Worlds compostos usam nomes fixos `nectar_indoor` / `nectar_outdoor` (tópico de pose `/world/<name>/dynamic_pose/info`). Worlds customizados completos usam o `<world name="...">` do SDF. Pacotes de missão que só fornecem scenery **não** devem fixar (hard-code) iris/câmeras em seu SDF.
+
+- ArduPilot headless sem Gazebo (MAVROS puro): rode `./scripts/simulation/start_sitl.sh` e depois `ros2 launch nectar sitl.launch.py` diretamente.
+
+> Rode `make sim-stop` antes de reiniciar o Terminal 2 — isso limpa todo processo de
+> simulação para os dois firmwares (arducopter/px4, Gazebo, MAVROS, pontes, nós de vision).
+
+### Arquitetura de world compartilhado
+
+**O Nectar possui a stack do veículo; as missões possuem o scenery.**
+
+- `simulation/templates/{indoor,outdoor}_vehicle.sdf.in` — templates de composição do ArduPilot (plugins, iris, câmeras/lidar do Nectar). O launch substitui scenery + spawn.
+- `simulation/models/indoor_room_scenery/` — sala indoor de estoque de 20×20×12 m + obstáculos.
+- `simulation/models/outdoor_field_scenery/` — portão outdoor + obstáculos. Também usado por `outdoor_field.sdf` / `outdoor_field_px4.sdf`.
+- `simulation/models/x500_nectar/` — `x500` do PX4 + sensores correspondentes. Outdoor/indoor do PX4 usam o mesmo scenery via include.
+- `simulation/worlds/outdoor_field_px4.sdf` — world somente-scenery para o PX4 (sem tags `<plugin>` de world; o `server.config` do PX4 injeta os systems). Origem GPS com declinação próxima de zero (lat 0, lon 40), **não** a Canberra do ArduPilot — veja as notas de magnetômetro em documentos anteriores ([gz-sim#2536](https://github.com/gazebosim/gz-sim/issues/2536)).
+- `simulation/worlds/indoor_room_px4.sdf` — world indoor somente-scenery para o PX4 (mesmo `indoor_room_scenery`). A pose GT vem do PosePublisher no `x500_nectar` (o Gazebo 8 exige attachment no nível do modelo; 50 Hz; spawnado como `x500_nectar_0`).
+
+Layout de um pacote de missão:
+
+```text
+my_mission/simulation/models/<arena>/{model.config,model.sdf,meshes/}
+```
+
+Sem iris, câmeras, ou plugins de world do Gazebo no pacote de missão.
+
+O `install_px4.sh` cria symlinks dos assets do Nectar (`x500_nectar`, scenery + worlds outdoor/indoor) em `Tools/simulation/gz/{models,worlds}` do PX4, de modo que o launcher do PX4 os encontre enquanto a fonte de verdade permanece em `nectar-sdk/`. `start_px4.sh --autostart` reaproveita o airframe `4001` (x500) já existente do PX4 via `PX4_SYS_AUTOSTART`, então nenhum arquivo de airframe é acrescentado na árvore do PX4. O indoor carrega automaticamente `params/px4_indoor.env` e faz o spawn em `PX4_GZ_MODEL_POSE=-5,0,0.2`.
+
+### Parar tudo
+
+```bash
+make sim-stop
+```
+
+Um único stop para os dois firmwares: mata arducopter, PX4 (px4_sitl/bin/px4), MicroXRCEAgent, Gazebo, MAVROS, ros_gz_bridge, gz_vision_source, e os processos do vision_pose_node.
+
+### Verificar sensores
+
+| Verificação | Comando |
+|-------|---------|
+| Estado | `ros2 topic echo /mavros/state --once` |
+| GPS (outdoor) | `ros2 topic echo /mavros/global_position/global --once --qos-reliability best_effort` |
+| Vision pose (indoor) | `ros2 topic echo /mavros/vision_pose/pose_cov --once` |
+| Rangefinder | `ros2 topic echo /mavros/rangefinder/rangefinder --once` |
+| Câmera frontal | `ros2 topic echo /front_camera/image --once` |
+| Profundidade | `ros2 topic echo /front_camera/depth_image --once` |
+
+### Rangefinders com múltiplas orientações
+
+O `rangefinder_test.sdf` posiciona um iris com lidares de raio único frontal e traseiro
+entre duas paredes. O modelo `iris_with_rangefinders` encaminha os lidares
+frontal/traseiro para o ArduPilot como `rng_2/rng_3`, e `rangefinder_test.parm` os expõe
+como `RNGFND2/3` (orientações frente/trás). O rangefinder voltado para baixo
+(`RNGFND1`, orientação para baixo) permanece no sonar analógico do SITL a partir de `gazebo.parm`:
+no solo a aeronave tem apenas ~0,2 m de altura, então um lidar GPU voltado para baixo lê
+abaixo do seu alcance mínimo, enquanto o sonar reporta a altura do veículo em relação ao
+terreno de forma confiável. O ArduPilot emite um `DISTANCE_SENSOR` por instância, acessível por
+`drone.distance_sensors` e `drone.get_distance(orientation)`.
+
+**Terminal 1 — SITL com os três rangefinders**:
+
+```bash
+./scripts/simulation/start_sitl.sh --gazebo \
+    --params nectar/simulation/params/rangefinder_test.parm
+```
+
+**Terminal 2 — Gazebo (e MAVROS) com o world de teste**:
+
+```bash
+ros2 launch nectar sitl_gazebo.launch.py world:=rangefinder_test.sdf
+```
+
+**Terminal 3 — inspecionar as leituras** (tópicos MAVROS):
+
+```bash
+ros2 topic echo /mavros/rangefinder/rangefinder --once
+ros2 topic echo /mavros/distance_sensor/rangefinder/front --once
+```
+
+No código, os dois transportes expõem cada unidade reportada via `drone.distance_sensors`
+e `drone.get_distance(orientation)` (a unidade voltada para baixo também atualiza
+`drone.rangefinder`); veja o [vehicle core README](control/vehicle/#distance-sensors).
+O caminho do MAVROS depende das entradas do plugin `distance_sensor` em
+`config/apm_config_sitl.yaml` (`rangefinder/rangefinder`, `rangefinder/front`,
+`rangefinder/back`) mapeadas para as orientações.
+
+## Presets de configuração
+
+Definidos em `nectar/control/config.py`:
+
+| Preset                       | Transporte | Porta  | PoseSource | Lidar | Caso de uso                                                                            |
+| ---------------------------- | --------- | ----- | ---------- | ----- | ----------------------------------------------------------------------------------- |
+| `SITL_CONFIG`                | mavros    | 5760  | GPS        | Não    | SITL headless, sem sensores                                                           |
+| `SITL_GPS_CONFIG`            | mavros    | 5760  | GPS        | Não    | SITL headless com GPS                                                              |
+| `SITL_GAZEBO_CONFIG`         | mavros    | 5760  | GPS        | Sim   | Gazebo outdoor                                                                      |
+| `SITL_VISION_CONFIG`         | mavros    | 5760  | VISION     | Sim   | Gazebo indoor                                                                       |
+| `MAVLINK_SITL_CONFIG`        | mavlink   | 5760  | GPS        | Não    | SITL headless, pymavlink direto                                                     |
+| `MAVLINK_SITL_GAZEBO_CONFIG` | mavlink   | 5762  | GPS        | Não    | Gazebo outdoor, direto (SERIAL1, junto com MAVROS)                                  |
+| `MAVLINK_SITL_VISION_CONFIG` | mavlink   | 5762  | VISION     | Não    | Gazebo indoor; feeder no SERIAL0 / 5760                                             |
+| `PX4_SITL_CONFIG`            | px4       | 14540 | GPS        | Não    | PX4 SITL headless (offboard via MAVROS)                                            |
+| `PX4_SITL_GAZEBO_CONFIG`     | px4         | 14540 | GPS        | Sim   | PX4 SITL + Gazebo (x500_nectar, outdoor)                                            |
+| `PX4_SITL_VISION_CONFIG`     | px4         | 14540 | VISION     | Sim   | PX4 SITL indoor (indoor_room_px4 + gz_vision_source → EKF2)                         |
+| `PX4_MAVLINK_SITL_CONFIG`        | px4_mavlink | 14540 | GPS        | Não    | PX4 SITL headless, pymavlink direto                                              |
+| `PX4_MAVLINK_SITL_GAZEBO_CONFIG` | px4_mavlink | 14540 | GPS        | Sim   | PX4 SITL + Gazebo (x500_nectar, outdoor), pymavlink direto                       |
+| `PX4_MAVLINK_SITL_VISION_CONFIG` | px4_mavlink | 14540 | VISION     | Sim   | PX4 SITL indoor; feed de vision de responsabilidade da missão (offboard UDP único)              |
+| `PX4_DDS_SITL_CONFIG`            | px4_dds     | 8888  | GPS        | Sim   | PX4 SITL uXRCE-DDS nativo (MicroXRCEAgent na 8888), outdoor                      |
+| `PX4_DDS_SITL_VISION_CONFIG`     | px4_dds     | 8888  | VISION     | Não    | PX4 SITL indoor uXRCE-DDS (VehicleOdometry EV)                                   |
+
+```python
+from nectar.control import (
+    DroneFactory,
+    SITL_GAZEBO_CONFIG,
+    MAVLINK_SITL_GAZEBO_CONFIG,
+    PX4_SITL_GAZEBO_CONFIG,
+    PX4_MAVLINK_SITL_GAZEBO_CONFIG,
+)
+```
+
+**Outdoor via MAVROS** (porta 5760):
+
+```python
+drone = DroneFactory.create("mavros", SITL_GAZEBO_CONFIG)
+```
+
+**Outdoor via MAVLink direto** (porta 5762, `sim-bridge ... PROTOCOL=mavlink`):
+
+```python
+drone = DroneFactory.create("mavlink", MAVLINK_SITL_GAZEBO_CONFIG)
+```
+
+**PX4 via MAVROS** (offboard UDP 14540, `sim-start`/`sim-bridge FIRMWARE=px4 ENV=outdoor`):
+
+```python
+drone = DroneFactory.create("px4", PX4_SITL_GAZEBO_CONFIG)
+```
+
+**PX4 via pymavlink direto** (offboard UDP 14540, `sim-bridge ... PROTOCOL=mavlink`):
+
+```python
+drone = DroneFactory.create("px4_mavlink", PX4_MAVLINK_SITL_GAZEBO_CONFIG)
+```
+
+## Suíte de testes
+
+O status por distro do protocolo outdoor vive em [`docs/COMPATIBILITY.md`](../setup/compatibility/) (seção Simulation). Gate do Tier-3 por protocolo: `make verify-sitl FIRMWARE=<ardupilot|px4> PROTOCOL=<mavros|mavlink|dds>` — mapeia para as linhas de cenário abaixo.
+
+`sitl_test.py` roda testes de navegação atômicos. Cada teste começa a partir de um hover limpo e verifica uma capacidade específica.
+
+### Uso
+
+```bash
+
+# All outdoor tests over MAVROS (37 tests, tcp 5760)
+
+python3 nectar/nectar/examples/simulation/sitl_test.py
+
+# Same suite over direct pymavlink (MavlinkDrone, tcp 5762)
+
+python3 nectar/nectar/examples/simulation/sitl_test.py --mavlink
+
+# Indoor-compatible subset (vision config, skips the 5 GPS-only tests -> 32 tests)
+
+python3 nectar/nectar/examples/simulation/sitl_test.py --indoor
+
+# Land between tests for a full reset
+
+python3 nectar/nectar/examples/simulation/sitl_test.py --fresh pid_fwd
+
+# Specific tests / a group / list everything
+
+python3 nectar/nectar/examples/simulation/sitl_test.py pid_fwd setpoint_fwd
+python3 nectar/nectar/examples/simulation/sitl_test.py --group vel
+python3 nectar/nectar/examples/simulation/sitl_test.py --list
+```
+
+Flags: `--mavlink` (pymavlink direto na tcp 5762), `--px4` (PX4 via MAVROS, offboard na udp 14540), `--indoor` (config vision, pula os testes somente-GPS), `--fresh` (pousa entre os testes).
+
+### Grupos de teste
+
+| Grupo             | Testes                                                                                                | Descrição                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `vel`             | vel_fwd, vel_lat, vel_up, vel_yaw, vel_takeoff, vel_world, vel_world_north, vel_world_rotated, brake | Velocidade nos frames BODY/WORLD/TAKEOFF  |
+| `pid`             | pid_fwd, pid_lat, pid_alt, pid_yaw                                                                   | Navegação PID com GPS bruto            |
+| `pid_local`       | pid_local_fwd, pid_local_lat, pid_local_yaw                                                          | Navegação PID com posição local do EKF |
+| `setpoint`        | setpoint_fwd, setpoint_lat, setpoint_yaw                                                             | Publicação de setpoint de posição local     |
+| `setpoint_global` | setpoint_global, setpoint_global_yaw                                                                 | Setpoint global GPS (somente outdoor)     |
+| `wpnav`           | setpoint_wpnav                                                                                       | Setpoint de waypoint AC_WPNav             |
+| `rtl`             | rtl_pid, rtl_ardupilot                                                                               | Retorno ao ponto de lançamento                       |
+| `yaw`             | vel_yaw, pid_yaw, pid_local_yaw, setpoint_yaw, setpoint_global_yaw, yaw_direction, yaw_takeoff_ref   | Tratamento de yaw entre métodos            |
+| `world`           | vel_world, vel_world_north, vel_world_rotated                                                        | Velocidade em frame WORLD                   |
+| `nav`             | pid_fwd, pid_lat, pid_local_fwd, pid_local_lat                                                       | Navegação PID central                    |
+| `compound`        | sequential, takeoff_ref                                                                              | Sequências de múltiplos passos                    |
+| `square`          | sq_pid, sq_pid_takeoff, sq_pid_local, sq_setpoint, sq_setpoint_global, sq_wpnav                      | Padrões de quadrado de 3m                     |
+
+Testes pré-voo (`sensors`, `heading_enu`) rodam sem takeoff. Testes somente-GPS (pulados com `--indoor`): `heading_enu`, `setpoint_global`, `setpoint_global_yaw`, `sq_setpoint_global`, `rtl_ardupilot`.
+
+O teste `set_speed` exercita o `MAV_CMD_DO_CHANGE_SPEED` (horizontal/subida/descida). Ele não
+está no conjunto pré-voo porque o ArduCopter só aceita esse comando em um modo capaz de navegação
+(GUIDED), então precisa rodar em voo.
+
+## Parâmetros do ArduPilot
+
+### gazebo.parm (carregado em todas as sessões Gazebo)
+
+| Parâmetro         | Valor | Finalidade                                |
+| ----------------- | ----- | -------------------------------------- |
+| `SIM_SONAR_SCALE` | 10    | Fator de escala do sonar do SITL              |
+| `RNGFND1_TYPE`    | 1     | Rangefinder analógico controlado por SIM_SONAR |
+| `RNGFND1_SCALING` | 10    | Escala de tensão para distância            |
+| `RNGFND1_PIN`     | 0     | Pino analógico                             |
+| `RNGFND1_MAX`     | 40    | Alcance máximo (m)                          |
+| `RNGFND1_MIN`     | 0.10  | Alcance mínimo (m)                          |
+
+### indoor.parm (carregado adicionalmente para ArduPilot indoor)
+
+| Parâmetro        | Valor  | Finalidade                           |
+| ---------------- | ------ | ---------------------------------- |
+| `GPS1_TYPE`      | 0      | Desabilita o GPS                       |
+| `EK3_SRC1_POSXY` | 6      | ExternalNav para posição XY       |
+| `EK3_SRC1_VELXY` | 6      | ExternalNav para velocidade XY       |
+| `EK3_SRC1_POSZ`  | 1      | Barômetro para Z (padrão)         |
+| `EK3_SRC1_YAW`   | 6      | ExternalNav para yaw               |
+| `VISO_TYPE`      | 1      | Habilita a entrada de odometria visual      |
+| `ARMING_CHECK`   | 388598 | Desabilita checagens de arming relacionadas ao GPS |
+
+### px4_indoor.env (carregado para PX4 indoor via `PX4_PARAM_*`)
+
+| Parâmetro        | Valor | Finalidade                                      |
+| ---------------- | ----- | --------------------------------------------- |
+| `EKF2_GPS_CTRL`  | 0     | Desabilita o auxílio de GNSS                          |
+| `EKF2_EV_CTRL`   | 11    | EV h-pos + v-pos + yaw (sem velocidade)         |
+| `EKF2_HGT_REF`   | 3     | Referência de altura = Vision                    |
+| `EKF2_MAG_TYPE`  | 5     | Nenhum (yaw pela vision)                       |
+| `COM_ARM_WO_GPS` | 1     | Permite armar sem GPS (SITL)              |
+
+## Vision indoor
+
+Pose/twist ground-truth → tópicos VSLAM canônicos via `gz_vision_source.py`, e depois
+os mesmos backends `vision_pose_node` do hardware. Notas completas (tempo de sim, velocidade,
+`send_speed`): [localization README — SITL](control/localization/#sitl).
+
+No Jazzy, o `ros_gz` pode remover o `child_frame_id`; a fonte usa
+`model_index` (padrão 0) como fallback.
+
+## Layout
+
+Assets de simulação (`nectar/simulation/`):
+
+- `params/` — arquivos de parâmetros do SITL: `gazebo.parm` / `indoor.parm` (ArduPilot), `px4_indoor.env` (PX4 EKF2 EV), `rangefinder_test.parm`
+- `config/` — perfis de ponte MAVROS: `apm_config_sitl.yaml` / `apm_pluginlists_sitl.yaml` (ArduPilot), `px4_config_sitl.yaml` / `px4_pluginlists_sitl.yaml` (PX4)
+- `models/` — `indoor_room_scenery`, `outdoor_field_scenery`, `iris_with_rangefinders`, `x500_nectar`
+- `templates/` — `indoor_vehicle.sdf.in`, `outdoor_vehicle.sdf.in` (compostos por `sitl_gazebo.launch.py`)
+- `worlds/` — `outdoor_field.sdf`, `outdoor_field_px4.sdf`, `indoor_room.sdf`, `indoor_room_px4.sdf`, `rangefinder_test.sdf`
+
+Scripts de instalação e start (`scripts/simulation/`): `install_sitl.sh`, `install_gazebo.sh`,
+`install_px4.sh`, `start_sitl.sh`, `start_px4.sh`, e `gz_vision_source.py`.
+
+Arquivos de launch (`nectar/launch/`): `sitl.launch.py` (somente MAVROS), `sitl_gazebo.launch.py`
+(Gazebo ArduPilot + `ros_gz_bridge`), `px4_sitl.launch.py` (ponte PX4). A suíte de testes de navegação
+é `examples/simulation/sitl_test.py`.
+
+## Referências
+
+- [ArduPilot SITL](https://ardupilot.org/dev/docs/sitl-simulator-software-in-the-loop.html)
+- [ArduPilot SITL com Gazebo](https://ardupilot.org/dev/docs/sitl-with-gazebo.html)
+- [Plugin ardupilot_gazebo](https://github.com/ArduPilot/ardupilot_gazebo)
+- [Gazebo Harmonic](https://gazebosim.org/docs/harmonic)
+- [Sensores do Gazebo](https://gazebosim.org/api/sensors)
+- [ros_gz_bridge](https://github.com/ros-gz/ros_gz)
+- [MAVROS](https://github.com/mavlink/mavros)
+- [EKF3 do ArduPilot](https://ardupilot.org/copter/docs/common-apm-navigation-extended-kalman-filter-overview.html)
+- [Configuração VIO do ArduPilot](https://ardupilot.org/copter/docs/common-vio-tracking-camera.html)
+- [Rangefinders do ArduPilot](https://ardupilot.org/copter/docs/common-rangefinder-landingpage.html)

--- a/i18n/pt/modules/utils.md
+++ b/i18n/pt/modules/utils.md
@@ -1,0 +1,283 @@
+# Módulo de Utilitários
+
+Funções utilitárias compartilhadas para gerenciamento de processos, cálculos de GPS e operações de posição.
+
+## Componentes
+
+| Arquivo | Descrição |
+|------|-------------|
+| `process.py` | Gerenciamento do ciclo de vida de processos e checagens do grafo do ROS 2 (tmux/gnome-terminal) |
+| `gps_calculate.py` | Transformações de coordenadas GPS e cálculos de distância |
+| `position_utils.py` | Conversões e transformações de posição/orientação |
+| `log.py` | Helpers de cor/símbolo ANSI para saída de log no terminal (`OK`, `ERR`, `WARN`, `ARROW`) |
+
+## ProcessUtils
+
+Gerencia processos externos com tmux ou fallback para gnome-terminal.
+
+### API
+
+| Método | Descrição |
+|--------|-------------|
+| `is_gui_available()` | Verifica se o gnome-terminal está disponível |
+| `get_ros2_nodes(timeout)` | Obtém a lista de nomes de nós ROS2 em execução |
+| `is_node_running(node_pattern, timeout)` | Verifica se um nó ROS2 correspondente ao padrão está em execução |
+| `wait_for_node(node_pattern, timeout, poll_interval)` | Espera um nó ROS2 aparecer |
+| `get_ros2_topics(timeout)` | Obtém a lista de nomes de tópicos ROS 2 anunciados |
+| `is_topic_present(topic_pattern, timeout)` | Verifica se um tópico correspondente ao padrão está anunciado |
+| `wait_for_topic(topic_pattern, timeout, poll_interval)` | Espera um tópico ROS 2 aparecer |
+| `start_process(command, name, gui)` | Inicia um comando em uma sessão tmux ou terminal |
+| `has_process(name)` | Verifica se a sessão tmux existe |
+| `kill_process(name)` | Termina a sessão tmux |
+
+### Uso
+
+```python
+from nectar.utils.process import ProcessUtils
+
+# Check if ROS2 node is running
+
+if ProcessUtils.is_node_running("mavros_node"):
+    print("MAVROS node is running")
+
+# Start a ROS2 node in background
+
+ProcessUtils.start_process(
+    command="ros2 launch mavros apm.launch fcu_url:=serial:///dev/ttyUSB0:921600",
+    name="mavros_node",
+    gui=False  # Use tmux (headless)
+)
+
+# Wait for node to appear
+
+if ProcessUtils.wait_for_node("mavros_node", timeout=10.0):
+    print("MAVROS node started")
+
+# Wait for a topic before connecting
+
+if ProcessUtils.wait_for_topic("/mavros/local_position/pose", timeout=10.0):
+    print("Local position topic is live")
+
+# Check if tmux session exists
+
+if ProcessUtils.has_process("mavros_node"):
+    print("MAVROS session exists")
+
+# Stop the process
+
+ProcessUtils.kill_process("mavros_node")
+```
+
+### Comportamento
+
+- `start_process()` verifica se já existe uma sessão tmux e a mata antes de iniciar
+- `kill_process()` retorna True se a sessão não existir (sem erro)
+- Todos os métodos usam o módulo de logging do Python (sem instruções print)
+- A detecção de nós ROS2 usa o comando `ros2 node list`
+- A detecção de tópicos usa o comando `ros2 topic list`
+
+## Helpers de log
+
+`log.py` fornece símbolos coloridos em ANSI para saída de CLI. Eles se autodesabilitam quando o stderr não é um
+TTY, quando `NO_COLOR` está definido, ou quando `RCUTILS_COLORIZED_OUTPUT=0` (convenção do ROS 2).
+
+```python
+from nectar.utils.log import OK, ERR, WARN, ARROW
+
+print(f"{OK} Driver started")
+print(f"{ERR} Connection failed")
+print(f"{WARN} Retrying...")
+print(f"{ARROW} Next step: arm")
+```
+
+## Utilitários de GPS
+
+Cálculos de coordenadas geográficas usando [geographiclib](https://geographiclib.sourceforge.io/) para operações geodésicas.
+
+### Classe GPSCalculate
+
+Classe utilitária estática para cálculos de coordenadas GPS.
+
+| Método | Descrição |
+|--------|-------------|
+| `haversine(lat1, lon1, lat2, lon2)` | Distância entre pontos GPS usando a fórmula de Haversine (metros) |
+| `bearing(lat1, lon1, lat2, lon2)` | Ângulo de rumo inicial entre pontos (graus, 0-360°) |
+| `calculate_gps_offset(x, y, z, lat, lon, alt, heading)` | Calcula novas coordenadas GPS a partir de um offset em metros |
+| `interp_geo(start, end, frac)` | Interpolação geodésica entre duas coordenadas GPS |
+| `generate_point_grid(vertices, grid_shape)` | Gera uma grade 2D de coordenadas GPS dentro de uma área quadrilateral |
+
+### Uso
+
+```python
+from nectar.utils.gps_calculate import GPSCalculate
+
+# Calculate distance between two GPS coordinates
+
+dist = GPSCalculate.haversine(-27.1234, -48.4567, -27.1245, -48.4578)
+print(f"Distance: {dist:.2f} m")
+
+# Calculate bearing
+
+bearing = GPSCalculate.bearing(-27.1234, -48.4567, -27.1245, -48.4578)
+print(f"Bearing: {bearing:.1f}°")
+
+# Calculate GPS offset
+
+new_lat, new_lon, new_alt = GPSCalculate.calculate_gps_offset(
+    x=10.0,  # 10 meters east
+    y=5.0,   # 5 meters north
+    z=2.0,   # 2 meters up
+    latitude=-27.1234,
+    longitude=-48.4567,
+    altitude=100.0,
+    heading=45.0  # degrees
+)
+
+# Interpolate between GPS points
+
+midpoint = GPSCalculate.interp_geo(
+    start=(-27.1234, -48.4567),
+    end=(-27.1245, -48.4578),
+    frac=0.5  # 50% of the way
+)
+
+# Generate grid of GPS points
+
+vertices = (
+    (-27.1234, -48.4567),  # top-left
+    (-27.1234, -48.4578),  # top-right
+    (-27.1245, -48.4578),  # bottom-right
+    (-27.1245, -48.4567),  # bottom-left
+)
+grid = GPSCalculate.generate_point_grid(vertices, grid_shape=(10, 10))
+```
+
+### Precisão: Haversine vs Geodésica
+
+`PositionUtils.get_body_distance()` usa `Geodesic.WGS84.Inverse` ([Karney 2013](https://doi.org/10.1007/s00190-012-0578-z)) para distância e rumo GPS. Haversine (esférica, R=6371km) permanece em `GPSCalculate` para uso geral.
+
+Pontos posicionados em distâncias exatas conhecidas usando `Geodesic.WGS84.Direct` (precisão de ~15nm). Os dois métodos então calculam a distância. Veja o [script de benchmark completo](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/experiments/benchmark_geodesic_vs_haversine.py).
+
+**Erro de distância** (contra distâncias exatas conhecidas):
+
+| Distância | Erro geodésico | Erro Haversine | Haversine % |
+|----------|---------------:|----------------:|------------:|
+| 1m N | 0,80 nm | 0,35 cm | 0,353% |
+| 1m E | 0,09 nm | 0,18 cm | 0,181% |
+| 5m N | 0,10 nm | 1,77 cm | 0,353% |
+| 10m E | 0,14 nm | 1,81 cm | 0,181% |
+| 50m N | 0,16 nm | 17,66 cm | 0,353% |
+| 100m E | 0,02 nm | 18,08 cm | 0,181% |
+| 1km | 0,00 nm | 1,23 m | 0,123% |
+| 5km | 0,00 nm | 17,68 m | 0,354% |
+| 100km | 0,00 nm | 121,91 m | 0,122% |
+| 500km | 0,00 nm | 2138,93 m | 0,428% |
+
+O erro do Haversine é (0,1%–0,43%), causado pelo achatamento da Terra (1/298). Ele subestima distâncias equatoriais (~0,11%) e polares (~0,45%) porque o raio de curvatura real difere da esfera média.
+
+**Erro de rumo**: A geodésica é exata (0,000000°). O Haversine tem erro < 0,2° em casos típicos.
+
+**Tempo de execução** (média sobre 10.000 iterações):
+
+| Escala | Haversine+Bearing | Geodesic.Inverse | Razão |
+|-------|------------------:|-----------------:|------:|
+| 1m | 18 µs | 37 µs | 2,1x |
+| 10m | 17 µs | 93 µs | 5,4x |
+| 1km | 22 µs | 38 µs | 1,7x |
+| 100km | 18 µs | 93 µs | 5,1x |
+| 5570km | 18 µs | 152 µs | 8,4x |
+
+Os dois são desprezíveis para um loop PID de 100Hz (orçamento de 10ms). O pior caso da geodésica é < 200µs.
+
+## Utilitários de posição
+
+Transformações de coordenadas, conversões de rotação e utilitários de mensagens ROS.
+
+### Classe PositionUtils
+
+Classe utilitária estática para operações de posição e orientação.
+
+| Método | Descrição |
+|--------|-------------|
+| `get_body_distance(target, current, heading)` | Calcula a distância da posição atual até o alvo em coordenadas de frame de corpo (body) |
+| `get_yaw_from_pose(pose)` | Extrai o ângulo de yaw de uma mensagem de pose do ROS (radianos) |
+| `compute_yaw_error(target_yaw, current_yaw, threshold)` | Calcula o erro de yaw pelo caminho mais curto, em radianos, com deadband opcional |
+| `convert_position_to_target(pose, heading, lidar)` | Converte mensagens de posição para tipos de mensagem de alvo (target) |
+| `transform_takeoff_to_body_velocities(vx, vy, vz, current_yaw, takeoff_yaw)` | Transforma velocidades do frame de takeoff para o frame de corpo |
+
+### Uso
+
+```python
+from nectar.utils.position_utils import PositionUtils
+from geometry_msgs.msg import PoseStamped
+from mavros_msgs.msg import PositionTarget
+
+# Calculate body frame distance
+
+dx_body, dy_body, dz_body = PositionUtils.get_body_distance(
+    target=target_position,  # PositionTarget or GeoPoseStamped
+    current=current_pose,     # PoseStamped, PoseWithCovarianceStamped, or NavSatFix
+    heading=45.0  # degrees (required for NavSatFix)
+)
+
+# Extract yaw from pose
+
+yaw = PositionUtils.get_yaw_from_pose(pose_message)  # radians
+
+# Compute yaw error (shortest path, wrapped to [-pi, pi])
+
+import numpy as np
+dyaw = PositionUtils.compute_yaw_error(target_yaw=1.0, current_yaw=0.5)  # radians
+dyaw = PositionUtils.compute_yaw_error(1.0, 0.5, threshold=np.radians(3))  # with deadband
+
+# Convert position to target message
+
+target = PositionUtils.convert_position_to_target(
+    pose=current_pose,
+    heading=45.0,  # degrees, required for NavSatFix
+    lidar=2.5  # optional altitude override
+)
+
+# Transform velocities from takeoff frame to body frame
+
+vx_body, vy_body, vz_body = PositionUtils.transform_takeoff_to_body_velocities(
+    vx=1.0,
+    vy=0.5,
+    vz=0.0,
+    current_yaw=0.785,  # radians (45°)
+    takeoff_yaw=0.0     # radians
+)
+```
+
+### Tipos de mensagem suportados
+
+**PositionUtils.get_body_distance()**:
+
+- `target`: `PositionTarget` (local) ou `GeoPoseStamped` (GPS)
+- `current`: `PoseStamped` ou `PoseWithCovarianceStamped` (local) ou `NavSatFix` (GPS)
+
+**PositionUtils.get_yaw_from_pose()**:
+
+- `PoseStamped`, `PoseWithCovarianceStamped`, `GeoPoseStamped`, ou `PositionTarget`
+
+**PositionUtils.compute_yaw_error()**:
+
+- `target_yaw`, `current_yaw`: floats em radianos
+- `threshold`: deadband opcional em radianos (erros abaixo desse valor retornam 0.0)
+
+**PositionUtils.convert_position_to_target()**:
+
+- `PoseStamped` / `PoseWithCovarianceStamped` → `PositionTarget` (local)
+- `NavSatFix` → `GeoPoseStamped` (GPS, exige heading)
+
+## Dependências
+
+| Pacote | Finalidade |
+|---------|---------|
+| `geographiclib` | Cálculos geodésicos (elipsoide WGS84) |
+| `tf_transformations` | Conversões de quaternion/Euler do ROS |
+| `numpy` | Operações com arrays |
+| `geographic_msgs` | Tipos de mensagem GPS do ROS |
+| `geometry_msgs` | Tipos de mensagem de pose do ROS |
+| `mavros_msgs` | Tipos de mensagem do MAVROS |
+| `sensor_msgs` | Tipos de mensagem de sensores do ROS |

--- a/i18n/pt/modules/vision/algorithms.md
+++ b/i18n/pt/modules/vision/algorithms.md
@@ -1,0 +1,469 @@
+# Visão — Algoritmos
+
+Algoritmos de processamento de imagem que rodam sobre frames de qualquer [câmera](../camera/):
+marcadores ArUco, filtragem de cor, detecção de linha, regressão de distância e tracking de
+mão/face com MediaPipe. Cada um é uma classe pequena que você constrói uma vez e chama a cada
+frame.
+
+Veja também: [Cameras](../camera/) · [ROS 2 nodes](../nodes/) ·
+[Vision overview](../).
+
+## Hierarquia de classes
+
+```mermaid
+classDiagram
+    class Aruco {
+        -camera_matrix ndarray
+        -camera_distortion ndarray
+        -aruco_detect Dictionary
+        -aruco_param DetectorParameters
+        +marker_dict int
+        +tag_size float
+        +detect(img, draw) tuple
+        +pose_estimate(img, draw) tuple
+        +calculateYawFromCorners(bbox) float
+        +aruco_config(marker_dict, tag_size)
+    }
+
+    class ColorDetector {
+        -mode str
+        -color_space ColorSpace
+        -color_values list
+        +mask ndarray
+        +result ndarray
+        +initTrackbars()
+        +getTrackValues() list
+        +filterColor(img)
+        +get_color_values(color_name) list
+        +saveColorValues()
+    }
+
+    class ColorSpace {
+        <<enumeration>>
+        HSV
+        LAB
+    }
+
+    class ILineEstimationMethod {
+        <<abstract>>
+        +estimate(img_detect, img_out, offset, draw, draw_color)* tuple
+    }
+
+    class HoughLinesP {
+        +estimate(img_detect, img_out, offset, draw, draw_color) tuple
+    }
+
+    class RotatedRect {
+        +estimate(img_detect, img_out, offset, draw, draw_color) tuple
+    }
+
+    class FitEllipse {
+        +estimate(img_detect, img_out, offset, draw, draw_color) tuple
+    }
+
+    class RansacLine {
+        +estimate(img_detect, img_out, offset, draw, draw_color) tuple
+    }
+
+    class AdaptiveHoughLinesP {
+        +estimate(img_detect, img_out, offset, draw, draw_color) tuple
+    }
+
+    class LineDetector {
+        -color_detector ColorDetector
+        -estimation_method ILineEstimationMethod
+        -prev_angle float
+        +detect_line(img, region, draw, draw_color) tuple
+        +set_text_positions(positions_dict)
+    }
+
+    ColorDetector --> ColorSpace
+    ILineEstimationMethod <|.. HoughLinesP
+    ILineEstimationMethod <|.. RotatedRect
+    ILineEstimationMethod <|.. FitEllipse
+    ILineEstimationMethod <|.. RansacLine
+    ILineEstimationMethod <|.. AdaptiveHoughLinesP
+    LineDetector o-- ColorDetector
+    LineDetector o-- ILineEstimationMethod
+```
+
+## Marcadores ArUco
+
+Detecta marcadores ArUco usando `cv2.aruco.ArucoDetector` e estima a posição do marcador mais o
+yaw via `cv2.aruco.estimatePoseSingleMarkers` (`pose_estimate` devolve a translação e um yaw
+derivado dos cantos; o vetor de rotação não é exposto).
+
+> **Nota:** a estimativa de pose exige a matriz intrínseca da câmera, obtida na [calibração de câmera](../camera/#calibracao-de-camera).
+
+```python
+Aruco(marker_dict: int, tag_size: float)
+
+bbox, marker_id = aruco.detect(img, draw=True)                  # detection only
+marker_id, translation, yaw = aruco.pose_estimate(img, draw=True)  # requires calibration
+```
+
+- `marker_dict`: tamanho do dicionário (4, 5, 6, 7 para 4x4, 5x5, ...)
+- `tag_size`: tamanho físico do marcador em metros
+- `pose_estimate` devolve o id do marcador (ou `None`), a `translation` [x, y, z] em metros
+  (frame da câmera), e o `yaw` em graus (0-360)
+
+```python
+from nectar.vision import Aruco
+
+aruco = Aruco(marker_dict=5, tag_size=0.05)  # 5x5, 5 cm
+marker_id, translation, yaw = aruco.pose_estimate(frame, draw=True)
+if marker_id is not None:
+    x, y, z = translation
+    print(f"Marker {marker_id}: x={x:.2f} y={y:.2f} z={z:.2f} yaw={yaw:.1f}")
+```
+
+## Detecção de cor
+
+Filtragem por espaço de cor usando `cv2.inRange()` com operações morfológicas. HSV (hue 0-179,
+saturation/value 0-255) e LAB (L 0-255, a/b 0-255) são suportados. Dois modos: `track`
+(calibração interativa por trackbar) e `preset` (carrega valores pré-calibrados de um JSON).
+
+```python
+ColorDetector(mode: str = "track", color: str = None, color_space: ColorSpace = ColorSpace.HSV)
+
+detector.filterColor(img)  # updates detector.mask and detector.result
+detector.initTrackbars()   # calibration window (track mode)
+detector.saveColorValues() # save calibration to JSON
+```
+
+```python
+from nectar.vision import ColorDetector, ColorSpace
+
+# track: tune thresholds live, press 's' to save
+
+detector = ColorDetector(mode="track", color_space=ColorSpace.HSV)
+detector.initTrackbars()
+
+# preset: load saved values from JSON
+
+detector = ColorDetector(mode="preset", color="red", color_space=ColorSpace.HSV)
+detector.filterColor(frame)
+mask = detector.mask
+```
+
+Arquivo de calibração (`color_calibration.json`):
+
+```json
+{
+    "red": {
+        "HSV": [[0, 100, 100], [10, 255, 255]],
+        "LAB": [[20, 150, 128], [255, 200, 200]]
+    },
+    "blue": {
+        "HSV": [[100, 100, 100], [130, 255, 255]]
+    }
+}
+```
+
+## Detecção de linha
+
+Detecção de linha baseada em cor: uma máscara binária do `ColorDetector` mais um método de
+estimação geométrica.
+
+| Método | Algoritmo | Quando usar |
+|--------|-----------|-------------|
+| `HoughLinesP` | `cv2.HoughLinesP` → `cv2.fitLine` nos pontos finais | Linhas finas, múltiplos segmentos a mesclar |
+| `RotatedRect` | `cv2.minAreaRect` no maior contorno | Linhas contínuas espessas, blob único |
+| `FitEllipse` | `cv2.fitEllipse` no contorno | Linhas curvas/em forma de arco |
+| `RansacLine` | `cv2.fitLine` com DIST_L2 nos pontos do contorno | Máscaras ruidosas com pixels outliers |
+| `AdaptiveHoughLinesP` | HoughLinesP com threshold a partir de `mean + std` da máscara | Iluminação variável |
+
+```python
+LineDetector(color: str, estimation_method: ILineEstimationMethod, color_space: ColorSpace = None)
+
+img, mask, cx, cy, angle, width, height = detector.detect_line(
+    img, region=(400, 300), draw=True, draw_color=(0, 255, 0)
+)
+```
+
+`detect_line` devolve a imagem anotada, a máscara binária da região, o centro da linha `cx, cy`
+em pixels, o `angle` em graus (-90 a 90), e a `width, height` média da linha em pixels.
+
+```python
+from nectar.vision import LineDetector, HoughLinesP, ColorSpace
+
+detector = LineDetector(color="blue", estimation_method=HoughLinesP, color_space=ColorSpace.HSV)
+result, mask, cx, cy, angle, w, h = detector.detect_line(frame, draw=True)
+if not math.isnan(cx):
+    print(f"Line at ({cx:.0f}, {cy:.0f}), angle {angle:.1f}")
+```
+
+## Estimativa de distância
+
+Converte uma medida em pixels para uma distância no mundo real usando modelos de regressão.
+
+> **Nota:** exige dados de calibração — pares `(distance_cm, pixel_value)` coletados em distâncias conhecidas.
+
+```mermaid
+classDiagram
+    class DistanceEstimator {
+        -_params Dict
+        -_models Dict~ModelType,EstimationModel~
+        -_model_type ModelType
+        +model EstimationModel
+        +model_type ModelType
+        +estimate(value, model_type) float
+        +estimate_batch(values, model_type) ndarray
+        +compare_methods(value) Dict~str,float~
+        +get_model(model_type) EstimationModel
+        +set_model_params(model_type, params)
+        +available_methods()$ list
+    }
+
+    class ModelCalibrator {
+        -pixels ndarray
+        -distances ndarray
+        -results Dict~ModelType,CalibrationResult~
+        +fit_model(model_type) CalibrationResult
+        +fit_all() Dict
+        +best_model(criterion) CalibrationResult
+        +save_params(path, default_method)
+        +print_results()
+        +plot(save_path)
+    }
+
+    class CalibrationResult {
+        <<dataclass>>
+        +model_type ModelType
+        +params Dict
+        +rmse float
+        +r2 float
+        +mae float
+        +aic float
+        +predictions ndarray
+        +name str
+    }
+
+    class ModelType {
+        <<enumeration>>
+        LINEAR
+        POLYNOMIAL
+        EXPONENTIAL
+        LOGARITHMIC
+        INVERSE_POWER
+        ROBUST_POLY2
+    }
+
+    class EstimationModel {
+        <<abstract>>
+        +estimate(value)* float
+        +fit(x, y)* Dict
+    }
+
+    class LinearModel {
+        +k float
+        +estimate(value) float
+        +fit(x, y) Dict
+    }
+
+    class PolynomialModel {
+        +coeffs list
+        +degree int
+        +estimate(value) float
+        +fit(x, y) Dict
+    }
+
+    class ExponentialModel {
+        +a float
+        +b float
+        +c float
+        +estimate(value) float
+        +fit(x, y) Dict
+    }
+
+    class LogarithmicModel {
+        +a float
+        +b float
+        +estimate(value) float
+        +fit(x, y) Dict
+    }
+
+    class InversePowerModel {
+        +k float
+        +p float
+        +estimate(value) float
+        +fit(x, y) Dict
+    }
+
+    class RobustPoly2Model {
+        +a float
+        +b float
+        +c float
+        +estimate(value) float
+        +fit(x, y) Dict
+    }
+
+    DistanceEstimator o-- EstimationModel
+    ModelCalibrator --> CalibrationResult
+    EstimationModel <|.. LinearModel
+    EstimationModel <|.. PolynomialModel
+    EstimationModel <|.. ExponentialModel
+    EstimationModel <|.. LogarithmicModel
+    EstimationModel <|.. InversePowerModel
+    EstimationModel <|.. RobustPoly2Model
+```
+
+| Modelo | Fórmula | Método de ajuste |
+|-------|---------|----------------|
+| `LINEAR` | d = k / pixels | Média de `distance × pixels` |
+| `POLYNOMIAL` | d = Σ(aᵢ × pixelsⁱ) | `np.polyfit` (mínimos quadrados) |
+| `EXPONENTIAL` | d = a × e^(-b×pixels) + c | `scipy.optimize.curve_fit` |
+| `LOGARITHMIC` | d = a × ln(pixels) + b | `scipy.optimize.curve_fit` |
+| `INVERSE_POWER` | d = k / pixels^p | `scipy.optimize.curve_fit` com bounds |
+| `ROBUST_POLY2` | d = a×pixels² + b×pixels + c | `sklearn.linear_model.HuberRegressor` (resistente a outliers) |
+
+Calibre uma vez, depois estime:
+
+```python
+from nectar.vision.algorithms.distance import ModelCalibrator
+from nectar.vision import DistanceEstimator, ModelType
+from pathlib import Path
+
+data = [(50, 32.2), (60, 28.5), (70, 24.2), (100, 21.6), (150, 16.8)]  # (distance_cm, pixels)
+calibrator = ModelCalibrator(data)
+calibrator.fit_all()
+calibrator.print_results()
+calibrator.save_params(Path("parameters.yaml"))
+calibrator.plot(Path("model_comparison.png"))
+
+estimator = DistanceEstimator(model_type=ModelType.POLYNOMIAL)
+distance_cm = estimator.estimate(21.6)                 # single
+distances = estimator.estimate_batch([15, 20, 25, 30]) # batch
+results = estimator.compare_methods(21.6)              # {model: distance}
+```
+
+## Tracking com MediaPipe
+
+Detecção de landmarks de mão e face em tempo real usando os modelos do MediaPipe.
+
+```mermaid
+classDiagram
+    class HandTrackerConfig {
+        <<dataclass>>
+        +model_path Optional~str~
+        +num_hands int
+        +min_detection_confidence float
+        +min_presence_confidence float
+        +min_tracking_confidence float
+        +running_mode str
+    }
+
+    class HandResult {
+        <<dataclass>>
+        +landmarks list
+        +world_landmarks list
+        +handedness str
+        +confidence float
+    }
+
+    class HandTracker {
+        -_config HandTrackerConfig
+        -_detector HandLandmarker
+        +is_running bool
+        +start()
+        +close()
+        +detect(frame, draw) ndarray
+        +get_hands() List~HandResult~
+        +raised_fingers(hand_idx) List~int~
+        +get_landmarks(hand_idx, landmark_ids) list
+        +find_distance(l1, l2, image, hand_idx, draw) tuple
+        +estimate_depth(hand_idx, width, height) float
+    }
+
+    class FaceMeshTrackerConfig {
+        <<dataclass>>
+        +model_path Optional~str~
+        +num_faces int
+        +min_detection_confidence float
+        +min_presence_confidence float
+        +min_tracking_confidence float
+        +output_blendshapes bool
+        +running_mode str
+    }
+
+    class FaceResult {
+        <<dataclass>>
+        +landmarks list
+        +blendshapes Optional~list~
+    }
+
+    class FaceMeshTracker {
+        -_config FaceMeshTrackerConfig
+        -_detector FaceLandmarker
+        +is_running bool
+        +start()
+        +close()
+        +detect(frame, draw) ndarray
+        +draw_region(image, landmark_indices, color, radius) ndarray
+        +get_faces() List~FaceResult~
+        +get_landmarks(face_idx, landmark_ids) list
+        +get_eye_aspect_ratio(eye, face_idx) float
+        +get_mouth_aspect_ratio(face_idx) float
+    }
+
+    HandTracker o-- HandTrackerConfig
+    HandTracker --> HandResult
+    FaceMeshTracker o-- FaceMeshTrackerConfig
+    FaceMeshTracker --> FaceResult
+```
+
+Os dois trackers compartilham a mesma forma: construa com uma config, use como context manager,
+chame `detect(frame, draw=True)` por frame, e depois leia os landmarks. `model_path=None` baixa
+o modelo automaticamente; `running_mode` é `"IMAGE"` (síncrono — resultados disponíveis
+imediatamente após `detect()`) ou `"LIVE_STREAM"` (assíncrono — resultados chegam via callback).
+Use `"IMAGE"` em scripts simples, a menos que você precise de um pipeline de callback de câmera
+ao vivo.
+
+**Tracking de mão** — 21 landmarks por mão, com reconhecimento de gestos por estado dos dedos:
+
+```python
+from nectar.vision import HandTracker, HandTrackerConfig
+
+with HandTracker(HandTrackerConfig(num_hands=2, running_mode="IMAGE")) as tracker:
+    tracker.detect(frame, draw=True)
+    fingers = tracker.raised_fingers()          # [thumb, index, middle, ring, pinky]
+    gestures = {
+        (0, 0, 0, 0, 0): "fist",
+        (1, 1, 1, 1, 1): "open_palm",
+        (0, 1, 0, 0, 0): "pointing",
+        (0, 1, 1, 0, 0): "peace",
+    }
+    gesture = gestures.get(tuple(fingers), "unknown")
+```
+
+**Tracking de face mesh** — 478 landmarks por face, com aspect ratios de olho/boca e extração de
+região:
+
+```python
+from nectar.vision import FaceMeshTracker, FaceMeshTrackerConfig, FaceLandmarkRegion
+
+with FaceMeshTracker(FaceMeshTrackerConfig(num_faces=1, running_mode="IMAGE")) as tracker:
+    tracker.detect(frame, draw=True)
+    if tracker.get_eye_aspect_ratio("left") < 0.15:
+        print("Blink detected")
+    left_eye = tracker.get_landmarks(landmark_ids=FaceLandmarkRegion.LEFT_EYE)
+    tracker.draw_region(frame, FaceLandmarkRegion.LEFT_EYE, color=(0, 255, 0))
+```
+
+## Optical flow
+
+`OpticalFlowEstimator` fornece estimativa de movimento esparsa e densa entre frames. Veja
+`examples/vision/optical_flow_example.py` para uma visualização executável.
+
+## Referências
+
+| Função / biblioteca | Documentação | Usado em |
+|--------------------|---------------|---------|
+| `cv2.aruco.ArucoDetector` | [ArUco Detection](https://docs.opencv.org/4.x/d5/dae/tutorial_aruco_detection.html) | `Aruco.detect()` |
+| `cv2.aruco.estimatePoseSingleMarkers` | [ArUco Pose](https://docs.opencv.org/4.x/d9/d6a/group__aruco.html#ga84dd2e88f3e8c3255eb78e0f79571571) | `Aruco.pose_estimate()` |
+| `cv2.inRange`, `cv2.morphologyEx` | [Thresholding](https://docs.opencv.org/4.x/da/d97/tutorial_threshold_inRange.html) | `ColorDetector.filterColor()` |
+| `cv2.HoughLinesP`, `cv2.fitLine` | [Hough Line Transform](https://docs.opencv.org/4.x/d9/db0/tutorial_hough_lines.html) | `HoughLinesP`, `RansacLine` |
+| `cv2.minAreaRect`, `cv2.fitEllipse` | [Contour Features](https://docs.opencv.org/4.x/d3/dc0/group__imgproc__shape.html) | `RotatedRect`, `FitEllipse` |
+| MediaPipe Hand Landmarker | [docs](https://ai.google.dev/edge/mediapipe/solutions/vision/hand_landmarker) | `HandTracker` |
+| MediaPipe Face Landmarker | [docs](https://ai.google.dev/edge/mediapipe/solutions/vision/face_landmarker) | `FaceMeshTracker` |
+| `numpy.polyfit` / `scipy.optimize.curve_fit` / `sklearn.HuberRegressor` | [numpy](https://numpy.org/doc/stable/reference/generated/numpy.polyfit.html) · [scipy](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html) · [sklearn](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.HuberRegressor.html) | distance models |

--- a/i18n/pt/modules/vision/camera.md
+++ b/i18n/pt/modules/vision/camera.md
@@ -1,0 +1,597 @@
+# Visão — Câmeras
+
+Camada de abstração de câmeras para o módulo de visão. A `CameraFactory` abre qualquer câmera
+suportada por meio de uma interface comum; o `ImageHandler` transforma uma câmera em um stream
+ROS 2 orientado a callback.
+
+Todas as câmeras implementam `AbstractCam` (`start` / `get_frame` / `close`); câmeras com
+capacidade de profundidade acrescentam `DepthCam` (`get_depth_frame` / `get_distance`).
+
+Veja também: [Algorithms](../algorithms/) · [ROS 2 nodes](../nodes/) ·
+[Vision overview](../).
+
+## Hierarquia de classes
+
+```mermaid
+classDiagram
+    class CameraFactory {
+        <<singleton>>
+        -_builders Dict~str,Type~
+        +register(key, builder)$
+        +from_source(source, config, node)$ AbstractCam
+    }
+
+    class AbstractCam {
+        <<abstract>>
+        -_name str
+        -_is_running bool
+        +name str
+        +is_running bool
+        +start()*
+        +get_frame()* Optional~ndarray~
+        +close()*
+    }
+
+    class DepthCam {
+        <<abstract>>
+        +get_depth_frame()* Optional~ndarray~
+        +get_distance(u, v)* Optional~float~
+    }
+
+    class OpenCVCam {
+        -_cap VideoCapture
+        -_config OpenCVConfig
+        +actual_settings dict
+        +start()
+        +get_frame() Optional~ndarray~
+        +close()
+    }
+
+    class RealsenseCam {
+        -_pipeline Pipeline
+        -_align Align
+        -_depth_scale float
+        -_use_ros_topics bool
+        +start()
+        +get_frame(wait_for_new, timeout) Optional~ndarray~
+        +get_depth_frame(wait_for_new, timeout) Optional~ndarray~
+        +get_distance(u, v) Optional~float~
+        +close()
+    }
+
+    class OakdCam {
+        -_pipeline Pipeline
+        -_config OakDConfig
+        +start()
+        +get_frame() Optional~ndarray~
+        +get_depth_frame() Optional~ndarray~
+        +get_distance(u, v) Optional~float~
+        +close()
+    }
+
+    class ROSCam {
+        -_node Node
+        -_config ROSConfig
+        -_bridge CvBridge
+        -_frame Optional~ndarray~
+        -_sub Subscription
+        +start()
+        +get_frame(wait_for_new, timeout) Optional~ndarray~
+        +close()
+    }
+
+    class ROSDepthCam {
+        -_node Node
+        -_config ROSDepthConfig
+        -_color_cam ROSCam
+        -_depth Optional~ndarray~
+        +start()
+        +get_frame(wait_for_new, timeout) Optional~ndarray~
+        +get_depth_frame(wait_for_new, timeout) Optional~ndarray~
+        +get_distance(u, v, color_shape) Optional~float~
+        +close()
+    }
+
+    class FileImageCam {
+        -_config FileImageConfig
+        -_frame Optional~ndarray~
+        +start()
+        +get_frame() Optional~ndarray~
+        +reload() bool
+        +close()
+    }
+
+    class C920Cam {
+        -_config C920Config
+        +start()
+        +get_frame() Optional~ndarray~
+        +close()
+    }
+
+    class IMX219Cam {
+        -_config IMX219Config
+        +start()
+        +get_frame() Optional~ndarray~
+        +close()
+    }
+
+    class T265Cam {
+        -_pipeline Pipeline
+        -_stereo StereoSGBM
+        -_config T265Config
+        +start()
+        +get_frame() Optional~ndarray~
+        +get_depth_frame() Optional~ndarray~
+        +get_distance(u, v) Optional~float~
+        +get_stereo_frames() tuple
+        +get_pose() T265Pose
+        +get_rectified_frames() tuple
+        +close()
+    }
+
+    class ImageHandler {
+        +node Node
+        +image_source str
+        +img ndarray
+        +camera AbstractCam
+        +poll_interval float
+        -_frame_timeout float
+        -cam_timer Timer
+        +open()
+        +close()
+        +run()
+        +take_photo(timeout, wait_for_new) Any
+        +process()
+        +cleanup()
+    }
+
+    AbstractCam <|-- DepthCam
+    AbstractCam <|-- OpenCVCam
+    AbstractCam <|-- ROSCam
+    AbstractCam <|-- FileImageCam
+    AbstractCam <|-- C920Cam
+    AbstractCam <|-- IMX219Cam
+    DepthCam <|-- RealsenseCam
+    DepthCam <|-- OakdCam
+    DepthCam <|-- ROSDepthCam
+    DepthCam <|-- T265Cam
+    ROSDepthCam *-- ROSCam
+    CameraFactory ..> AbstractCam : creates
+    ImageHandler o-- AbstractCam
+    ImageHandler ..> CameraFactory : uses
+```
+
+## CameraFactory
+
+Cria instâncias de câmera a partir de um identificador de fonte, detectando automaticamente o
+tipo de fonte.
+
+```python
+CameraFactory.from_source(source: str, *, config: CameraConfig = None, node: Node = None) -> AbstractCam
+CameraFactory.register(key: str, builder: Type[AbstractCam])
+```
+
+**Fontes registradas**:
+
+| Chave | Classe de câmera | Descrição |
+|-----|--------------|-------------|
+| `webcam` | `OpenCVCam` | Webcams USB genéricas |
+| `opencv` | `OpenCVCam` | Alias para webcam |
+| `realsense` | `RealsenseCam` | Intel RealSense D4xx (cor + profundidade via pyrealsense2) |
+| `t265` | `T265Cam` | Intel RealSense T265 (fisheye + profundidade estéreo + pose 6DOF) |
+| `oakd` | `OakdCam` | Câmeras Luxonis OAK-D |
+| `c920` | `C920Cam` | Logitech C920/C920e |
+| `imx219` | `IMX219Cam` | Raspberry Pi Camera v2 (Jetson) |
+| `ros` | `ROSCam` | Tópicos de imagem ROS 2 |
+| `ros_depth` | `ROSDepthCam` | Tópicos de imagem ROS 2 cor + profundidade |
+| `file` | `FileImageCam` | Arquivos de imagem estáticos |
+
+Detecção automática: um caminho de arquivo resolve para `FileImageCam`, uma fonte que começa com
+`/` resolve para `ROSCam`, e qualquer chave registrada resolve para sua câmera correspondente.
+
+```python
+from nectar.vision import CameraFactory, OpenCVConfig
+
+camera = CameraFactory.from_source("webcam")
+camera = CameraFactory.from_source("webcam", config=OpenCVConfig(width=1280, height=720, fps=30))
+camera = CameraFactory.from_source("/camera/image_raw", node=node)   # ROS topic
+camera = CameraFactory.from_source("/path/to/image.jpg")             # file
+```
+
+## ImageHandler
+
+Interface de câmera baseada em timer, apoiada por um `Node` ROS 2 interno (registrado no
+executor de runtime do SDK — veja
+[`nectar.runtime`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/runtime.py)).
+Invoca um callback de processamento em cada frame e, opcionalmente, renderiza em uma janela
+OpenCV.
+
+```python
+ImageHandler(
+    image_source: str,
+    image_processing_callback: Callable = None,
+    show_result: str = None,             # OpenCV window name
+    *,
+    config: CameraConfig = None,
+    camera: AbstractCam = None,          # pre-configured camera
+    poll_interval: float = 0.01,         # timer period (seconds)
+    frame_timeout: float = 0.1,          # frame wait timeout (async)
+    executor: Executor = None,           # defaults to nectar.runtime executor
+)
+```
+
+| Método | Finalidade |
+|--------|---------|
+| `run()` | Inicia a captura contínua de frames com o timer |
+| `open()` | Inicialização manual da câmera |
+| `close()` | Interrompe a câmera |
+| `take_photo(timeout_sec=1.0, wait_for_new=True)` | Captura única (single-shot) |
+| `cleanup()` | Libera a câmera, destrói o timer, desregistra o nó interno |
+
+```python
+import nectar
+from nectar.vision import ImageHandler, OpenCVConfig
+
+nectar.init()
+handler = ImageHandler(
+    image_source="webcam",
+    config=OpenCVConfig(width=1280, height=720),
+    image_processing_callback=lambda frame: detector.detect(frame),
+    show_result="Camera View",
+)
+handler.run()
+nectar.spin()
+```
+
+## AbstractCam e DepthCam
+
+`AbstractCam` é a classe base para todo driver; `DepthCam` a estende para câmeras RGB-D.
+
+```python
+class AbstractCam(ABC):
+    name: str                              # camera identifier
+    is_running: bool                       # capture status
+
+    def start() -> None                    # initialize camera
+    def get_frame() -> Optional[ndarray]   # capture BGR frame
+    def close() -> None                    # release resources
+
+class DepthCam(AbstractCam):
+    def get_depth_frame() -> Optional[ndarray]           # depth in meters (float32)
+    def get_distance(u: int, v: int) -> Optional[float]  # distance at pixel
+```
+
+## Classes de configuração
+
+Cada driver recebe uma config em dataclass, subclasse de `CameraConfig`.
+
+```mermaid
+classDiagram
+    class CameraConfig {
+        <<dataclass>>
+        +name str
+    }
+
+    class OpenCVConfig {
+        <<dataclass>>
+        +device_index int
+        +width Optional~int~
+        +height Optional~int~
+        +fps Optional~int~
+        +fourcc Optional~str~
+        +autofocus Optional~bool~
+        +focus Optional~int~
+        +buffer_size Optional~int~
+        +threaded bool
+    }
+
+    class RealSenseConfig {
+        <<dataclass>>
+        +color_res Tuple~int,int~
+        +depth_res Tuple~int,int~
+        +fps int
+        +align_to_color bool
+        +enable_depth bool
+        +use_ros_topics bool
+        +color_topic str
+        +depth_topic str
+        +color_compressed bool
+        +depth_compressed bool
+    }
+
+    class OakDConfig {
+        <<dataclass>>
+        +cam_num int
+        +enable_depth bool
+    }
+
+    class ROSConfig {
+        <<dataclass>>
+        +topic str
+        +compressed bool
+        +reliability QoSReliability
+        +durability QoSDurability
+        +history_depth int
+        +encoding str
+    }
+
+    class ROSDepthConfig {
+        <<dataclass>>
+        +depth_topic str
+        +depth_compressed bool
+        +depth_encoding str
+        +enable_depth bool
+    }
+
+    class C920Config {
+        <<dataclass>>
+        +profile int
+        +fallback_device_index int
+    }
+
+    class IMX219Config {
+        <<dataclass>>
+        +sensor_id int
+        +width int
+        +height int
+        +fps int
+        +flip int
+    }
+
+    class FileImageConfig {
+        <<dataclass>>
+        +path str
+    }
+
+    class T265Config {
+        <<dataclass>>
+        +enable_pose bool
+        +enable_depth bool
+        +stereo_fov_deg float
+        +stereo_height_px int
+        +num_disparities int
+        +block_size int
+        +use_ros_topics bool
+        +fisheye1_topic str
+        +fisheye2_topic str
+        +pose_topic str
+    }
+
+    CameraConfig <|-- T265Config
+    CameraConfig <|-- OpenCVConfig
+    CameraConfig <|-- RealSenseConfig
+    CameraConfig <|-- OakDConfig
+    CameraConfig <|-- ROSConfig
+    CameraConfig <|-- C920Config
+    CameraConfig <|-- IMX219Config
+    CameraConfig <|-- FileImageConfig
+    ROSConfig <|-- ROSDepthConfig
+```
+
+## Câmera de tracking T265 {#t265-tracking-camera}
+
+A T265 tem duas câmeras fisheye global-shutter de 848x800 (30 Hz), uma IMU BMI055 (giroscópio a
+200 Hz, acelerômetro a 62 Hz), e um VPU Movidius Myriad 2 embarcado rodando V-SLAM, que emite pose
+6DOF a 200 Hz.
+
+Não é uma câmera de profundidade. A `T265Cam` computa profundidade estéreo no host a partir do
+par fisheye, usando o StereoSGBM do OpenCV com correção de distorção fisheye Kannala-Brandt,
+seguindo a referência
+[librealsense t265_stereo.py](https://github.com/IntelRealSense/librealsense/blob/v2.53.1/wrappers/python/examples/t265_stereo.py).
+O alcance efetivo de profundidade é de ~0,3-3 m, dada a baseline de 64 mm.
+
+**Modos de acesso**:
+
+| Modo | `use_ros_topics` | Quando usar |
+|------|-------------------|-------------|
+| Direto | `False` | T265 dedicada ao SDK. Usa o pipeline baseado em callback do pyrealsense2. |
+| Tópicos ROS | `True` | `realsense2_camera` já em execução. Assina os tópicos de fisheye + CameraInfo + pose. |
+
+> **Aviso:** quando o `realsense2_camera` detém o dispositivo USB, o modo direto falha. Use o modo de tópicos ROS para compartilhar a câmera.
+
+O pipeline de profundidade estéreo roda uma vez em `start()` (intrínsecos/extrínsecos
+Kannala-Brandt a partir dos perfis do pyrealsense2 ou de `CameraInfo`, mapas de undistort/rectify,
+matrizes de projeção/reprojeção), e depois por frame em `get_depth_frame()` (remapeia o par
+fisheye, roda o `cv2.StereoSGBM`, converte disparidade em profundidade via
+`depth = focal * baseline / disparity`).
+
+**`T265Config`**:
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|---------|-------------|
+| `enable_pose` | bool | `True` | Assina/captura o stream de pose 6DOF |
+| `enable_depth` | bool | `True` | Computa profundidade estéreo a partir do par fisheye |
+| `stereo_fov_deg` | float | `90.0` | FOV de saída para as imagens estéreo rectificadas |
+| `stereo_height_px` | int | `300` | Altura de saída em pixels (largura = altura + max_disp) |
+| `num_disparities` | int | `96` | Faixa máxima de busca de disparidade do StereoSGBM (divisível por 16) |
+| `block_size` | int | `16` | Tamanho de bloco do StereoSGBM |
+| `use_ros_topics` | bool | `False` | `True`: assina tópicos ROS. `False`: pyrealsense2 direto. |
+| `fisheye1_topic` | str | `/camera/fisheye1/image_raw` | Tópico do fisheye esquerdo (modo ROS) |
+| `fisheye2_topic` | str | `/camera/fisheye2/image_raw` | Tópico do fisheye direito (modo ROS) |
+| `pose_topic` | str | `/camera/pose/sample` | Tópico de pose (modo ROS, Odometry ou PoseStamped) |
+
+**`T265Pose`** (devolvido por `get_pose()`):
+
+| Campo | Tipo | Descrição |
+|-------|------|-------------|
+| `translation` | ndarray (3,) | Posição [x, y, z] em metros |
+| `rotation` | ndarray (4,) | Quaternion [x, y, z, w] |
+| `velocity` | ndarray (3,) | Velocidade linear [vx, vy, vz] m/s |
+| `angular_velocity` | ndarray (3,) | Velocidade angular [wx, wy, wz] rad/s |
+| `tracker_confidence` | int | 0 (falhou) a 3 (alta) |
+| `timestamp` | float | Timestamp sincronizado com o host, em segundos |
+
+```python
+from nectar.vision import T265Cam, T265Config
+
+# Direct mode (T265 dedicated to the SDK)
+
+cam = T265Cam(T265Config(enable_depth=True, enable_pose=True))
+cam.start()
+frame = cam.get_frame()          # left fisheye (BGR, 800x848x3)
+depth = cam.get_depth_frame()    # stereo depth (float32, meters, 300x300)
+pose = cam.get_pose()            # T265Pose
+left, right = cam.get_stereo_frames()
+
+# ROS topic mode (realsense2_camera already running)
+
+cam = T265Cam(T265Config(use_ros_topics=True), node=node)
+cam.start()
+```
+
+**Opções de V-SLAM** (somente no modo direto, definidas no sensor de pose antes de
+`pipeline.start()`):
+
+| Opção | Nome no pyrealsense2 | Padrão | Descrição |
+|--------|-------------------|---------|-------------|
+| Mapeamento | `rs.option.enable_mapping` | 1 (ativo) | Mapa de features interno. Reduz o drift por meio de pequenos loop closures. |
+| Relocalização | `rs.option.enable_relocalization` | 1 (ativo) | Reconecta ao mapa após um grande drift. Pode causar saltos grandes de pose. |
+| Salto de pose | `rs.option.enable_pose_jumping` | 1 (ativo) | Permite correções de translação descontínuas. |
+| Preservação de mapa | `rs.option.enable_map_preservation` | 0 (inativo) | Preserva o mapa entre ciclos de stop/start. |
+
+> **Aviso:** para voo de drone com o EKF do ArduPilot, desative a relocalização e o salto de pose (o EKF não lida bem com teletransportes descontínuos de posição); mantenha o mapeamento ativado. Veja [PR #4321](https://github.com/IntelRealSense/librealsense/pull/4321), [realsense-ros #779](https://github.com/IntelRealSense/realsense-ros/issues/779).
+>
+> **Nota — versões do T265 e do RealSense:** o suporte a RealSense usa duas pilhas
+> independentes:
+>
+> 1. **Sistema / ROS (`make realsense`)** — compila o **librealsense** e o **realsense-ros** a
+>    partir do source. Sobrescreva as versões com `LIBREALSENSE_VERSION` e `REALSENSE_ROS_TAG`
+>    (os padrões por distro do ROS estão em `scripts/lib/config.sh`). Para a T265, descontinuada
+>    no Humble: `LIBREALSENSE_VERSION=v2.53.1 REALSENSE_ROS_TAG=4.51.1 make realsense`. Esse
+>    build também instala um **pyrealsense2** correspondente em `/usr/local/lib` (adicionado ao
+>    `PYTHONPATH`).
+> 2. **Extra do pip (`nectar-sdk[realsense]`)** — instala o **pyrealsense2 do PyPI ≥2.55** para
+>    o **modo direto D4xx** (`RealsenseCam`). O PyPI descontinuou o suporte à T265 (TM2) depois
+>    da versão 2.53.x; o extra do pip não é destinado à T265.
+>
+> Para a T265: use o **modo de tópicos ROS** (`T265Config(use_ros_topics=True)`) com as versões
+> de `make realsense` da T265 acima, ou o **modo direto** com o pyrealsense2 de um build source
+> v2.53.1 — não apenas o extra do pip isoladamente. Veja [RealSense setup](../../../setup/realsense/).
+
+## Calibração de câmera
+
+A calibração intrínseca computa a matriz de câmera 3×3 (fx, fy, cx, cy) e os coeficientes de
+distorção (k1, k2, p1, p2, k3). Um único nó `CameraCalibration` trata os dois padrões de
+tabuleiro e grava os arquivos de saída compartilhados (`camera_matrix.txt`,
+`camera_distortion.txt`), carregados via `load_calibration()`.
+
+| Padrão | Valor de `pattern` | Notas |
+|---------|-----------------|-------|
+| ChArUco (padrão, recomendado) | `charuco` | Precisão subpixel de tabuleiro de xadrez combinada com a robustez do ArUco a oclusão e visões parciais, então frames nas bordas da imagem ainda contribuem |
+| Chessboard | `chessboard` | Tabuleiro de xadrez impresso simples, totalmente visível em cada frame, com refinamento via `cornerSubPix` |
+
+**Modos de captura**:
+
+| Modo | Valor de `mode` | Comportamento |
+|------|--------------|----------|
+| Auto (padrão) | `auto` | Aceita uma view automaticamente quando o tabuleiro é detectado com pelo menos `min_corners_per_frame` cantos e `auto_interval` segundos tiverem passado. Para depois de `target_views`. |
+| Manual | `manual` | Acionado por teclas na janela de preview: `c` captura, `u` desfaz a última, `r` reseta tudo, `Enter` finaliza + calibra, `q` sai. Exige uma janela GUI; recorre ao modo auto quando nenhuma está disponível. |
+
+A janela de preview é opcional (`show_preview`), então o nó roda headless (por exemplo, em um
+Jetson via SSH). O progresso é logado no terminal nos dois modos.
+
+**Imprima o tabuleiro** (ChArUco): qualquer PDF de tabuleiro de
+[`carlosmccosta/charuco_detector`](https://github.com/carlosmccosta/charuco_detector/tree/master/boards/vector_format/black_and_white)
+em escala 100%. Os padrões correspondem ao PDF A4, 5×7, quadrado de 40 mm, marcador de 30 mm,
+DICT_4X4_1000. Cole a impressão em uma superfície rígida e plana. Impressoras rescalam ~0,5-2%,
+então meça N quadrados com um paquímetro após imprimir e calcule o tamanho real do quadrado; o
+comprimento do marcador escala pelo mesmo fator (30/40 = 0,75 para esse tabuleiro).
+
+```bash
+ros2 run nectar calibration.py                                          # auto ChArUco (default)
+ros2 run nectar calibration.py --ros-args -p width:=1920 -p height:=1080 # match production resolution
+
+ros2 run nectar calibration.py --ros-args \
+    -p pattern:=chessboard -p mode:=manual \
+    -p chessboard_cols:=9 -p chessboard_rows:=7 -p square_length:=0.025  # manual chessboard
+
+ros2 run nectar calibration.py --ros-args -p show_preview:=false         # headless
+```
+
+Calibre na mesma resolução que você vai usar em produção (os intrínsecos são específicos da
+resolução). Mova o tabuleiro para preencher diferentes regiões da imagem e use inclinações
+fortes (pitch/yaw ±30°), especialmente perto das bordas, onde a distorção é mais forte.
+
+**Parâmetros**:
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|---------|-------------|
+| `pattern` | string | `charuco` | Padrão do tabuleiro: `charuco` ou `chessboard` |
+| `mode` | string | `auto` | Modo de captura: `auto` ou `manual` |
+| `image_source` | string | `webcam` | Fonte de câmera (qualquer valor de `CameraFactory`) |
+| `device_index` | int | `0` | Índice do `VideoCapture` do OpenCV (só para `webcam`/`opencv`) |
+| `width` | int | `0` | Largura de captura solicitada; `0` mantém o padrão da câmera |
+| `height` | int | `0` | Altura de captura solicitada; `0` mantém o padrão da câmera |
+| `chessboard_cols` | int | `9` | Cantos internos em X (só chessboard) |
+| `chessboard_rows` | int | `7` | Cantos internos em Y (só chessboard) |
+| `squares_x` | int | `5` | Quadrados do tabuleiro em X (só charuco) |
+| `squares_y` | int | `7` | Quadrados do tabuleiro em Y (só charuco) |
+| `square_length` | float | `0.040` | Lado do quadrado medido em metros (paquímetro após imprimir) |
+| `marker_length` | float | `0.030` | Lado do marcador medido em metros (charuco; escala com `square_length`) |
+| `aruco_dict` | string | `DICT_4X4_1000` | Nome do dicionário predefinido (charuco); abreviação `4X4_1000` aceita |
+| `min_corners_per_frame` | int | `6` | Número mínimo de cantos exigido para aceitar um frame |
+| `target_views` | int | `20` | Views aceitas a coletar antes da calibração automática |
+| `auto_interval` | float | `0.75` | Segundos entre capturas automáticas (modo auto) |
+| `show_preview` | bool | `true` | Janela de preview ao vivo; desativada automaticamente quando não há GUI disponível |
+| `save_dataset` | bool | `true` | Também grava os frames aceitos em `dataset/` |
+| `output_dir` | string | `""` | Diretório de saída; vazio resolve para o diretório do pacote de calibração, para que `load_calibration()` o encontre |
+
+Procure obter `reprojection_error < 0.5 px` (logado após a calibração). Valores acima de 1,0 px
+disparam um aviso e geralmente indicam um tabuleiro flexionado, motion blur, ou baixa cobertura de
+poses.
+
+```python
+from nectar.vision.camera import CameraCalibration
+
+matrix, distortion = CameraCalibration.load_calibration()
+```
+
+## Geometria de imagem (ImageCalculus)
+
+Transformações de coordenadas de pixel para mundo, para câmeras voltadas para baixo, usando um
+modelo de câmera pinhole com aproximações de pequeno ângulo para compensação de pitch/roll.
+
+```python
+from nectar.vision.utils import ImageCalculus
+
+calc = ImageCalculus(
+    camera_offset={"forward": 0.1, "right": 0.0, "up": 0.0},   # meters
+    camera_resolution={"width": 1920, "height": 1080},
+    pixels_per_degree={"horizontal": 30, "vertical": 30},
+)
+
+# Ground intersection from a pixel -> (forward, right, down) in meters
+
+vector = calc.calculate_vector_from_drone_to_ground(
+    target_pixel=(640, 360), height=10.0, pitch=5.0, roll=2.0
+)
+
+# Pixel -> GPS
+
+lat, lon = ImageCalculus.estimate_pixel_gps(
+    origin_lat=-27.1234, origin_lon=-48.4567,
+    origin_row=540, origin_col=960,
+    target_row=300, target_col=800,
+    gsd=0.05, image_bearing=45.0,
+)
+
+# Meters -> pixel offset
+
+offset_px = ImageCalculus.calculate_offset_pixels(
+    offset_meters=0.1, height_meters=10.0, fov_degrees=60.0, image_pixels=1920
+)
+```
+
+## Referências
+
+| SDK | Documentação | Classe de câmera |
+|-----|---------------|--------------|
+| Intel RealSense (D4xx) | [RealSense SDK 2.0](https://dev.intelrealsense.com/docs/docs-get-started) | `RealsenseCam` |
+| Intel RealSense (T265) | [T265 docs](https://github.com/IntelRealSense/librealsense/blob/v2.53.1/doc/t265.md), [t265_stereo.py](https://github.com/IntelRealSense/librealsense/blob/v2.53.1/wrappers/python/examples/t265_stereo.py) | `T265Cam` |
+| DepthAI | [Luxonis DepthAI](https://docs.luxonis.com/software/) | `OakdCam` |
+| GStreamer | [nvarguscamerasrc](https://docs.nvidia.com/jetson/archives/r35.4.1/DeveloperGuide/text/SD/CameraDevelopment/CameraSoftwareDevelopmentSolution.html) | `IMX219Cam` |
+| `cv2.VideoCapture` | [Video I/O](https://docs.opencv.org/4.x/d8/dfe/classcv_1_1VideoCapture.html) | `OpenCVCam` |
+| `cv2.calibrateCamera` | [Camera Calibration](https://docs.opencv.org/4.x/dc/dbb/tutorial_py_calibration.html) | `CameraCalibration` |
+| `cv2.aruco.CharucoDetector` | [ChArUco Detection](https://docs.opencv.org/4.x/df/d4a/tutorial_charuco_detection.html) | `CameraCalibration` |
+| `sensor_msgs/Image`, `CompressedImage` | [sensor_msgs](https://docs.ros.org/en/humble/p/sensor_msgs/) | `ROSCam`, camera publisher node |
+| `cv_bridge` | [cv_bridge](https://github.com/ros-perception/vision_opencv/tree/humble) | `ROSCam` |

--- a/i18n/pt/modules/vision/index.md
+++ b/i18n/pt/modules/vision/index.md
@@ -1,0 +1,77 @@
+# Módulo de Visão
+
+Camada de abstração de câmeras e algoritmos de processamento de imagem para ROS 2. Uma `CameraFactory`
+abre qualquer câmera suportada por meio de uma interface comum, um `ImageHandler` a transforma em um
+stream orientado a callback, e um conjunto de algoritmos (ArUco, cor, linha, distância, MediaPipe)
+roda sobre os frames.
+
+## Resumo rápido
+
+```python
+import nectar
+from nectar.vision.camera import ImageHandler
+
+nectar.init()
+ImageHandler("webcam", image_processing_callback=lambda frame: print(frame.shape)).run()
+nectar.spin()
+nectar.shutdown()
+```
+
+Frame único (sem stream):
+
+```python
+from nectar.vision import CameraFactory
+
+cam = CameraFactory.from_source("webcam")
+cam.start()
+frame = cam.get_frame()
+cam.close()
+```
+
+Lado a lado com OpenCV / subscribers do ROS:
+[Com e sem Nectar](../../get-started/with-without.md)
+([with-without.md](../../get-started/with-without/)).
+
+## Documentação
+
+| Página | Escopo |
+|------|-------|
+| [Cameras](camera/) | `CameraFactory`, `ImageHandler`, `AbstractCam`/`DepthCam`, drivers, configs, T265, calibração, geometria de imagem |
+| [Algorithms](algorithms/) | ArUco, cor, linha, regressão de distância, mão/face MediaPipe, optical flow |
+| [ROS 2 nodes](nodes/) | Nós de ArUco, detecção de linha, calibração de cor e publisher de câmera |
+
+## Conceitos
+
+Duas camadas sustentam o módulo:
+
+- **Câmeras.** `CameraFactory.from_source(key)` devolve um driver que implementa `AbstractCam`
+  (`start` / `get_frame` / `close`); câmeras com profundidade acrescentam `DepthCam` (`get_depth_frame` /
+  `get_distance`). Veja [Cameras](camera/).
+- **Streaming + algoritmos.** `ImageHandler` envolve qualquer câmera em um nó ROS 2 acionado por
+  timer e chama seu callback de processamento em cada frame. O callback roda um [algoritmo](algorithms/)
+  (ArUco, cor, linha, distância, MediaPipe), ou você pode rodar os
+  [nós ROS 2](nodes/) prontos.
+
+Ambos compartilham o executor de runtime do SDK (veja [`nectar.runtime`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/runtime.py)), então o vision se compõe
+com o control e a AI em uma única missão.
+
+## Exemplos
+
+Veja `examples/vision/` para scripts completos e funcionais:
+
+| Exemplo | Descrição |
+|---------|-------------|
+| `camera_example.py` | Captura básica de câmera e configuração |
+| `depth_example.py` | Visualização de câmera de profundidade e distância (RealSense D4xx, OAK-D) |
+| `t265_example.py` | Fisheye T265 + profundidade estéreo + overlay de pose + medição por clique |
+| `optical_flow_example.py` | Visualização de optical flow esparso/denso |
+| `collect_photos.py` | Salva frames em intervalos para criação de dataset |
+
+## Estendendo o módulo
+
+- Drivers de câmera: adicione em `camera/drivers/`, herde de `AbstractCam` ou `DepthCam`, acrescente
+  uma dataclass de config em `camera/config.py`, e registre-a com `CameraFactory.register()` em
+  `camera/factory.py`.
+- Algoritmos: adicione em `algorithms/<category>/`.
+- Nós ROS 2: adicione em `nodes/`.
+- Exporte os símbolos públicos em `__init__.py`.

--- a/i18n/pt/modules/vision/nodes.md
+++ b/i18n/pt/modules/vision/nodes.md
@@ -1,0 +1,147 @@
+# Visão — Nós ROS 2
+
+Nós prontos para rodar que envolvem os [algoritmos](../algorithms/) e as [câmeras](../camera/)
+de visão como executáveis ROS 2 (`ros2 run nectar <node>.py`). Cada um controla um
+`ImageHandler` internamente e publica em mensagens `nectar_interfaces`.
+
+Veja também: [Cameras](../camera/) · [Algorithms](../algorithms/) ·
+[Vision overview](../).
+
+## Arquitetura
+
+```mermaid
+classDiagram
+    class ArucoNode {
+        -aruco Aruco
+        -img_handler ImageHandler
+        -pose_estime_pub Publisher
+        +process_image(img)
+        +cleanup()
+    }
+
+    class LineDetectionNode {
+        -line_detectors Dict~str,LineDetector~
+        -estimation_methods Dict~str,ILineEstimationMethod~
+        -image_handler ImageHandler
+        +process_image(img)
+        +initialize_color_detector(color, color_space)
+        +run()
+        +cleanup()
+    }
+
+    class ColorCalibrationNode {
+        -color_detector ColorDetector
+        -img_handler ImageHandler
+        -_process(img)
+    }
+
+    class CameraPublisherNode {
+        -camera AbstractCam
+        -image_handler ImageHandler
+        -publisher Publisher
+        +cleanup()
+    }
+
+    ArucoNode o-- Aruco
+    ArucoNode o-- ImageHandler
+    LineDetectionNode o-- LineDetector
+    LineDetectionNode o-- ImageHandler
+    ColorCalibrationNode o-- ColorDetector
+    ColorCalibrationNode o-- ImageHandler
+    CameraPublisherNode o-- ImageHandler
+```
+
+## Nó de detecção ArUco
+
+```bash
+ros2 run nectar aruco_node.py --ros-args \
+    -p image_source:=webcam -p marker_dict:=5 -p tag_size:=0.05
+```
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|---------|-------------|
+| `image_source` | string | webcam | Fonte de câmera |
+| `marker_dict` | int | 5 | Dicionário ArUco (4, 5, 6, 7) |
+| `tag_size` | float | 0.2 | Tamanho do marcador em metros |
+
+Publica `/aruco/pose_estimate` (`nectar_interfaces/ArucoTransforms`).
+
+## Nó de detecção de linha
+
+```bash
+ros2 run nectar line_detection_node.py --ros-args \
+    -p line_colors:="blue,red" -p method:=HoughLinesP \
+    -p spaces:="hsv,lab" -p image_source:=webcam -p show_visualization:=true
+```
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|---------|-------------|
+| `line_colors` | string | teste | Nomes de cor separados por vírgula, de `color_calibration.json` (por exemplo, `blue,red`). O padrão `teste` é um placeholder — defina nomes explícitos que existam no seu arquivo de calibração, como no exemplo acima. |
+| `method` | string | HoughLinesP | Método de estimação |
+| `spaces` | string | hsv | Espaços de cor separados por vírgula |
+| `image_source` | string | webcam | Fonte de câmera |
+| `show_visualization` | bool | true | Mostra a janela OpenCV |
+| `visualization_name` | string | Line Detection | Título da janela |
+
+Métodos: `HoughLinesP`, `RotatedRect`, `FitEllipse`, `RansacLine`, `AdaptiveHoughLinesP`. Por
+cor, publica `/line_state/{color}` (`nectar_interfaces/LineInfo`) e `/line_detect/{color}`
+(`std_msgs/Bool`).
+
+## Nó de calibração de cor
+
+```bash
+ros2 run nectar color_calibration_node.py --ros-args \
+    -p image_source:=webcam -p color_space:=hsv -p flood_tolerance:=15
+```
+
+Calibração interativa HSV/LAB em uma única janela: clique com o botão esquerdo em uma região
+colorida para computar automaticamente os thresholds via flood fill, depois ajuste fino com as
+seis trackbars de canal. A visão empilhada mostra `original | mask | result`.
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|---------|-------------|
+| `image_source` | string | webcam | Fonte de câmera |
+| `color_space` | string | hsv | Espaço de cor inicial (`hsv` ou `lab`) |
+| `flood_tolerance` | int | 15 | Tolerância inicial de flood-fill para a amostragem por clique |
+
+| Tecla | Ação |
+|-----|--------|
+| clique esquerdo | Amostra a região clicada (flood fill) |
+| `c` | Alterna HSV / LAB |
+| `s` | Salva (pede um nome de cor) |
+| `l` | Carrega uma cor nomeada |
+| `z` | Desfaz a última amostra |
+| `r` | Reseta |
+| `q` | Sai |
+
+As cores salvas são gravadas no `algorithms/color/color_calibration.json` compartilhado e
+carregadas via `ColorDetector(mode="preset", color=<name>)` e pelo nó de detecção de linha.
+
+> **Nota:** este nó exige uma GUI do OpenCV (mouse + trackbars).
+
+## Nó publisher de câmera
+
+Publica qualquer fonte de `CameraFactory` como um tópico de imagem ROS 2. Selecione o driver com
+`camera_source` (`webcam`, `realsense`, `oakd`, `c920`, `imx219`, `ros`, ...) e defina os
+parâmetros específicos da fonte.
+
+```bash
+ros2 run nectar camera_publisher_node.py --ros-args \
+    -p camera_source:=webcam -p device_index:=0 \
+    -p width:=1280 -p height:=720 -p fps:=30 \
+    -p use_compression:=true -p jpeg_quality:=80 -p threaded:=true
+```
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|---------|-------------|
+| `camera_source` | string | webcam | Chave do driver de câmera passada para `CameraFactory` |
+| `device_index` | int | 0 | Índice do dispositivo USB/webcam |
+| `width` / `height` | int | 640 / 480 | Tamanho do frame |
+| `fps` | int | 30 | FPS alvo |
+| `use_compression` | bool | true | Publica imagens comprimidas em JPEG |
+| `jpeg_quality` | int | 80 | Qualidade do JPEG (0-100) |
+| `buffer_size` | int | 2 | Tamanho do buffer da câmera |
+| `threaded` | bool | true | Thread de captura em background |
+
+Publica `image_raw/compressed` (`sensor_msgs/CompressedImage`) ou `image_raw`
+(`sensor_msgs/Image`, quando a compressão está desabilitada).

--- a/i18n/pt/project/code-of-conduct.md
+++ b/i18n/pt/project/code-of-conduct.md
@@ -1,0 +1,71 @@
+# Código de Conduta do Contributor Covenant
+
+## Nosso Compromisso
+
+No interesse de fomentar um ambiente aberto e acolhedor, nós, como contribuidores e
+mantenedores, nos comprometemos a tornar a participação em nosso projeto e em nossa
+comunidade uma experiência livre de assédio para todos, independentemente de idade, tamanho
+corporal, deficiência, etnia, características sexuais, identidade e expressão de gênero,
+nível de experiência, educação, condição socioeconômica, nacionalidade, aparência pessoal,
+raça, religião, ou identidade e orientação sexual.
+
+## Nossos Padrões
+
+Exemplos de comportamento que contribuem para criar um ambiente positivo incluem:
+
+* Usar linguagem acolhedora e inclusiva
+* Respeitar pontos de vista e experiências diferentes
+* Aceitar críticas construtivas com elegância
+* Focar no que é melhor para a comunidade
+* Demonstrar empatia com outros membros da comunidade
+
+Exemplos de comportamento inaceitável por parte dos participantes incluem:
+
+* O uso de linguagem ou imagens sexualizadas e atenção ou avanços sexuais indesejados
+* Trolling, comentários insultuosos/depreciativos, e ataques pessoais ou políticos
+* Assédio público ou privado
+* Publicar informações privadas de terceiros, como endereço físico ou eletrônico, sem permissão explícita
+* Outras condutas que poderiam razoavelmente ser consideradas inadequadas em um ambiente profissional
+
+## Nossas Responsabilidades
+
+Os mantenedores do projeto são responsáveis por esclarecer os padrões de comportamento
+aceitável e espera-se que tomem ações corretivas apropriadas e justas em resposta a
+qualquer instância de comportamento inaceitável.
+
+Os mantenedores do projeto têm o direito e a responsabilidade de remover, editar ou rejeitar
+comentários, commits, código, edições de wiki, issues e outras contribuições que não estejam
+alinhadas a este Código de Conduta, ou de banir temporária ou permanentemente qualquer
+contribuidor por outros comportamentos que considerem inadequados, ameaçadores, ofensivos ou
+nocivos.
+
+## Abrangência
+
+Este Código de Conduta se aplica em todos os espaços do projeto, e também se aplica quando
+um indivíduo está representando o projeto ou sua comunidade em espaços públicos. Exemplos de
+representação de um projeto ou comunidade incluem usar um endereço de e-mail oficial do
+projeto, postar por meio de uma conta oficial de redes sociais, ou atuar como representante
+designado em um evento online ou presencial. A representação de um projeto pode ser
+definida e esclarecida com mais detalhes pelos mantenedores do projeto.
+
+## Aplicação
+
+Instâncias de comportamento abusivo, de assédio ou de outra forma inaceitável podem ser
+relatadas contatando o mantenedor do projeto por meio de qualquer um dos
+[endereços de contato privados](https://github.com/Black-Bee-Drones#support). Todas as
+reclamações serão revisadas e investigadas, e resultarão em uma resposta considerada
+necessária e apropriada às circunstâncias. A equipe do projeto é obrigada a manter a
+confidencialidade em relação à pessoa que relatou o incidente. Mais detalhes sobre políticas
+de aplicação específicas podem ser publicados separadamente.
+
+Mantenedores do projeto que não seguirem ou aplicarem o Código de Conduta de boa-fé podem
+enfrentar repercussões temporárias ou permanentes, conforme determinado por outros membros
+da liderança do projeto.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org),
+versão 1.4, disponível em <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+Para respostas a perguntas comuns sobre este código de conduta, veja
+<https://www.contributor-covenant.org/faq>

--- a/i18n/pt/project/contributing.md
+++ b/i18n/pt/project/contributing.md
@@ -1,0 +1,368 @@
+# Contribuindo com o Nectar SDK
+
+Discuta mudanças significativas via [GitHub Issues](https://github.com/Black-Bee-Drones/nectar-sdk/issues)
+ou [Discussions](https://github.com/Black-Bee-Drones/nectar-sdk/discussions) antes de
+implementar, e leia primeiro o [Código de Conduta](code-of-conduct.md).
+
+## Issues e Pedidos de Funcionalidade
+
+### Relatando Bugs
+
+Crie relatos de bug que sejam:
+
+- **Reproduzíveis**: inclua os passos para reproduzir o problema
+- **Específicos**: números de versão, SO, detalhes de hardware
+- **Únicos**: procure primeiro nas issues existentes
+- **Delimitados**: um bug por relato
+
+### Pedidos de Funcionalidade
+
+Verifique as [Discussions](https://github.com/Black-Bee-Drones/nectar-sdk/discussions) por
+conversas em andamento antes de abrir um novo pedido.
+
+## Configuração de Desenvolvimento
+
+### Git LFS
+
+Este repositório usa o [Git LFS](https://git-lfs.github.com/) para rastrear arquivos
+binários grandes (imagens, vídeos, pesos de modelo etc.). Instale o Git LFS antes de clonar:
+
+```bash
+git lfs install
+
+git clone git@github.com:Black-Bee-Drones/nectar-sdk.git
+cd nectar-sdk
+```
+
+O Git LFS trata automaticamente os arquivos grandes definidos em `.gitattributes`. Ao
+adicionar imagens, vídeos ou outros arquivos grandes, eles são automaticamente rastreados
+pelo LFS.
+
+**Nota:** se você clonou antes do Git LFS ser configurado, talvez precise baixar os
+arquivos LFS:
+
+```bash
+git lfs pull
+```
+
+### Ambiente Python
+
+O SDK instala as dependências Python com [uv](https://github.com/astral-sh/uv) em uma venv
+compartilhada do workspace (`$WORKSPACE/.venv`), reutilizada por todos os pacotes do
+workspace. Veja o [guia de instalação](../setup/index.md#ambiente-python).
+
+### Hooks de Pre-commit
+
+Instale os hooks do [pre-commit](https://pre-commit.com/) (configuração única):
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Depois de `pre-commit install`, os hooks rodam **automaticamente em todo `git commit`** —
+eles verificam somente os arquivos staged, corrigem automaticamente o que puderem, e abortam
+o commit se alguma alteração foi feita. Basta `git add` nas correções e commitar de novo.
+
+### Antes de Fazer Push
+
+Sempre rode o check completo antes de fazer push (o mesmo comando que o CI roda):
+
+```bash
+make check
+
+# or equivalently: pre-commit run --all-files
+
+```
+
+Isso valida **todos os arquivos** (Python, Markdown, YAML, shell scripts) quanto a:
+
+- Espaços em branco no final da linha e newlines ausentes no final do arquivo
+- Erros de lint do Python (imports não usados, nomes indefinidos)
+- Ordenação de imports
+- Formatação de código
+
+### Comandos Rápidos
+
+```bash
+make check       # run all checks (same as CI)
+make lint        # Python lint only (ruff check)
+make lint-fix    # Python lint + auto-fix (ruff check --fix)
+make format      # Python format only (ruff format)
+```
+
+Use `make lint` / `make format` durante o desenvolvimento para feedback rápido em arquivos
+Python. Use `make check` antes de fazer push para garantir que o CI vai passar.
+
+## Processo de Pull Request
+
+### 1. Faça um Fork e Clone
+
+```bash
+
+# Fork via GitHub UI, then:
+
+git clone git@github.com:YOUR_USERNAME/nectar-sdk.git
+cd nectar-sdk
+git remote add upstream git@github.com:Black-Bee-Drones/nectar-sdk.git
+```
+
+### 2. Crie uma Branch de Feature
+
+```bash
+git checkout -b feat/your-feature-name
+
+# or
+
+git checkout -b fix/bug-description
+```
+
+**Nomenclatura de Branches**:
+
+- `feat/` - Novas funcionalidades
+- `fix/` - Correções de bugs
+- `docs/` - Somente documentação
+- `refactor/` - Refatoração de código
+- `test/` - Adições/correções de testes
+
+### 3. Faça as Alterações
+
+Siga o estilo de código do projeto:
+
+- **Python**: siga o [PEP 8](https://peps.python.org/pep-0008/)
+- **Docstrings**: use o [estilo NumPy](https://numpydoc.readthedocs.io/en/latest/format.html)
+- **Type hints**: inclua anotações de tipo para APIs públicas
+
+### 4. Faça Commit com Conventional Commits
+
+Seguimos o [Conventional Commits](https://www.conventionalcommits.org):
+
+```bash
+
+# Format: type(scope): description
+
+git commit -m "feat(control): add obstacle avoidance strategy"
+git commit -m "fix(vision): resolve camera initialization race condition"
+git commit -m "docs(readme): update installation instructions"
+```
+
+**Tipos**:
+
+| Tipo | Descrição |
+|------|-------------|
+| `feat` | Nova funcionalidade |
+| `fix` | Correção de bug |
+| `docs` | Documentação |
+| `style` | Formatação (sem alteração de código) |
+| `refactor` | Reestruturação de código |
+| `test` | Adições de teste |
+| `chore` | Build/ferramental |
+
+### 5. Faça Push e Crie o PR
+
+```bash
+git push origin feat/your-feature-name
+```
+
+Depois abra um Pull Request no GitHub usando nosso
+[template de PR](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
+
+## Diretrizes de Código
+
+### Documentação
+
+- Atualize o README.md do módulo ao adicionar funcionalidades
+- Adicione docstrings às classes e métodos públicos
+- Inclua exemplos de uso para novas APIs
+
+**Convenções de README** (padrão de excelência: [`control/mavros/README.md`](../modules/control/mavros.md)):
+
+- **Estrutura (progressive disclosure)**: comece com um propósito de uma linha, depois um snippet executável de **visão rápida** (o caso comum), depois **Conceitos** (prosa curta + um diagrama de nível médio), depois um **Uso** orientado a tarefas, depois uma seção de **Referência** para tabelas exaustivas (tópicos/serviços/parâmetros/tipos). O Uso vem antes do diagrama de classes detalhado, nunca depois de uma parede dele. Mantenha a prosa concisa e técnica — sem buzzwords, sem repetição.
+- **Fonte única de verdade**: documente a lógica compartilhada uma única vez e aponte para ela; não repita a mesma coisa em dois READMEs. A lógica de voo compartilhada vive em [Vehicle core](../modules/control/vehicle.md) (especificidades do ArduPilot em [ArduPilot](../modules/control/ardupilot.md)); o VSLAM indoor em [Localization](../modules/control/localization/index.md); a instalação no [Guia de instalação](../setup/index.md); o Docker no [Guia Docker](../setup/docker.md); a simulação em [Simulation](../modules/simulation.md). Os READMEs dos módulos concentram a profundidade técnica; o [site de documentação](https://black-bee-drones.github.io/nectar-sdk/) os espelha por meio de `scripts/docs/sync_readmes.py`. O **README raiz** é uma landing page curta do GitHub — aponte para o site, não duplique tabelas de instalação, diagramas de arquitetura ou índices de módulo ali.
+- **Diagramas (Mermaid)**: mantenha um diagrama por README, em uma seção **Conceitos** *depois* do uso de visão rápida. O Zensical renderiza Mermaid no lado do cliente e adapta fontes/cores ao esquema claro/escuro ativo, e todo diagrama tem clique para zoom/pan (veja `website/javascripts/`). Para os diagramas **técnicos** (classe, sequência, estado), confie no tema — **não** defina cores, para que fiquem legíveis nos dois esquemas. Reserve cores para o diagrama de alto nível de **arquitetura/visão geral**, onde uma paleta `classDef` curada (`fill:` em tom médio com um `color:` de texto explícito) ajuda a compreensão e funciona nos dois esquemas. Use o layout **ELK** (`config: { layout: elk }` no frontmatter do diagrama) somente para fluxogramas densos no **site** — o Mermaid do GitHub não tem ELK, então nunca coloque `layout: elk` em um README que também deve renderizar no GitHub. Evite envolver o Mermaid em `<details>`/colapsáveis (a fence não renderiza dentro de blocos raw-HTML). Git graphs renderizam, mas não seguem o tema e são fracos no mobile — use com moderação.
+- **Renderiza no parser estrito**: o site de documentação usa Python-Markdown, que é mais estrito que o GitHub. Coloque uma linha em branco antes de toda lista, tabela e bloco de código com fence (regras `MD022`/`MD031`/`MD032`/`MD058`, aplicadas pelo `markdownlint-cli2` no pre-commit e no CI). Markdown que passa pelo linter renderiza tanto no site quanto no GitHub; o inverso não é garantido. Faça o preview localmente com `make docs-serve`.
+- **Tabs e admonitions são exclusivos do site**: tabs de conteúdo (`=== "..."`) e admonitions `!!!`/`???` renderizam somente no site de documentação, não no GitHub. Use-os nas páginas autorais de `website/` e nos guias site-first sob `docs/` (setup, Docker), onde eles carregam a escolha do leitor (backend, câmera, SO) do início ao fim. READMEs de módulo e de exemplo também são exibidos no GitHub, então ali apresente alternativas como **blocos com fence e rótulo em negrito** separados (não tabs) e use blockquotes simples (`> **Warning:** ...`) para notas. Uma fence que usa comentários `#` como cabeçalhos de caso/variante deve se tornar blocos com rótulo em negrito (ou uma tabela) em um README, e um grupo de tabs em uma página do site.
+- **Texto de link legível**: nunca use um caminho como o texto visível do link (`[vehicle/README.md](...)`, `[control/px4/config](...)`). Escreva um título legível (`[Vehicle core](...)`, `[PX4 config](...)`). Apontadores inline para arquivo-fonte (`([`sequencer.py`](sequencer.py))`) são aceitáveis. Links de símbolo → API gerada pertencem somente às páginas de `website/` (um link de README para `api/*.md` não é seguro para renderização dupla).
+- **Mantenha-se fiel ao código**: todo comando, flag, tópico e nome de classe deve corresponder ao código. Prefira flags reais de argparse / nomes de parâmetros reais em vez de inventados.
+- **Ao adicionar um módulo**: atualize o README do módulo e seu índice pai; se for uma nova área de nível superior, adicione **um bullet** em Features no README raiz apontando para a página correspondente no [site de documentação](https://black-bee-drones.github.io/nectar-sdk/). Siga [Adicionando um componente](#adicionando-um-componente) abaixo.
+
+**Exemplo de Docstring**:
+
+```python
+def move_to(
+    self,
+    x: float,
+    y: float,
+    z: float,
+    precision: float = 0.2,
+) -> bool:
+    """
+    Navigate to a position in the world frame.
+
+    Parameters
+    ----------
+    x : float
+        Target X position in meters.
+    y : float
+        Target Y position in meters.
+    z : float
+        Target Z position (altitude) in meters.
+    precision : float, optional
+        Position tolerance in meters. Default is 0.2.
+
+    Returns
+    -------
+    bool
+        True if target reached within timeout, False otherwise.
+
+    Examples
+    --------
+    >>> drone.move_to(x=2.0, y=1.0, z=1.5, precision=0.3)
+    True
+    """
+```
+
+### Testes
+
+A suíte funcional vive em
+[`nectar/test/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/test) (ela
+**não** é instalada com o pacote) e é `pytest` puro:
+
+- `nectar/test/functional/` — um `test_<module>.py` por módulo do SDK. Cada teste realiza
+  uma *operação real* sobre entradas sintéticas ou um loopback. Os testes se auto-pulam
+  (nunca falham) quando uma dependência opcional está ausente, via
+  `pytest.importorskip(...)`.
+- `nectar/test/hardware/` — checks condicionados a dispositivo (RealSense, OAK-D, TF-Luna),
+  marcados como `hardware` e **desselecionados por padrão**.
+- `nectar/test/conftest.py` + `nectar/test/helpers.py` — fixtures (`ros_node`, `fake_fcu`,
+  `qt_app`) e o FCU de loopback.
+
+Rode:
+
+```bash
+make verify-functional                      # all modules (hardware/gpu deselected)
+make verify-functional MODULE="vision control"   # subset -> pytest -m "vision or control"
+make test                                   # colcon test: the suite + cmake/xml lint
+make verify-hardware                         # opt in to device checks on the rig
+
+# (equivalently, from the package dir: cd nectar && pytest test/hardware -m hardware)
+
+```
+
+Diretrizes:
+
+- **Adicione um teste para toda nova funcionalidade.** Coloque-o no
+  `test/functional/test_<module>.py` correspondente, marque o módulo com `pytestmark =
+  pytest.mark.<module>`, e condicione qualquer coisa que precise de dispositivo/GPU/sim/rede
+  com os markers `hardware` / `gpu` / `sim` / `network` (registrados em `pyproject.toml`).
+  Faça assert com `assert` simples; pule com `pytest.skip(...)` / `pytest.importorskip(...)`
+  — nunca falhe por uma dependência opcional ausente.
+- **Faça lint/format com o ruff** (a única fonte de verdade — `make lint` / `make format`,
+  também aplicado pelo pre-commit). `make verify-functional` se auto-pula de forma limpa,
+  então um run verde na sua máquina reflete o que sua instalação de fato suporta.
+- **Teste com hardware real** ao modificar código de controle de drone, e rode os markers
+  relevantes de `make verify-functional` antes de submeter.
+- `make doctor` imprime um relatório somente leitura do ambiente e dispositivos atuais —
+  útil quando um teste é pulado e você quer saber por quê.
+
+#### CI local (cross-distro)
+
+Os checks rodam em fidelidade crescente:
+
+- **Lint** — `make check` (ruff via pre-commit).
+- **Suíte no host** (a mais rica; todas as deps instaladas, incl. AI/Qt/CUDA) — `make
+  verify`, `make verify-functional`, `make verify-hardware` na sua máquina de dev.
+- **Cross-distro em Docker** — `make ci-local` builda a imagem do SDK a partir do código
+  *local* para cada distro ROS e roda `verify` + `verify-functional` em cada uma, espelhando
+  [`.github/workflows/_build-verify.yml`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/.github/workflows/_build-verify.yml).
+  Ele imprime um resumo de pass/fail e grava um relatório JUnit por distro em
+  `ci-local-results/`. Somente amd64 (arm64 é coberto em um Jetson; Windows via WSL2 mais
+  adiante). Builda uma imagem por vez e a remove depois, para limitar o uso de disco.
+
+  ```bash
+  make ci-local                                  # humble jazzy kilted (sdk stage)
+  make ci-local DISTROS=jazzy                     # one distro
+  make ci-local DISTROS="humble kilted" FULL=1    # include torch/AI (sdk-full; heavy)
+  make ci-local REALSENSE=1                        # also build librealsense + realsense-verify
+  ```
+
+  Disco: builds de imagem completos são grandes. O data-root do Docker precisa ter vários GB
+  livres (cada imagem `sdk` tem ~4-5 GB, `sdk-full` ~10 GB); o runner aborta um build abaixo
+  de `MIN_FREE_GB` (padrão 8). Recupere espaço com `docker system prune` / removendo imagens
+  antigas.
+
+#### Voos SITL / integração (Tier 3)
+
+A suíte em [`nectar/test/sitl/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/test/sitl)
+voa uma missão smoke real em um simulador **headless** para cada firmware + protocolo
+(connect → takeoff → move → land), validando o núcleo do veículo e o link
+firmware/protocolo de ponta a ponta. A fixture `sim_session` possui o ciclo de vida da
+simulação (reaproveitando `make sim-start` / `sim-bridge` / `sim-stop`), então um único
+comando substitui a orquestração manual em dois terminais.
+
+```bash
+make verify-sitl                          # full matrix (needs the sim stack: make sim-install)
+make verify-sitl FIRMWARE=px4 PROTOCOL=dds  # one entry (FIRMWARE -> marker, PROTOCOL -> -k)
+```
+
+Matriz: `ardupilot` (mavros, mavlink), `px4` (mavros, mavlink, dds), `crazyflie` (sim do
+Crazyswarm2). O Bebop é hardware-only (sem simulador). O tier é marcado como `sitl` e
+**desselecionado por padrão**.
+
+Rode onde a stack de simulação estiver instalada (`make sim-install`): sua máquina de dev ou
+o Jetson, e como um gate de pré-release. **Não** está no CI — buildar os simuladores
+(ArduPilot + PX4 + Gazebo, todos a partir do código-fonte) leva ~45-70 min e não há binário
+apt para atalhar isso, então não vale a pena como job por PR ou agendado. O mesmo comando
+`make verify-sitl` roda sem alterações em amd64 e arm64. (O Crazyflie se auto-pula a menos
+que o backend `crazyflie_sim` do Crazyswarm2 seja buildado a partir do código-fonte.)
+
+Para adicionar um firmware/protocolo: adicione um `SimSpec` a
+[`nectar/test/sitl/sim_helpers.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/test/sitl/sim_helpers.py)
+(seus `start_cmds`, tipo de drone, preset de config e envelope de voo); o `test_smoke_flight`
+parametrizado e os markers pegam isso automaticamente. A suíte de navegação mais profunda do
+ArduPilot fica em
+[`examples/simulation/sitl_test.py`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/nectar/nectar/examples/simulation/sitl_test.py).
+
+### Adicionando um componente
+
+Ao adicionar novos componentes:
+
+1. **Módulo Control**: estenda `BaseDrone` ou implemente o protocolo `Drone`; registre em `DroneFactory`. A lógica do ArduPilot agnóstica a transporte fica em `control/ardupilot/`; a navegação externa indoor (VSLAM, ponte de vision-pose) em `control/localization/`.
+2. **Módulo Vision**:
+   - Câmeras: adicione em `vision/camera/drivers/`, registre em `CameraFactory`
+   - Algoritmos: adicione em `vision/algorithms/<category>/`
+3. **Módulo AI**: estenda `BaseDetectionModel` (ou o equivalente de segmentação), registre em `Detector`/`Segmentor`
+4. **Pontos de entrada ROS**: os nós vão no diretório `nodes/` correspondente e os arquivos `launch/` em `nectar/launch/`; instale os dois em `nectar/CMakeLists.txt`
+5. **Export**: adicione os símbolos públicos ao `__init__.py` (deps pesadas via `_LAZY_ATTRS`)
+6. **Documente**: atualize o README.md do módulo; para um novo módulo de nível superior, adicione um bullet em Features no README raiz apontando para a página correspondente no [site de documentação](https://black-bee-drones.github.io/nectar-sdk/)
+
+### Contrato de Tempo de Importação
+
+Dependências pesadas de terceiros (`torch`, `transformers`, `rfdetr`, `tensorflow`, `jax`, `matplotlib`, `mediapipe`, `pyrealsense2`, `depthai`, `supervision`, `ultralytics`, `pandas`, `geopy`) **não devem** ser importadas no momento de carregamento do módulo, no caminho de `from nectar.ai import Detector`, `from nectar.vision import ImageHandler`, ou `from nectar.control import MavrosConfig`.
+
+Dois padrões são usados para reforçar isso, ambos padrão de mercado
+([PEP 562](https://peps.python.org/pep-0562/), a mesma abordagem do scikit-learn / NumPy /
+SciPy):
+
+1. **Superfície lazy do pacote em `__init__.py`**: re-exports pesados passam por um dict `_LAZY_ATTRS` e `__getattr__`. Tipos leves (dataclasses, enums, exceptions) permanecem eager. Veja `nectar/ai/detection/__init__.py` e `nectar/vision/__init__.py` para o padrão canônico.
+2. **Imports locais em funções**: quando um módulo precisa de `matplotlib` / `pandas` somente dentro de um helper de plotagem, o import vive dentro do corpo da função, não no topo do arquivo. Veja `nectar/vision/algorithms/distance/calibrator.py::ModelCalibrator.plot`.
+
+Verifique o contrato disparando um interpretador novo e afirmando que os módulos proibidos
+estão ausentes de `sys.modules` depois de um import público:
+
+```bash
+python -c "import sys, nectar.control; assert 'torch' not in sys.modules and 'mediapipe' not in sys.modules"
+```
+
+Se você adicionar uma nova dependência pesada ou re-export, roteie-a por `_LAZY_ATTRS` (ou um
+import local à função) para que o caminho de import público permaneça leve.
+
+## Processo de Revisão
+
+Os mantenedores revisam o código e fornecem feedback; trate as alterações solicitadas e,
+uma vez aprovado, o PR é mesclado.
+
+## Dúvidas?
+
+- [GitHub Discussions](https://github.com/Black-Bee-Drones/nectar-sdk/discussions) para perguntas gerais
+- [GitHub Issues](https://github.com/Black-Bee-Drones/nectar-sdk/issues) para bugs/funcionalidades

--- a/i18n/pt/project/releasing.md
+++ b/i18n/pt/project/releasing.md
@@ -1,0 +1,113 @@
+# Processo de Release
+
+## Versionamento
+
+Este projeto segue o [Semantic Versioning](https://semver.org/):
+
+```
+vMAJOR.MINOR.PATCH
+```
+
+- **Major**: mudanças que quebram a API
+- **Minor**: novas funcionalidades, compatíveis com versões anteriores
+- **Patch**: correções de bugs
+
+## Nomes de Código (opcional)
+
+Releases podem ter um nome de código associado à versão. A tag git é sempre `vX.Y.Z`
+(legível por máquina). O título da release no GitHub inclui o nome de código (legível por
+humanos).
+
+Exemplos:
+
+- `v0.2.0 "Tadini"` — capitão do time
+- `v1.0.0 "CBR 2026"` — nome da competição
+- `v1.1.0 "Mangalarga"` — nome de código interno
+
+## Checklist de Release
+
+### 1. PR de bump de versão
+
+Crie um PR que atualiza a versão:
+
+- `nectar/pyproject.toml` → `version = "X.Y.Z"`
+- `nectar/package.xml` → `<version>X.Y.Z</version>`
+- `CITATION.cff` → `version: X.Y.Z` e `date-released`
+
+O CI roda `code-quality` (lint) e `pr-check` (build Docker Humble + `verify` +
+`verify-functional`) no PR.
+
+### 2. Merge para main
+
+Depois da revisão, faça o merge do PR. O CI roda no push para `main`:
+
+- `build-test-{humble,jazzy,kilted}` — build Docker + `verify` + `verify-functional` (+ RealSense onde habilitado; Humble também em amd64 e arm64)
+- `docs.yml` — builda e faz deploy do site de documentação no GitHub Pages
+
+Verifique a [aba Actions](https://github.com/Black-Bee-Drones/nectar-sdk/actions) — tudo
+verde antes de prosseguir.
+
+### 3. Crie a release no GitHub
+
+- Vá para [Releases](https://github.com/Black-Bee-Drones/nectar-sdk/releases/new)
+- Tag: `vX.Y.Z` (crie uma nova tag, apontando para `main`)
+- Título: `vX.Y.Z "Nome de Código"`
+- Inclua notas de migração de breaking changes quando aplicável (veja a descrição do PR de merge)
+- Aponte para o [site de documentação](https://black-bee-drones.github.io/nectar-sdk/) no corpo da release
+- Clique em "Generate release notes" para o changelog, depois publique
+
+### 4. Automaticamente pelo CI
+
+`docker-push.yml` é disparado ao publicar a release. Para cada distro (Humble, Jazzy,
+Kilted) e arquitetura (amd64, arm64):
+
+1. Builda a imagem Docker com RealSense e todos os drivers de drone (`INSTALL_DRONE=all`)
+2. Roda `verify` + `verify-functional` + `realsense-verify`
+3. **Somente se todos os checks passarem para aquela distro**: faz push dos manifests multi-arch para o Docker Hub
+
+As distros são independentes — uma falha no Kilted não bloqueia o tagging de Humble/Jazzy.
+
+Para republicar tags do Docker sem uma nova release no GitHub, rode
+**Actions → Docker Push → Run workflow** com o `release_tag` desejado (por exemplo,
+`v1.1.0`) e `distros`.
+
+## Site de documentação (GitHub Pages)
+
+- **URL:** [black-bee-drones.github.io/nectar-sdk](https://black-bee-drones.github.io/nectar-sdk/)
+- **Fonte:** `website/` (páginas autorais), `docs/`, e os READMEs dos módulos, montados por `scripts/docs/sync_readmes.py`
+- **Workflow:** `.github/workflows/docs.yml` — build no PR; build + deploy no push para `main`
+- **Configuração do repositório (única):** Settings → Pages → Build and deployment → **GitHub Actions**
+- **Preview local:** `make docs-install && make docs-serve`
+
+## Docker Hub
+
+As imagens são enviadas ao [Docker Hub](https://hub.docker.com/r/blackbeedrones/nectar-sdk)
+em toda release.
+
+| Padrão de tag | Exemplo | Conteúdo |
+|---|---|---|
+| `:<distro>` | `humble`, `jazzy`, `kilted` | Última release daquela distro |
+| `:<distro>-vX.Y.Z` | `humble-v1.1.0` | Release específica |
+
+Baixe e rode:
+
+```bash
+docker pull blackbeedrones/nectar-sdk:humble
+docker run -it --rm --net=host blackbeedrones/nectar-sdk:humble
+```
+
+## Workflows de CI
+
+| Workflow | Gatilho | Distros | O que faz |
+|---|---|---|---|
+| `code-quality.yml` | PR para `main` ou `dev` | — | Lint + format (~30s) |
+| `pr-check.yml` | PR para `main` | Humble (amd64) | Build Docker + `verify` + `verify-functional` |
+| `build-test-humble.yml` | Push para `main`, semanal (seg 05:00 UTC) | Humble (amd64 + arm64) | Build Docker + `verify` + `verify-functional` + RealSense |
+| `build-test-jazzy.yml` | Push para `main`, semanal (seg 05:00 UTC) | Jazzy | Build Docker + `verify` + `verify-functional` + RealSense |
+| `build-test-kilted.yml` | Push para `main`, semanal (seg 05:00 UTC) | Kilted | Build Docker + `verify` + `verify-functional` + RealSense |
+| `docs.yml` | PR (build) / push para `main` (build + deploy) | — | Site Zensical; faz deploy no GitHub Pages |
+| `docker-push.yml` | Release no GitHub / dispatch manual | Todas as 3 × amd64 + arm64 (independente por distro) | Build → `verify` + `verify-functional` + RealSense → push para o Docker Hub |
+
+A lógica de build e verify do Docker é compartilhada via `_build-verify.yml` (workflow
+reutilizável). O `docker-push.yml` espelha os mesmos passos de verificação antes de publicar
+as imagens de release.

--- a/i18n/pt/project/security.md
+++ b/i18n/pt/project/security.md
@@ -1,0 +1,16 @@
+# Política de Segurança
+
+## Relatando uma Vulnerabilidade
+
+Se houver alguma vulnerabilidade no **nectar-sdk**, não hesite em _relatá-la_.
+
+1. Abra um [GitHub Security Advisory](https://github.com/Black-Bee-Drones/nectar-sdk/security/advisories/new) (preferencial) ou inicie uma [GitHub Discussion](https://github.com/Black-Bee-Drones/nectar-sdk/discussions) privada se os advisories não estiverem disponíveis.
+2. Descreva a vulnerabilidade.
+
+   Se você tiver uma correção, ela é muito bem-vinda -- por favor, anexe ou resuma-a na sua mensagem!
+
+3. Vamos avaliar a vulnerabilidade e, se necessário, publicar uma correção ou passos de mitigação para tratá-la. Vamos contatar você para informar o resultado, e vamos creditá-lo no relatório.
+
+   Por favor, **não divulgue a vulnerabilidade publicamente** até que uma correção seja publicada!
+
+4. Depois que tivermos a) publicado uma correção, ou b) decidido não tratar a vulnerabilidade por qualquer motivo, você está livre para divulgá-la publicamente.

--- a/i18n/pt/projects/index.md
+++ b/i18n/pt/projects/index.md
@@ -1,0 +1,114 @@
+# Projetos
+
+O Nectar SDK é a base compartilhada que a Black Bee Drones usa para as missões de
+competição. Cada repositório contém o README completo da missão e o código; esta página
+lista apenas os eventos e os links oficiais.
+
+!!! note "Linhagem do SDK"
+
+    O SDK evoluiu ao longo de três gerações: `tadinisdk` (ROS 1) → `mirela_sdk` (ROS 2) →
+    **`nectar`**. Projetos mais antigos referenciam os nomes anteriores.
+
+<div class="nectar-project-list" markdown>
+
+<div class="nectar-project-row" markdown>
+
+## SAE EletroQuad 2026
+
+<p class="nectar-project-caption">Competição EletroQuad SAE BRASIL – AXIA Energia 2026</p>
+
+<p class="nectar-project-award">2º lugar</p>
+
+<p class="nectar-project-desc">Quadrotor autônomo — pouso de precisão em bases marcadas, posicionamento de gancho em cordas suspensas, inspeção de medidor analógico.</p>
+
+<div class="nectar-meta" markdown>
+
+- [:simple-github: Repositório](https://github.com/Black-Bee-Drones/SAE-Eletroquad)
+- [:simple-huggingface: Modelos](https://huggingface.co/collections/blackbeedrones/sae-2026)
+- [Competição](https://saebrasil.org.br/programas-estudantis/eletroquad/)
+- [Regras](https://saebrasil.org.br/programas-estudantis/eletroquad/regras-e-relatorios/)
+
+</div>
+
+</div>
+
+<div class="nectar-project-row" markdown>
+
+## IMAV 2025
+
+<p class="nectar-project-caption">16ª International Micro Air Vehicle Conference and Competition · competição indoor</p>
+
+<p class="nectar-project-award">3º lugar, indoor</p>
+
+<p class="nectar-project-desc">Busca e salvamento indoor — entrada por portal, desvio de obstáculos, pouso em uma plataforma em movimento com fumaça.</p>
+
+<div class="nectar-meta" markdown>
+
+- [:simple-github: Repositório](https://github.com/Black-Bee-Drones/imav-2025)
+- [:simple-huggingface: Modelos](https://huggingface.co/collections/blackbeedrones/imav-2025)
+- [Competição](https://femexrobotica.org/imav2025/)
+- [Regulamento](https://femexrobotica.org/imav2025/index.php/rulebook-imav-2025/)
+
+</div>
+
+</div>
+
+<div class="nectar-project-row" markdown>
+
+## CBR 2025 — Flying Robot League
+
+<p class="nectar-project-caption">Competição Brasileira de Robótica 2025 · Flying Robot League (RoboCup Brasil)</p>
+
+<p class="nectar-project-desc">Indoor sem GPS — mapeamento de arena, entrega de pacotes, controle por gestos, navegação em labirinto.</p>
+
+<div class="nectar-meta" markdown>
+
+- [:simple-github: Repositório](https://github.com/Black-Bee-Drones/cbr-2025)
+- [:simple-huggingface: Modelos](https://huggingface.co/collections/blackbeedrones/cbr-2025)
+- [Competição](https://cbr.robocup.org.br/)
+- [Regras (PDF)](https://cbr.robocup.org.br/wp-content/uploads/2025/07/Regras-Flying-Robots-League-CBR-2025-Ingles-.pdf)
+
+</div>
+
+</div>
+
+<div class="nectar-project-row" markdown>
+
+## IMAV 2024
+
+<p class="nectar-project-caption">15ª International Micro Air Vehicle Conference and Competition</p>
+
+<p class="nectar-project-desc">Circuito indoor multitarefa e monitoramento outdoor de vida selvagem.</p>
+
+<div class="nectar-meta" markdown>
+
+- [:simple-github: Repositório](https://github.com/Black-Bee-Drones/imav-2024)
+- [Competição](https://www.imavs.org/2024/)
+- [Regras](https://www.imavs.org/2024/competition/index.html)
+
+</div>
+
+</div>
+
+<div class="nectar-project-row" markdown>
+
+## IMAV 2023
+
+<p class="nectar-project-caption">14ª International Micro Air Vehicle Conference and Competition · Stacking Challenge (indoor)</p>
+
+<p class="nectar-project-award">3º lugar, Stacking Challenge · Special Achievement Award</p>
+
+<p class="nectar-project-desc">Transporte de payload indoor — pouso com ArUco, seguimento de linha colorida, coleta e liberação de cones.</p>
+
+<div class="nectar-meta" markdown>
+
+- [:simple-github: Repositório](https://github.com/Black-Bee-Drones/imav2023-indoor)
+- [Competição](https://www.imavs.org/2023/)
+- [Resultados](https://www.imavs.org/2023/index.html@p=2323.html)
+- [Regras (PDF)](https://2023.imavs.org/wp-content/uploads/2023/08/IMAV2023_Indoor_CompetitionRules_v1.1.pdf)
+
+</div>
+
+</div>
+
+</div>

--- a/i18n/pt/setup/compatibility.md
+++ b/i18n/pt/setup/compatibility.md
@@ -1,0 +1,160 @@
+# Matriz de compatibilidade
+
+O que o Nectar SDK suporta, e até onde cada parte foi verificada, nas distribuições ROS 2
+e plataformas. O SDK é modular: uma instalação core puxa a base ROS, os pacotes do SDK e
+as deps Python core; todo o resto (backends de control, AI, RealSense, OAK-D, simulação)
+é um grupo opt-in. Cada tabela de módulo indica como instalá-lo.
+
+Este é um documento vivo. O status reflete a verificação mais completa feita até agora;
+as células avançam conforme mais setups são exercitados.
+
+## Legenda
+
+O símbolo de cada célula reflete o nível mais profundo de verificação alcançado (veja
+[Como é verificado](#how-its-verified)).
+
+| Símbolo | Significado |
+|:---:|---|
+| `●` | **Functional** — um check `verify-functional`, uma execução SITL ou um voo em hardware exercitou (uma operação real, não só um import). |
+| `◐` | **Build** — a imagem faz build e `make verify` passa (pacote presente, imports, nós); o check funcional ainda não foi registrado naquela distribuição. |
+| `○` | **Ainda não testado**. |
+| `—` | **Não aplicável** (o recurso ou sua dependência não está disponível ali). |
+
+A distribuição ROS 2 implica a base Ubuntu: **Humble** = 22.04, **Jazzy** / **Kilted** =
+24.04. A coluna **Jetson** é JetPack 6.x (L4T, arm64, CUDA), build a partir de
+[`docker/Dockerfile.jetson`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/docker/Dockerfile.jetson)
+sobre base Humble.
+
+## Plataformas
+
+SDK base (`nectar`, `nectar_interfaces`, Python core) — builds e `make verify`:
+
+| Plataforma | Humble | Jazzy | Kilted |
+|---|:---:|:---:|:---:|
+| Ubuntu amd64 (CI) | ● | ● | ● |
+| Ubuntu arm64 (CI) | ◐ | ◐ | ◐ |
+| Jetson JetPack 6.x (arm64) | ● | — | — |
+| Windows (WSL2 / Docker Desktop) | ● | ● | ● |
+
+## Runtime core
+
+Sempre instalado. Executor ROS 2, mensagens customizadas, interoperabilidade cv_bridge.
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| Executor rclpy + round-trip `nectar_interfaces` | ● | ● | ● | ● |
+| cv_bridge ↔ numpy (ABI `<2.0`) | ● | ● | ● | ● |
+
+## Vision
+
+Instalar: `make python-vision` (algoritmos) / extras de câmera conforme necessário.
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| ArUco / cor / linha / distância (algoritmos) | ● | ● | ● | ● |
+| Câmera por tópico ROS (`CameraFactory`) | ● | ● | ● | ● |
+| Câmera USB / OpenCV | ● | ● | ● | ● |
+| RealSense D4xx (librealsense source)[^realsense] | ● | ● | ◐ | ● |
+| OAK-D (`depthai`)[^oakd] | ● | ● | ◐ | ● |
+| MediaPipe mão / face[^mediapipe] | ● | ● | ● | ◐ |
+
+## Control
+
+Instalar: `make python-control`; backends são opt-in (`make drone-<x>`).
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| Núcleo do veículo (PID, navigator, transforms de frame) | ● | ● | ● | ● |
+| Transporte MAVLink direto (`pymavlink`)[^mavlink] | ● | ● | ● | ● |
+| Backend MAVROS (ArduPilot / PX4) | ◐ | ● | ● | ◐ |
+| PX4 nativo uXRCE-DDS[^px4dds] | ● | ● | ● | ◐ |
+| Crazyflie / Crazyswarm2[^crazyflie] | ● | ● | ● | ○ |
+| Driver Bebop[^bebop] | ● | ◐ | ◐ | — |
+
+## Localização (indoor / sem GPS)
+
+Instalar: `make python-control`; o container Isaac é só Jetson.
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| Ponte vision-pose — backend MAVROS | ● | ● | ● | ● |
+| Ponte vision-pose — backend MAVLink | ● | ● | ● | ● |
+| Isaac ROS Visual SLAM (producer)[^isaac] | — | — | — | ● |
+
+## Sensors
+
+Instalar: `make python-sensors`.
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| Filtro de máscara de obstáculo | ● | ● | ● | ● |
+| Rangefinder → MAVLink `DISTANCE_SENSOR` | ● | ● | ● | ● |
+| Driver UART TF-Luna[^tfluna] | ● | ● | ● | ● |
+
+## AI / detecção
+
+Instalar: `make python-ai && make pytorch`.
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| CLI `nectar-ai` | ● | ● | ● | ● |
+| Inferência de detecção (YOLO / DETR / RF-DETR)[^detect] | ● | ● | ◐ | ● |
+| Inferência de classificação (YOLO-cls / ViT) | ● | ● | ◐ | ● |
+| PyTorch CUDA (tensor GPU)[^torchcuda] | ● | ● | ● | ● |
+| Treinamento / segmentação / classificação | ● | ● | ◐ | ◐ |
+
+## Interface
+
+Instalar: `make python-interface`.
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| GUI Qt6 / PySide6 (construct offscreen) | ● | ● | ● | ● |
+| GUI completa em display[^gui] | ● | ● | ● | ● |
+
+## Simulação
+
+Instalar: `make sim-install`. Não faz parte de nenhuma imagem publicada.
+
+| Recurso | Humble | Jazzy | Kilted | Jetson |
+|---|:---:|:---:|:---:|:---:|
+| Gazebo + ponte `ros_gz`[^gazebo] | ● | ● | ● | ○ |
+| ArduPilot SITL — MAVROS[^sitl] | ● | ● | ● | — |
+| ArduPilot SITL — MAVLink[^sitl] | ● | ● | ● | — |
+| PX4 SITL — MAVROS[^sitl] | ◐ | ● | ● | — |
+| PX4 SITL — MAVLink[^sitl] | ◐ | ● | ● | — |
+| PX4 SITL — uXRCE-DDS[^sitl] | ● | ● | ● | — |
+
+## Versões pinadas
+
+<span id="pinned-versions"></span>
+
+Versões por distro em
+[`scripts/lib/config.sh`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/lib/config.sh).
+
+| | Humble | Jazzy | Kilted | Jetson |
+|---|---|---|---|---|
+| librealsense / realsense-ros | v2.55.1 / 4.55.1 | v2.56.5 / 4.56.4 | v2.57.6 / 4.57.2 | v2.55.1 / 4.55.1 (CUDA, RSUSB) |
+| Micro-XRCE-DDS-Agent | v2.4.2 | v2.4.3 | v3.0.1 | (igual ao Humble) |
+| Gazebo (`ros_gz`) | Harmonic (source) | Harmonic (binary) | Ionic (binary) | — |
+| PyTorch | uv `--torch-backend` (CPU/CUDA) | igual | igual | wheels JetPack (CUDA) |
+
+## Como é verificado
+
+<span id="how-its-verified"></span>
+
+Três comandos sustentam esta matriz; o símbolo de uma célula reflete o nível mais profundo
+alcançado. O CI roda os níveis 1-2 em distros/arches e as células acima são atualizadas à
+mão a partir desses resultados.
+
+| Nível | Comando | O que prova |
+|------|---------|----------------|
+| 1 — Build | `make verify` | A imagem faz build, os pacotes estão presentes, os módulos importam e os executáveis dos nós estão instalados. (`make doctor` dá um relatório somente leitura de ambiente/dispositivo/CUDA.) |
+| 2 — Functional | `make verify-functional` | A suíte **pytest** em [`nectar/test/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/test) (também por `colcon test`). Cada teste faz uma *operação real* — detectar um ArUco sintético, um passo de PID, handshake MAVLink em loopback, relé de pose VSLAM, abrir a janela Qt offscreen, inferência com nano-modelo. Os testes se pulam quando dispositivo/GPU/sim/dependência falta. Subconjunto com `MODULE="vision control"`; testes de hardware/GPU entram com `make verify-hardware`; reproduza por distro com `make ci-local`. |
+| 3 — SITL / integração | `make verify-sitl` | A suíte em [`nectar/test/sitl/`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/nectar/test/sitl): um voo headless real (connect, takeoff, move, land) por firmware/protocolo. |
+
+## Ainda não coberto
+
+- **ROS 2 Lyrical (Ubuntu 26.04)**: ainda não suportado. No momento da escrita o deb
+  `mavros` não está publicado para Lyrical e a stack scientific-Python não tem wheels para
+  Python 3.14; a camada ROS/C++ e o Gazebo compilam. Revisar quando os dois chegarem.

--- a/i18n/pt/setup/configuration.md
+++ b/i18n/pt/setup/configuration.md
@@ -1,0 +1,40 @@
+# Configuração
+
+De onde o SDK lê versões e caminhos, e como sobrescrevê-los.
+
+## Versões e listas de pacotes
+
+Todas as versões e listas de pacotes ficam em um único arquivo:
+
+```
+scripts/lib/config.sh
+```
+
+Edite-o para mudar a distro ROS, a versão do PyTorch, a do librealsense, as listas apt e
+mais. Todo script, o Makefile e o Dockerfile leem deste arquivo, então uma mudança aqui
+se propaga. Overrides comuns por invocação (sem editar):
+
+| Variável | Controla |
+|---|---|
+| `ROS_DISTRO` | Distribuição ROS 2 (p.ex. `humble`, `jazzy`, `kilted`) |
+| `TORCH_VERSION` / `TORCHVISION_VERSION` | Par PyTorch (defina os dois juntos) |
+| `LIBREALSENSE_VERSION` / `REALSENSE_ROS_TAG` | Versões da stack RealSense |
+
+## Local do ambiente Python
+
+<span id="python-environment-location"></span>
+
+As dependências Python instalam em `$WORKSPACE/.venv`. Sobrescreva com `NECTAR_VENV=/path`;
+um `VIRTUAL_ENV` ativo é respeitado. Para ativação e compartilhamento no workspace, veja
+[Instalação — Ambiente Python](index.md#python-environment).
+
+!!! warning "Deixe o SDK criar o venv"
+    Use sempre `make python*` / `make setup` para criar `$WORKSPACE/.venv` — ele fixa o
+    venv no `python3` do ROS. Um `uv venv` manual pode escolher um Python mais novo sem
+    wheels para algumas dependências (p.ex. `mediapipe`).
+
+## Mudar versões no workspace
+
+Como `scripts/lib/config.sh` é a fonte única, atualizar uma dependência para todo o
+workspace (SDK + seus pacotes de missão que compartilham o venv) é uma edição seguida de
+uma nova execução do alvo `make python*` / `make pytorch` / `make realsense` correspondente.

--- a/i18n/pt/setup/docker.md
+++ b/i18n/pt/setup/docker.md
@@ -1,0 +1,606 @@
+# Docker
+
+## Imagens
+
+Imagens x86_64 (`Dockerfile`) recebem tag por distro ROS (`nectar-sdk:<distro>`), por exemplo `:humble`, `:jazzy`, `:kilted`; variantes de AI acrescentam `-full-<torch>`. Imagens Jetson (`Dockerfile.jetson`) recebem as tags `:jetson` / `:jetson-full` — veja [Jetson (Orin)](#jetson-orin).
+
+| Tag | Conteúdo | PyTorch |
+|-----|----------|---------|
+| `:humble` | core + control + vision + interface + realsense + oakd + `INSTALL_DRONE=all` | Nenhum |
+| `:humble-t265` | Tudo acima + librealsense v2.53.1 + suporte a T265 | Nenhum |
+| `:humble-full-cpu` | Tudo acima + pacotes de AI | CPU |
+| `:humble-full-cu126` | Tudo acima + pacotes de AI | CUDA 12.6 |
+| `:jetson` | todos os módulos não-AI (base L4T) | Nenhum |
+| `:jetson-full` | Tudo acima + AI + RealSense (RSUSB) | CUDA 12.6 (wheels Jetson) |
+
+## Início rápido
+
+```bash
+make docker-build       # SDK (no AI, ~5 min)
+make docker-run         # auto-selects image, GPU auto-detected
+make docker-exec        # open more terminals
+```
+
+No Jetson, esses comandos direcionam automaticamente para `Dockerfile.jetson` (tags `:jetson`) e `--runtime nvidia` — veja [Jetson (Orin)](#jetson-orin).
+
+## Build
+
+```bash
+make docker-build                              # SDK (no AI)
+make docker-build-full                         # + AI with PyTorch CPU (default)
+TORCH_VARIANT=cu126 make docker-build-full     # + AI with PyTorch CUDA 12.6
+TORCH_VARIANT=auto  make docker-build-full     # auto-detect CUDA from nvidia-smi
+```
+
+### Distro ROS diferente
+
+```bash
+ROS_DISTRO=jazzy make docker-build
+ROS_DISTRO=jazzy TORCH_VARIANT=cu126 make docker-build-full
+```
+
+### Fixar uma versão específica do PyTorch (avançado)
+
+Por padrão o pip resolve a versão mais recente do torch compatível com o índice CUDA escolhido.
+Sobrescreva com variáveis de ambiente:
+
+```bash
+TORCH_VERSION=2.9.1 TORCHVISION_VERSION=0.24.1 TORCH_VARIANT=cu126 make docker-build-full
+```
+
+## Rodar
+
+```bash
+make docker-run         # shows menu if multiple images exist
+make docker-exec        # extra terminal in running container
+```
+
+`docker-run` automaticamente:
+
+- Detecta as imagens disponíveis (mostra um menu se houver mais de uma)
+- Adiciona `--gpus all` quando detecta uma GPU NVIDIA
+- Monta o projeto local dentro do container (edição de código ao vivo)
+- Monta X11, câmeras (`/dev/video*`), USB, `/dev`
+- Habilita host networking para o ROS2
+
+O mount do projeto local significa que edições em arquivos Python no host aparecem
+instantaneamente dentro do container (via `--symlink-install`). Para mudanças em C++ ou
+em mensagens, rode `colcon build` dentro do container.
+
+Para rodar só com o código já embutido na imagem (sem mount local):
+
+```bash
+DOCKER_NO_MOUNT=true make docker-run
+```
+
+### Windows
+
+**Nota:** usuários Windows não podem usar comandos `make` nem o script bash `setup.sh`. Use o script auxiliar do PowerShell.
+
+**PowerShell:**
+
+```powershell
+.\docker\run_docker_win.ps1 build jazzy full-cu126 -Realsense   # + librealsense (~15-20 min)
+.\docker\run_docker_win.ps1 test jazzy full-cu126
+.\docker\run_docker_win.ps1 run jazzy full-cu126                # GUI + GPU + USB bus
+.\docker\run_docker_win.ps1 exec
+```
+
+O script suporta:
+
+- Distros ROS 2: `humble`, `jazzy`, `kilted`
+- Variantes de build: `full-cpu`, `full-cu126` (para builds completos; `cu126` casa com os pins padrão do torch 2.9.x)
+- `-Realsense` em `build` — define `INSTALL_REALSENSE=true` (librealsense + realsense-ros a partir do source)
+- Detecção automática de GPU (exige Docker Desktop com NVIDIA Container Toolkit)
+- GUI via [VcXsrv](https://sourceforge.net/projects/vcxsrv/) / XLaunch (`DISPLAY=host.docker.internal:0.0`)
+- USB via [usbipd-win](https://github.com/dorssel/usbipd-win) (subcomando `usb`; veja abaixo)
+
+#### GUI (VcXsrv)
+
+1. Instale o [VcXsrv](https://sourceforge.net/projects/vcxsrv/) e rode o **XLaunch**.
+2. **Multiple windows**, display **0**, **Start no client**.
+3. Habilite **Disable access control** (obrigatório).
+4. Inicie o XLaunch **antes** do `run`. Desmarque **Native opengl** se a janela do Qt aparecer em branco.
+
+```powershell
+.\docker\run_docker_win.ps1 run jazzy full-cu126
+
+# inside container:
+
+ros2 run nectar app.py
+```
+
+#### Câmeras USB e RealSense
+
+<span id="usb-cameras-and-realsense"></span>
+
+O Docker Desktop não repassa dispositivos USB nativamente ([Docker FAQ](https://docs.docker.com/desktop/troubleshoot-and-support/faqs/general/#can-i-pass-through-a-usb-device-to-a-container)). Use o **usbipd-win** para compartilhar dispositivos com a VM WSL `docker-desktop` e depois monte `/dev/bus/usb` dentro do container (o comando `run` faz isso por padrão).
+
+**Instale o usbipd-win** ([releases](https://github.com/dorssel/usbipd-win/releases)) e depois:
+
+```powershell
+.\docker\run_docker_win.ps1 usb list
+```
+
+| Dispositivo | Windows Docker | Notas |
+|--------|----------------|-------|
+| **Intel RealSense D435i** | Suportado (com instalação) | Usa libusb (RSUSB); **não** precisa de `/dev/video*`. Rebuild com `-Realsense`. |
+| **Webcam integrada / USB** | Limitado | O USB conecta e o `lsusb` vê o dispositivo, mas o kernel WSL do Docker Desktop costuma não ter o driver UVC — `/dev/video0` pode não aparecer, então `webcam` / `VideoCapture(0)` do OpenCV falha. Use RealSense ou Linux nativo para fluxos de webcam. |
+
+**Fluxo de trabalho com RealSense:**
+
+```powershell
+
+# 1) One-time bind (admin PowerShell) — or use: .\run_docker_win.ps1 usb bind realsense
+
+usbipd bind --busid <BUSID>    # from: .\run_docker_win.ps1 usb list
+
+# 2) Attach before each session (re-attach after unplug with -AutoAttach)
+
+.\docker\run_docker_win.ps1 usb attach realsense -AutoAttach
+
+# 3) Rebuild image with RealSense stack (once, ~15-20 min extra)
+
+.\docker\run_docker_win.ps1 build jazzy full-cu126 -Realsense
+
+# 4) Probe inside container
+
+.\docker\run_docker_win.ps1 -Command usb -UsbAction check -Distro jazzy -Variant full-cu126
+
+# 5) Run and test
+
+.\docker\run_docker_win.ps1 run jazzy full-cu126
+```
+
+Dentro do container:
+
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+source /home/ros2_ws/install/local_setup.bash
+rs-enumerate-devices
+ros2 launch realsense2_camera rs_launch.py
+```
+
+Enquanto um dispositivo está anexado ao WSL, o acesso é **exclusivo** — apps do Windows não conseguem usá-lo até um `usbipd detach`.
+
+**Webcam (experimental):** `usb attach webcam` compartilha o dispositivo, mas sem `/dev/video*` o OpenCV não consegue abri-lo. Se nós de vídeo aparecerem (`usb list` os mostra sob docker-desktop), o `run` acrescenta flags `--device` automaticamente.
+
+Passe `-NoUsb` no `run` para pular os mounts de volume USB.
+
+**Nota:** para aplicações GUI no Windows, garanta que o VcXsrv esteja rodando com o controle de acesso desabilitado.
+
+## GPU
+
+| Hardware | Comando de build |
+|----------|-------------|
+| Sem GPU | `make docker-build-full` |
+| GPU NVIDIA | `TORCH_VARIANT=cu126 make docker-build-full` |
+| Auto-detecção | `TORCH_VARIANT=auto make docker-build-full` |
+| Jetson (Orin) | `make docker-build-full` (auto-detectado → `Dockerfile.jetson`) |
+| Não precisa de AI | `make docker-build` |
+
+O passthrough de GPU é adicionado automaticamente em runtime: `--gpus all` em x86_64 quando `nvidia-smi` é encontrado, `--runtime nvidia` no Jetson.
+Veja a [documentação de GPU do Docker](https://docs.docker.com/desktop/features/gpu/) para a instalação.
+
+Você também pode instalar o torch CUDA dentro de um container CPU já em execução:
+
+```bash
+./scripts/setup.sh pytorch cu126
+./scripts/setup.sh python ai
+```
+
+## Jetson (Orin)
+
+`make docker-build` / `docker-build-full` auto-detectam o Jetson (Tegra) e fazem build do
+[`Dockerfile.jetson`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/docker/Dockerfile.jetson): uma base `l4t-jetpack` com ROS 2 Humble e o SDK;
+`-full` acrescenta o PyTorch a partir do [índice do Jetson AI Lab](https://pypi.jetson-ai-lab.io/jp6/cu126)
+(CUDA 12.6) mais a stack de AI. As imagens recebem as tags `:jetson` / `:jetson-full`.
+
+```bash
+make docker-build        # nectar-sdk:jetson
+make docker-build-full   # nectar-sdk:jetson-full
+make docker-run          # auto-uses --runtime nvidia (Tegra rejects --gpus all)
+```
+
+Exige o NVIDIA Container Toolkit. Sobrescreva a imagem base ou o índice do torch com
+`L4T_TAG=` / `TORCH_INDEX=`. Esta é a imagem do SDK (control/vision/AI); o producer VSLAM
+sem GPS é um container separado — veja [Isaac ROS Visual SLAM](#isaac-ros-visual-slam-jetson).
+
+O RealSense também é opt-in aqui (backend RSUSB, necessário para a IMU do D435i no
+JetPack 6; CUDA é opcional). O build compila o librealsense a partir do source, então
+leva ~40-50 min em um Orin Nano:
+
+```bash
+INSTALL_REALSENSE=true REALSENSE_CUDA=true make docker-build-full
+```
+
+### Publicando a imagem Jetson
+
+O CI x86 não consegue fazer build da imagem Jetson (L4T), então ela é publicada manualmente a partir de
+um Jetson no release. `make docker-publish-jetson` verifica a imagem local
+nesse hardware (SDK + `torch.cuda` + RealSense) e só faz push se a verificação passar:
+
+```bash
+docker login                                                       # Docker Hub account
+INSTALL_REALSENSE=true REALSENSE_CUDA=true make docker-build-full  # complete image
+make docker-publish-jetson JETSON_NAMESPACE=blackbeedrones VERSION=v1.1.0
+```
+
+Isso faz push de três tags: `:jetson-full-<VERSION>`, `:jetson-full-jp6.2` (linha do JetPack
+— a imagem só roda em um JetPack compatível) e `:jetson-full`. Passe
+`JETSON_TARGET=sdk` para publicar a imagem sem AI em vez disso.
+
+## Backends de controle
+
+Backends de controle são opt-in via o build arg `INSTALL_DRONE`. Use `all` para a
+imagem de release publicada (`make drone-all`: MAVROS + Crazyflie são obrigatórios; Bebop e
+PX4 uXRCE-DDS são best-effort por distro). A imagem core traz só MAVLink (`pymavlink`).
+
+**Conjunto publicado** (`INSTALL_DRONE=all`):
+
+```bash
+INSTALL_DRONE=all make docker-build
+```
+
+**Só MAVLink/pymavlink** (padrão):
+
+```bash
+make docker-build
+```
+
+**Lista customizada:**
+
+```bash
+INSTALL_DRONE="mavros crazyflie" make docker-build
+```
+
+O Crazyflie instala via apt no Humble/Jazzy e a partir do source no Kilted quando não há
+binário apt disponível. Bebop e PX4-DDS são tentados em `all`, mas são pulados com um aviso
+se falharem em uma determinada distro. PX4 sobre MAVROS precisa do `mavros` (incluído em `all`).
+
+## RealSense
+
+O suporte a RealSense é opt-in (compila o librealsense a partir do source, acrescenta ~15-20 min e ~500 MB).
+É instalado no stage `sdk`, então tanto a imagem base (`:<distro>`) quanto a full (`:<distro>-full-*`) o incluem.
+
+**SDK com RealSense** (sem AI):
+
+```bash
+INSTALL_REALSENSE=true make docker-build
+```
+
+**Full com RealSense + AI + GPU**:
+
+```bash
+INSTALL_REALSENSE=true TORCH_VARIANT=cu126 make docker-build-full
+```
+
+**Com librealsense acelerado por CUDA**:
+
+```bash
+INSTALL_REALSENSE=true REALSENSE_CUDA=true TORCH_VARIANT=cu126 make docker-build-full
+```
+
+As versões são auto-selecionadas por distro ROS (`scripts/lib/config.sh`). Os pins padrão de
+librealsense / realsense-ros do D4xx por distro estão em
+[COMPATIBILITY.md](compatibility.md#pinned-versions).
+
+**T265 (só no Humble, descontinuada):** librealsense **v2.53.1** e realsense-ros **4.51.1**.
+Sobrescreva no momento do build:
+
+```bash
+
+# T265 tracking camera (Humble only, last supported versions)
+
+LIBREALSENSE_VERSION=v2.53.1 REALSENSE_ROS_TAG=4.51.1 \
+  INSTALL_REALSENSE=true make docker-build
+```
+
+Regras udev e scripts de hotplug para D435/D435i/D455/T265 estão incluídos para
+acesso a dispositivos em runtime (seguindo o padrão Docker do
+[VSLAM-UAV](https://github.com/bandofpv/VSLAM-UAV)).
+
+### Câmera de tracking T265 (Docker)
+
+Usa as versões de override da T265 acima. O build usa `FORCE_RSUSB_BACKEND=true` (libusb
+em user-space), então qualquer kernel do host funciona, incluindo o 6.x. O Docker mantém essas
+versões legadas isoladas do librealsense mais novo no host.
+
+**Build** (exige a imagem base `:humble` — construída automaticamente se estiver faltando):
+
+```bash
+make docker-build-t265
+```
+
+Isso produz `nectar-sdk:humble-t265`. Internamente ele inicia um container
+a partir de `:humble`, instala librealsense v2.53.1 + realsense-ros 4.51.1,
+refaz o build do workspace e commita o resultado.
+
+**Run** (conecte a T265 primeiro):
+
+```bash
+make docker-run   # select the humble-t265 image from the menu
+```
+
+O comando `docker-run` já passa `--privileged`, `--device=/dev/bus/usb`
+e forwarding de X11, o que é suficiente para acesso a câmeras USB e ferramentas GUI.
+
+**Teste dentro do container:**
+
+```bash
+
+# Check if the T265 is detected
+
+rs-enumerate-devices
+
+# GUI viewer (requires X11 forwarding)
+
+realsense-viewer
+
+# ROS 2 launch
+
+source /home/ros2_ws/install/setup.bash
+ros2 launch realsense2_camera rs_launch.py device_type:=t265
+
+# Relay the camera pose to the FCU with the SDK vision-pose bridge (replaces the
+
+# external vision_to_mavros). Point input_topic at the T265 pose topic; see
+
+# nectar/nectar/control/localization/README.md.
+
+ros2 launch nectar vision_pose.launch.py backend:=mavros
+```
+
+**Regra udev no host** (opcional, para permissões USB consistentes):
+
+```bash
+
+# Copy the rules file to the host
+
+sudo cp docker/realsense/99-realsense-libusb-custom.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+> **Nota:** se o `realsense-viewer` falhar com erros de OpenGL, defina `LIBGL_ALWAYS_SOFTWARE=1` dentro do
+> container para renderização via software.
+
+## Isaac ROS Visual SLAM (Jetson)
+
+O **producer** do pipeline de localização (RealSense + Isaac ROS Visual SLAM) roda
+no container de dev do Isaac ROS. Ele é separado da imagem principal do SDK porque
+o Isaac ROS só é suportado dentro do seu próprio ambiente de dev (que traz o
+repositório apt da NVIDIA Isaac e as versões corretas de CUDA/TensorRT/VPI). A imagem
+do SDK ou o host roda o lado **consumer** (MAVROS + ponte vision-pose), compartilhando
+`ROS_DOMAIN_ID`.
+
+[`docker/isaac_vslam`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/docker/isaac_vslam) é um wrapper autocontido em torno do
+[`isaac_ros_common/run_dev.sh`](https://nvidia-isaac-ros.github.io/v/release-3.2/concepts/docker_devenv/index.html) oficial da NVIDIA.
+Um único comando clona o `isaac_ros_common` (`release-3.2`) e faz build da imagem
+com a key `ros2_humble.realsense.nectar` de baixo para cima: a base NVCR pré-compilada →
+`realsense` (o [`Dockerfile.realsense`](https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common) do isaac_ros_common:
+librealsense `v2.55.1` compilado a partir do source com o **backend RSUSB/libuvc** +
+realsense-ros `4.51.1-isaac`) → `nectar`
+([`Dockerfile.nectar`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/docker/isaac_vslam/Dockerfile.nectar): Visual SLAM + o
+helper `nectar-vslam`). O `run_dev.sh` fornece toda a config de device/GPU/X11/Jetson
+(`--privileged`, `--runtime nvidia`, mounts do tegra, `-e ROS_DOMAIN_ID`); o wrapper acrescenta
+`-v /dev/bus/usb:/dev/bus/usb` para que o RealSense continue visível entre re-enumerações de USB.
+
+> **Nota — O primeiro build leva ~40-50 min em um Orin Nano:** ele compila o librealsense a partir do source;
+> as execuções seguintes usam cache.
+> **Nota — Por que o backend RSUSB (não instale `realsense2-camera` via apt):** o backend RSUSB é
+> necessário para a IMU do D435i no JetPack 6, que removeu o suporte de kernel `hiddraw` do qual o build
+> apt do `realsense2-camera` depende (senão: `No HID info provided, IMU is disabled`).
+> Instalar `realsense2-camera` via apt no `Dockerfile.nectar` traria esse build quebrado de kernel-HID
+> no lugar do build a partir do source.
+> **Aviso — Mounts de device: bind em `/dev/bus/usb`, nunca em todo o `/dev`:** com `--privileged` sozinho
+> o `/dev` do container é um snapshot estático tirado na criação, então os nós da câmera — recriados na
+> enumeração/reset de USB depois que o container inicia — nunca aparecem; o bind mount de `/dev/bus/usb`
+> é uma visão viva do host que sobrevive a essas re-enumerações. Não monte todo o `/dev` (`-v /dev:/dev`):
+> isso esconde os nós de device de GPU que o `--runtime nvidia` injeta, e como o `run_dev.sh` roda o cuVSLAM
+> como o usuário não-root `admin`, a inicialização do pool de memória CUDA falha com `cudaErrorNotSupported` /
+> `setCUDAMemoryPoolSize Error: GXF_FAILURE` (funciona como root, falha como `admin`).
+
+**Inicie (ou entre no) container Isaac** — clone + build (se necessário) + entrada:
+
+```bash
+make isaac-run        # or: ./docker/isaac_vslam/run_docker.sh
+```
+
+**Dentro do container, inicie o producer** com o helper já embutido:
+
+```bash
+nectar-vslam          # = ros2 launch nectar/launch/isaac_vslam_realsense.launch.py
+```
+
+> **Aviso — rode só um container cuVSLAM por vez:** o container usa `--ipc=host` e
+> `--pid=host`, então se o cuVSLAM travar, o processo GXF morto deixa um mutex robusto em memória
+> compartilhada que aborta o próximo launch com `cudaErrorNotSupported` / `setCUDAMemoryPoolSize Error` e
+> uma assertion `pthread ... ESRCH`. Recupere removendo o container (ao qual o `run_dev.sh`, senão,
+> voltaria a se conectar):
+>
+> ```bash
+> make isaac-stop       # docker rm -f the nectar (and old isaac) containers
+> make isaac-run        # fresh container; cuVSLAM initializes cleanly
+> ```
+
+Lado consumer (imagem do SDK ou host), mesmo `ROS_DOMAIN_ID`:
+
+```bash
+ros2 launch nectar vision_pose.launch.py backend:=mavros fcu_url:=/dev/ttyTHS1:921600
+```
+
+Requisitos no Jetson: Docker (non-root), `git-lfs` e o NVIDIA Container
+Toolkit. Para permissões USB do RealSense no host, instale as regras udev em
+[`docker/realsense`](https://github.com/Black-Bee-Drones/nectar-sdk/tree/main/docker/realsense).
+
+### Requisitos de hardware (cuVSLAM)
+
+O Isaac ROS Visual SLAM (cuVSLAM) tem um piso de GPU rígido, segundo as páginas oficiais de
+[compute setup](https://nvidia-isaac-ros.github.io/v/release-3.2/getting_started/hardware_setup/compute/index.html)
+e [Visual SLAM](https://nvidia-isaac-ros.github.io/v/release-3.2/repositories_and_packages/isaac_ros_visual_slam/index.html)
+(release-3.2):
+
+- Jetson: família Orin no JetPack 6.1 / 6.2.
+- x86_64: GPU NVIDIA discreta, **arquitetura Ampere ou mais recente**, **>= 8 GB de VRAM**
+  (12 GB+ recomendado), driver **560+**, CUDA 12.6+, Ubuntu 22.04+.
+
+GPUs pré-Ampere **não** são compatíveis com a biblioteca cuVSLAM (os maintainers
+confirmam isso para arquiteturas mais antigas em
+[isaac_ros_visual_slam#117](https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_visual_slam/issues/117)).
+Uma placa GTX série 16 (Turing) ou anterior não consegue rodar o nó Visual SLAM. A
+imagem do container ainda **faz build e inicia** nesse hardware (útil para validar
+a fiação Docker do SDK), mas o próprio nó cuVSLAM não vai rodar -- teste o pipeline
+de localização via o sim indoor do Gazebo em vez disso (veja o
+[módulo Simulation](../modules/simulation.md)), que exercita as mesmas
+pontes e tópicos sem precisar de cuVSLAM/Jetson.
+
+### Versão e distro ROS
+
+O Isaac ROS vincula cada linha de release a uma distro ROS 2 e um JetPack, segundo as
+[release notes](https://nvidia-isaac-ros.github.io/releases/index.html):
+
+| Isaac ROS | ROS 2 | Ubuntu | JetPack | CUDA | Método de build |
+|---|---|---|---|---|---|
+| **3.2** (padrão do SDK) | Humble | 22.04 | 6.1 / 6.2 | 12.6 | `isaac_ros_common/run_dev.sh` (este wrapper) |
+| 4.x (mais recente, 4.4) | Jazzy | 24.04 | 7.x | 13.0 | Repo APT do Isaac ROS + CLI `isaac-ros` |
+
+O SDK fixa **`ISAAC_ROS_VERSION=release-3.2`** ([scripts/lib/config.sh](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/lib/config.sh))
+porque o Jetson alvo roda JetPack 6.2 (Humble). O Isaac ROS 4.x **não** é
+um simples bump de config: ele exige um reflash para JetPack 7 (Ubuntu 24.04 / Jazzy) e usa uma
+toolchain diferente.
+
+#### Migrando para o Isaac ROS 4.x (futuro, requer JetPack 7)
+
+O 4.x substitui o `run_dev.sh` pela [CLI `isaac-ros`](https://github.com/NVIDIA-ISAAC-ROS/isaac-ros-cli)
+sobre um repositório APT ([getting started](https://nvidia-isaac-ros.github.io/getting_started/)):
+
+```bash
+
+# 1. Add the Isaac ROS APT repo (noble = Ubuntu 24.04; use noble-jetpack on Jetson)
+
+#    deb https://isaac.download.nvidia.com/isaac-ros/release-4 noble main
+
+sudo apt-get install isaac-ros-cli
+sudo isaac-ros init docker        # modes: docker | venv | baremetal
+isaac-ros activate
+sudo apt-get install ros-jazzy-isaac-ros-visual-slam ros-jazzy-isaac-ros-examples ros-jazzy-isaac-ros-realsense
+```
+
+Quando o time migrar para o JetPack 7, o lado producer (`docker/isaac_vslam`) passaria
+a usar esse fluxo baseado em CLI com pacotes `ros-jazzy-*`; o lado consumer do SDK
+(`vision_pose_node`, launches, configs) é agnóstico de distro e não é afetado. Nota:
+as release notes apontam problemas de estabilidade do RealSense no JetPack 7 (nvbugs/5561995),
+mitigados pelo tutorial de instalação do RealSense.
+
+## Gazebo
+
+O suporte a simulação Gazebo é opt-in. Instala o Gazebo, a ponte `ros_gz` e o
+plugin ArduPilot Gazebo. A versão correta do Gazebo e o método de instalação são
+selecionados automaticamente por distro ROS (`scripts/lib/config.sh`).
+
+**SDK com Gazebo** (sem AI):
+
+```bash
+INSTALL_GAZEBO=true make docker-build
+```
+
+**Distro ROS diferente**:
+
+```bash
+INSTALL_GAZEBO=true ROS_DISTRO=jazzy make docker-build
+```
+
+**Combinado com RealSense + AI + GPU**:
+
+```bash
+INSTALL_GAZEBO=true INSTALL_REALSENSE=true TORCH_VARIANT=cu126 make docker-build-full
+```
+
+As versões do Gazebo por distro e o método de instalação do `ros_gz` (source vs binário)
+estão fixados em [`config.sh`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/lib/config.sh)
+e resumidos em [COMPATIBILITY.md](compatibility.md#pinned-versions).
+
+### SITL (voo em simulação)
+
+`INSTALL_SIM` compila a stack SITL do autopilot (`ardupilot`, `px4` ou `all`) dentro
+da imagem — pesado, já que os autopilots compilam a partir do source (~1-2 h a frio). Para
+voar de fato você também precisa do backend de controle correspondente (`INSTALL_DRONE`):
+
+```bash
+
+# ArduPilot SITL image (MAVROS + direct MAVLink)
+
+INSTALL_SIM=ardupilot INSTALL_DRONE=mavros make docker-build
+```
+
+Rode a suíte de voo headless (sem precisar de GPU — usa Mesa software GL):
+
+```bash
+docker run --rm --shm-size=1g -e LIBGL_ALWAYS_SOFTWARE=1 nectar-sdk:<distro> \
+  bash -lc 'source /opt/ros/$ROS_DISTRO/setup.bash; \
+            source /home/ros2_ws/install/local_setup.bash; \
+            make verify-sitl FIRMWARE=ardupilot'
+```
+
+O PX4 não precisa de mavros (use `INSTALL_SIM=px4`; para uXRCE-DDS acrescente `INSTALL_DRONE=px4-dds`).
+Em um host você não precisa de imagem nenhuma — `make sim-install` e depois `make verify-sitl`.
+
+## Estratégia de dependências
+
+O PyTorch **não** está listado nas dependências do `pyproject.toml`. Isso é intencional:
+
+1. `setup.sh pytorch <variant>` instala torch + torchvision a partir do índice
+   correto de wheels (CPU ou CUDA) e salva um arquivo de constraints.
+2. `setup.sh python ai` instala o extra `[ai]` **com** esse arquivo de constraints
+   e `--extra-index-url`, então o pip nunca substitui as wheels CUDA por
+   wheels genéricas do PyPI.
+
+### numpy < 2.0
+
+`numpy>=1.26,<2.0` é forçado no `pyproject.toml` para compatibilidade com os binários
+`cv_bridge` / `vision_opencv` do ROS 2 em Humble, Jazzy e Kilted.
+Veja [vision_opencv#535](https://github.com/ros-perception/vision_opencv/issues/535).
+
+## Instalação do Docker
+
+### Windows
+
+1. Baixe o [instalador do Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/#install-from-the-command-line).
+2. Abra a pasta que contém o instalador no Command Prompt (execute como Administrador).
+3. Instale o Docker Desktop usando a linha de comando para ter mais controle sobre as opções de instalação:
+
+    ```bash
+    start /w "" "Docker Desktop Installer.exe" install -accept-license --installation-dir="D:\Docker\Docker" --wsl-default-data-root="D:\Docker\wsl" --windows-containers-default-data-root="D:\Docker"
+    ```
+
+    - Essa configuração permite personalizar o diretório de instalação e o local padrão do WSL (imagens Docker).
+    - Personalizar esses caminhos é especialmente útil se o seu drive principal (por exemplo, `C:`) tiver espaço limitado.
+
+4. Para GUI no Docker, instale o [VcXsrv](https://sourceforge.net/projects/vcxsrv/) (XLaunch: desabilite o access control). Para câmeras USB / RealSense, instale o [usbipd-win](https://github.com/dorssel/usbipd-win/releases) — veja [Windows USB](#usb-cameras-and-realsense) neste guia.
+
+### Linux (Ubuntu)
+
+1. Adicione a chave GPG e o repositório oficiais do Docker:
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install ca-certificates curl
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update
+    ```
+
+2. Baixe o arquivo `.deb` mais recente do Docker Desktop nas [release notes oficiais](https://docs.docker.com/desktop/release-notes/).
+3. Instale o Docker Desktop e o Docker Engine:
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install ./docker-desktop-amd64.deb
+    sudo apt-get install docker-ce
+    ```

--- a/i18n/pt/setup/drivers.md
+++ b/i18n/pt/setup/drivers.md
@@ -1,0 +1,133 @@
+# Drivers de drone
+
+Cada drone precisa do próprio driver ou ponte, iniciado em um terminal separado antes da
+missão se conectar (os exemplos usam `start_driver=False` por padrão). Este é o
+correspondente no mundo real da ponte de [simulação](simulation.md).
+
+Escolha o drone abaixo para instalação, comando do driver e um voo exemplo. Os alvos estão
+em `scripts/lib/drones.sh`.
+
+## Escolha seu drone
+
+=== "ArduPilot · MAVROS"
+
+    Instala MAVROS e os datasets geoid GeographicLib.
+
+    ```bash
+    make setup                 # pick: control
+    make drone-mavros
+    ```
+
+    Inicie o driver e depois voe um quadrado de 2 m:
+
+    ```bash
+    make driver DRONE=mavros FCU_URL=serial:///dev/ttyUSB0:921600   # terminal 1
+    nectar-activate                                                 # terminal 2
+    python3 nectar/nectar/examples/control/basic.py --drone mavros --mode position --side 2.0
+    ```
+
+=== "ArduPilot · MAVLink"
+
+    Sem instalação separada: `pymavlink` vem com o SDK core, então a missão abre o link.
+    `make drone-mavros` adiciona os dados geoid usados na altitude GPS.
+
+    Outdoor não precisa de ponte; voe direto:
+
+    ```bash
+    nectar-activate
+    python3 nectar/nectar/examples/control/basic.py \
+        --drone mavlink --mode position --side 2.0 --env outdoor \
+        --connection serial:///dev/ttyUSB0:921600
+    ```
+
+    Indoor (sem GPS): inicie o alimentador de visão primeiro e depois a missão em outro
+    endpoint MAVLink (exemplo Black Bee com MAVProxy: feeder `14552`, missão `14551`):
+
+    ```bash
+    make driver DRONE=mavlink ENV=indoor          # terminal 1: vision feeder
+    python3 nectar/nectar/examples/control/basic.py \
+        --drone mavlink --mode position --side 2.0 --env indoor \
+        --connection udp:127.0.0.1:14551           # terminal 2: mission
+    ```
+
+=== "PX4 · MAVROS"
+
+    Reutiliza MAVROS, lançado com `px4.launch`.
+
+    ```bash
+    make setup                 # pick: control
+    make drone-px4
+    ```
+
+    ```bash
+    make driver DRONE=px4 FCU_URL=udp://:14540@127.0.0.1:14580   # terminal 1
+    nectar-activate                                              # terminal 2
+    python3 nectar/nectar/examples/control/basic.py --drone px4 --mode position --side 2.0
+    ```
+
+=== "PX4 · MAVLink"
+
+    Sem instalação separada: `pymavlink` vem com o SDK core. Outdoor a missão abre o link;
+    indoor inicia a ponte de vision-pose (`make driver DRONE=px4_mavlink ENV=indoor`).
+
+    ```bash
+    nectar-activate
+    python3 nectar/nectar/examples/control/basic.py --drone px4_mavlink --mode position --side 2.0
+    ```
+
+=== "PX4 · uXRCE-DDS"
+
+    Instala `px4_msgs` e o Micro XRCE-DDS Agent (hardware real; sem SITL).
+
+    ```bash
+    make setup                 # pick: control
+    make drone-px4-dds
+    ```
+
+    ```bash
+    make driver-px4-dds DEV=/dev/ttyUSB0 BAUD=921600   # terminal 1 (PORT=8888 for UDP)
+    nectar-activate                                    # terminal 2
+    python3 nectar/nectar/examples/control/basic.py --drone px4_dds
+    ```
+
+    Para acrescentar um detector de objetos à mesma missão, instale também `ai`
+    (`make setup` → `control ai`) e use `from nectar.ai.detection import Detector`.
+
+=== "Crazyflie"
+
+    Instala Crazyswarm2 (apt quando disponível, senão source) mais regras udev do rádio.
+    Defina o URI em `crazyflies.yaml`.
+
+    ```bash
+    make drone-crazyflie
+    ```
+
+    ```bash
+    make driver-crazyflie      # terminal 1: Crazyflie server
+    nectar-activate            # terminal 2
+    python3 nectar/nectar/examples/control/basic.py \
+        --drone crazyflie --mode position --height 0.5 --side 0.6
+    ```
+
+=== "Bebop"
+
+    Instala `ros2_parrot_arsdk` e `ros2_bebop_driver` (build source).
+
+    ```bash
+    make drone-bebop
+    ```
+
+    ```bash
+    make driver-bebop IP=192.168.42.1   # terminal 1
+    nectar-activate                     # terminal 2
+    python3 nectar/nectar/examples/control/basic.py --drone bebop
+    ```
+
+!!! note "Gerenciar drivers"
+    - Instale todos de uma vez com `make drone-all`.
+    - Pare todos os drivers e pontes em execução com `make driver-stop`.
+    - Sobrescreva conexões com as variáveis `FCU_URL`, `DEV`, `BAUD`, `PORT` e `IP`.
+    - Existem atalhos por tipo (`make driver-mavros`, `driver-px4`, ...).
+
+Para a matriz completa de backends e configuração, veja o
+[módulo Control](../modules/control/index.md).

--- a/i18n/pt/setup/index.md
+++ b/i18n/pt/setup/index.md
@@ -1,0 +1,241 @@
+# Instalação
+
+Instale o SDK aqui e depois acrescente o que a missão precisa: [drivers de drone](drivers.md),
+[simulação](simulation.md), [RealSense e indoor](realsense.md) ou
+[Docker](docker.md). A matriz de plataformas testadas está em
+[Compatibilidade](compatibility.md).
+
+## Escolha sua instalação
+
+Comece pela linha que corresponde à sua máquina:
+
+| Ponto de partida | Faça isto |
+|---|---|
+| Máquina limpa, sem ROS 2 | Aba [**Do zero**](#from-scratch-no-ros-2) — um comando de bootstrap instala ROS 2 + o SDK |
+| ROS 2 instalado, SDK ainda não clonado | clone em `~/ros2_ws/src`, depois aba [**Workspace existente**](#existing-ros-2-workspace) → `make setup` |
+| SDK clonado, nada instalado | `make setup` (abre o menu de setup) |
+| Deps instaladas, só falta o venv | rode de novo `make python-all` (ou seus módulos) — cria `$WORKSPACE/.venv` |
+| Quer zero setup no host | [Docker](docker.md): `make docker-build && make docker-run` |
+
+`make setup` (ou `./scripts/setup.sh` sem args) abre um menu interativo. Entradas:
+
+- **Quick setup** — deps de sistema + escolha de módulos + build + verify
+- **Python modules** — instala só os módulos que você escolher
+- **Drone driver** — mavros / px4 / px4-dds / crazyflie / bebop
+- **System packages** — pulado quando já instalado
+- **ROS 2 environment**, **Build**, **Verify**, **RealSense**
+
+!!! note "Nada instala até você escolher"
+    Pacotes de sistema são idempotentes. **MAVROS** (`ros-*-mavros`) é opt-in — rode
+    `make drone-mavros` quando usar o backend MAVROS. Datasets geoid do **GeographicLib**
+    instalam com `make full-install` / bootstrap (idempotente) ou com `make drone-mavros`;
+    não são puxados a cada execução do menu.
+
+### Depois acrescente o que a missão precisa
+
+| Objetivo | Comandos |
+|---|---|
+| ArduPilot / PX4 via MAVLink direto | `make setup` (escolha `control`) — `pymavlink` vem com o SDK core; opcional `make drone-mavros` para dados geoid |
+| ArduPilot / PX4 via MAVROS | `make setup` (escolha `control`) e depois `make drone-mavros` |
+| PX4 via uXRCE-DDS + detecção | `make setup` (escolha `control ai`) e depois `make drone-px4-dds` |
+| Crazyflie / Bebop | `make drone-crazyflie` / `make drone-bebop` |
+| Só o app GUI | `make python-interface` |
+| Simulação (SITL + Gazebo) | [`make sim-install`](simulation.md) |
+
+Detalhes: [Drivers de drone](drivers.md) (instalar + voar hardware), [Simulação](simulation.md)
+e [RealSense e indoor](realsense.md).
+
+<span id="from-scratch-no-ros-2"></span>
+<span id="existing-ros-2-workspace"></span>
+
+=== "Do zero (sem ROS 2)"
+
+    Um script de bootstrap standalone instala tudo em uma máquina Ubuntu/Debian limpa:
+    pacotes de sistema, ROS 2 (ros-base), dados geoid GeographicLib, Git LFS, o próprio SDK,
+    dependências Python (`python all`) e build do workspace. MAVROS e outros drivers
+    continuam opt-in — acrescente-os no menu de setup ou com `make drone-mavros` após o
+    bootstrap.
+
+    ```bash
+    bash <(curl -fsSL https://raw.githubusercontent.com/Black-Bee-Drones/nectar-sdk/main/scripts/bootstrap.sh)
+    ```
+
+    O bootstrap pergunta o caminho do workspace (padrão `~/ros2_ws`) e o branch (main ou
+    dev), clona o repositório e delega a `./scripts/setup.sh full-install`.
+
+    Para CI/Docker (não interativo):
+
+    ```bash
+    NON_INTERACTIVE=true ROS2_WORKSPACE=~/ros2_ws bash scripts/bootstrap.sh
+    ```
+
+    ### Menu de setup
+
+    Rodar o script de setup sem argumentos abre o mesmo menu interativo de `make setup`
+    (configurar módulos, drivers, pacotes de sistema, env ROS, build, verify — nada roda
+    até você escolher):
+
+    ```bash
+    ./scripts/setup.sh
+    ```
+
+=== "Workspace ROS 2 existente"
+
+    Clone no workspace e abra o menu de setup:
+
+    ```bash
+    cd ~/ros2_ws/src
+    git clone git@github.com:Black-Bee-Drones/nectar-sdk.git
+    cd nectar-sdk
+    make setup
+    ```
+
+    O **Quick setup** do menu roda: `system` (idempotente) → `git-lfs` → **seleção de
+    módulos** (`cmd_python` para os módulos escolhidos; PyTorch primeiro se escolher AI) →
+    `rosdep-init` → `ros2-deps` → `build-pkg` → `verify`. GeographicLib não faz parte do
+    Quick setup — instala com `make full-install` / bootstrap ou com `make drone-mavros`
+    (idempotente). Sem interação (`NON_INTERACTIVE=true`, p.ex. CI) `make setup` pula o
+    menu e roda Quick setup com `all`.
+
+=== "Docker"
+
+    Pule o setup de ROS/Python no host — faça build e entre no container de desenvolvimento:
+
+    ```bash
+    make docker-build
+    make docker-run
+    ```
+
+    Para fluxos Isaac / VSLAM / RealSense, veja o [guia Docker](docker.md)
+    (`make isaac-run`, mounts de dispositivo, notas Jetson).
+
+## Ambiente Python
+
+<span id="python-environment"></span>
+
+As dependências Python instalam em um único ambiente virtual compartilhado, gerenciado pelo
+[uv](https://github.com/astral-sh/uv), em `$WORKSPACE/.venv` (p.ex. `~/ros2_ws/.venv`). O
+`uv` é instalado automaticamente se estiver ausente.
+
+- **Criado automaticamente** no primeiro `make python*` / `make setup`, com
+  `--system-site-packages` para que o ROS 2 (`rclpy`, bindings de mensagens, `colcon`)
+  continue visível dentro dele.
+- **A ativação é opt-in.** Os próprios comandos do SDK (`make build`, `make verify`,
+  `make python*`, `make pytorch`) usam o venv internamente, então sempre funcionam. No seu
+  shell interativo ele **não** é forçado — assim não atrapalha outros projetos e
+  workspaces. `make ros2-env` instala o comando `nectar-activate` para quando quiser.
+- **Reutilizado por todo o workspace.** Todo pacote sob `src/` — o SDK e o seu código de
+  missão/competição — compartilha este venv, então você instala uma vez e faz
+  `import nectar` de qualquer lugar. Não precisa de venv por projeto.
+
+Entre nele quando precisar (p.ex. para `ros2 run nectar <node>` ou seus scripts); o prompt
+mostra `(nectar)`:
+
+```bash
+nectar-activate            # enter the SDK env (command added by `make ros2-env`)
+deactivate                 # leave it (shell built-in)
+uv pip install <package>   # add a package (fast); plain `pip install` also works
+```
+
+Para ativar o env em todo shell novo, acrescente uma linha ao `~/.bashrc`:
+
+```bash
+source ~/ros2_ws/.venv/bin/activate
+```
+
+Sobrescreva o local com `NECTAR_VENV=/path` (um `VIRTUAL_ENV` já ativo é respeitado); veja
+[Configuração](configuration.md#python-environment-location) para o caveat do venv.
+
+## Instalar por módulo
+
+Instale só os módulos de que precisa (dependências em `nectar/pyproject.toml`). Cada alvo
+`make` é um wrapper fino sobre o script de setup, então as duas colunas fazem o mesmo:
+
+| Alvo `make` | Script de setup | Instala |
+|---|---|---|
+| `make python` | `./scripts/setup.sh python` | Só o core (numpy, opencv, scipy) |
+| `make python-control` | `./scripts/setup.sh python control` | + navegação GPS/PID, pymavlink (MAVLink direto) |
+| `make python-vision` | `./scripts/setup.sh python vision` | + drivers de câmera, ArUco, cor, detecção de linha |
+| `make python-ai` | `./scripts/setup.sh python ai` | + YOLO, DETR, RF-DETR (exige PyTorch) |
+| `make python-interface` | `./scripts/setup.sh python interface` | + GUI Qt6 / PySide6 |
+| `make python-sensors` | `./scripts/setup.sh python sensors` | + pyserial / pymavlink (driver TF-Luna, ponte MAVLink) |
+| `make python-all` | `./scripts/setup.sh python all` | Todos os módulos |
+| `make python-full` | `./scripts/setup.sh python full` | Todos + drivers de hardware de câmera |
+
+## PyTorch (obrigatório para o módulo de IA)
+
+Instalado pela integração nativa de PyTorch do uv (`--torch-backend`), que detecta o driver
+CUDA e puxa torch mais as wheels `nvidia-*` CUDA do índice correto em
+`download.pytorch.org`:
+
+| Comando | Efeito |
+|---|---|
+| `make pytorch` | Auto-detecta GPU (CUDA 13 -> cu130; sem GPU -> cpu) |
+| `./scripts/setup.sh pytorch cpu` | Força CPU |
+| `./scripts/setup.sh pytorch cu128` | Força um backend (cpu/cu118/cu126/cu128/cu130/...) |
+
+Um par conhecido `torch`/`torchvision` é pinado por padrão em
+[`scripts/lib/config.sh`](https://github.com/Black-Bee-Drones/nectar-sdk/blob/main/scripts/lib/config.sh)
+para reprodutibilidade; sobrescreva com `TORCH_VERSION` / `TORCHVISION_VERSION` (defina os
+dois juntos). Wheels CUDA grandes em links lentos podem travar — o timeout por request sobe
+para 600s (`UV_HTTP_TIMEOUT`); em redes muito instáveis também
+`export UV_CONCURRENT_DOWNLOADS=1`. Veja [PyTorch Get Started](https://pytorch.org/get-started/locally/)
+e o [guia PyTorch do uv](https://docs.astral.sh/uv/guides/integration/pytorch/).
+
+## Build e verificação
+
+| Comando | Faz |
+|---|---|
+| `make build` | Build de todo o workspace |
+| `make build-pkg` | Build só dos pacotes do SDK |
+| `make verify` | Checa a instalação (presença/imports) |
+| `make doctor` | Relatório de ambiente (ROS, módulos, dispositivos, CUDA) |
+| `make clean` | Remove artefatos de build |
+| `make verify-functional` | Testes funcionais de regressão (pytest; `MODULE="vision control"`) |
+| `make test` | colcon test (suíte funcional + lint cmake/xml) |
+
+A lista completa de comandos está na referência
+[Comandos e Makefile](../development/commands.md).
+
+## Setup de sistema (passos individuais)
+
+| Comando | Passo |
+|---|---|
+| `./scripts/setup.sh system` | pacotes apt |
+| `./scripts/setup.sh ros2` | pacotes base ROS 2 (ros-base, rviz2, cv_bridge, …) |
+| `./scripts/setup.sh geographiclib` | datasets geoid GeographicLib (também por `full-install` e `make drone-mavros`) |
+| `./scripts/setup.sh ros2-env` | Configura `~/.bashrc` |
+| `./scripts/setup.sh rosdep-init` | Inicializa rosdep |
+| `./scripts/setup.sh git-ssh` | Configura git e chaves SSH |
+
+## Solução de problemas
+
+### ROS 2 não encontrado
+
+```bash
+source /opt/ros/humble/setup.bash
+```
+
+### Pacote não encontrado após o build
+
+```bash
+source ~/ros2_ws/install/local_setup.bash
+```
+
+### Permissão negada na câmera
+
+```bash
+sudo usermod -a -G video $USER
+
+# Logout and login
+
+```
+
+### Problemas de conexão MAVROS
+
+```bash
+sudo usermod -a -G dialout $USER
+
+# Logout and login
+
+```

--- a/i18n/pt/setup/realsense.md
+++ b/i18n/pt/setup/realsense.md
@@ -1,0 +1,48 @@
+# RealSense e navegação indoor
+
+Câmeras Intel RealSense de profundidade e tracking alimentam tanto os recursos de
+profundidade da visão quanto o voo sem GPS (indoor). Esta página instala librealsense e
+realsense-ros; o pipeline VSLAM indoor se apoia neles.
+
+## Instalar
+
+Compila librealsense a partir do source e instala realsense-ros. O menu interativo oferece
+passos customizados, auto-detecção de CUDA e verificação.
+
+```bash
+make realsense
+```
+
+As versões de `realsense-ros` / `librealsense` por distro são selecionadas automaticamente
+em `scripts/lib/config.sh`; veja [COMPATIBILITY](compatibility.md#pinned-versions).
+
+!!! tip "CUDA"
+    Em GPUs NVIDIA o librealsense compila com CUDA automaticamente (detectado via `nvcc`).
+    Desative com `REALSENSE_CUDA=false make realsense`.
+
+!!! note "Câmera de tracking T265 (descontinuada)"
+    A T265 precisa das últimas versões suportadas de **librealsense** / **realsense-ros**,
+    só no Humble:
+
+    ```bash
+    LIBREALSENSE_VERSION=v2.53.1 REALSENSE_ROS_TAG=4.51.1 make realsense
+    ```
+
+    Esse build source também fornece o **pyrealsense2** correspondente para o modo direto
+    da T265. O extra pip `nectar-sdk[realsense]` (PyPI pyrealsense2 ≥2.55) é só para modo
+    direto D4xx — veja
+    [Cameras](../modules/vision/camera.md#t265-tracking-camera).
+
+## Navegação indoor
+
+A navegação indoor (sem GPS) está no módulo de Localização do SDK: um RealSense alimenta o
+Isaac ROS Visual SLAM em um Jetson, que envia pose ao FCU via MAVROS ou MAVLink direto.
+
+| Doc | Escopo |
+|-----|--------|
+| [Localization](../modules/control/localization/index.md) | Arquitetura, Run, FCU, origem EKF, SOP indoor |
+| [Concepts](../modules/control/localization/concepts.md) | Teoria SLAM / VIO / V-SLAM |
+| [Legacy T265](../modules/control/localization/legacy.md) | T265 + `vision_to_mavros` |
+
+O producer Isaac roda no próprio container (`make isaac-run`). Veja o
+[guia Docker](docker.md) para o container.

--- a/i18n/pt/setup/simulation.md
+++ b/i18n/pt/setup/simulation.md
@@ -1,0 +1,86 @@
+# Simulação (Gazebo + ArduPilot / PX4 SITL)
+
+Voe as mesmas missões que no hardware, no Gazebo com ArduPilot ou PX4 SITL — sem veículo.
+Instale uma vez por firmware; depois inicie o simulador e a ponte ROS em dois terminais.
+
+## Instalar
+
+Um comando de instalação por firmware. ArduPilot puxa ArduCopter SITL, Gazebo, a ponte
+`ros_gz` e o plugin ArduPilot Gazebo (seleciona a versão do Gazebo por distro ROS; tabela
+por distro no [guia Docker](docker.md)). PX4 puxa PX4-Autopilot e Gazebo
+e cria symlinks dos assets compartilhados do Nectar na árvore do PX4.
+
+=== "ArduPilot"
+
+    ```bash
+    make sim-install FIRMWARE=ardupilot   # ArduCopter SITL + Gazebo + plugin
+    ```
+
+=== "PX4"
+
+    ```bash
+    make sim-install FIRMWARE=px4          # PX4 SITL + Gazebo + Nectar assets
+    ```
+
+=== "Both"
+
+    ```bash
+    make sim-install FIRMWARE=all          # ArduPilot + PX4
+    ```
+
+=== "PX4 native (uXRCE-DDS)"
+
+    Para **PX4 uXRCE-DDS** (`PROTOCOL=dds`), instale também o agent nativo e `px4_msgs` uma
+    vez:
+
+    ```bash
+    make sim-install FIRMWARE=px4 ARGS=--native
+    ```
+
+### Docker com Gazebo
+
+```bash
+INSTALL_GAZEBO=true make docker-build
+INSTALL_GAZEBO=true ROS_DISTRO=jazzy make docker-build
+```
+
+Veja o [guia Docker](docker.md) para mais opções.
+
+## Rodar a simulação
+
+Dois terminais, o mesmo padrão nos dois firmwares: o simulador (terminal 1) mais a stack
+ROS (terminal 2). Escolha `FIRMWARE` / `ENV` / `PROTOCOL` (padrões: `ardupilot` /
+`outdoor` / `mavros`).
+
+!!! warning "Combine o ENV entre os terminais"
+    Use o mesmo `FIRMWARE` e `ENV` no terminal 1 (`sim-start`) e no terminal 2
+    (`sim-bridge`). Indoor acrescenta o pipeline de visão; outdoor usa GPS.
+
+| Setup | Terminal 1 (simulador) | Terminal 2 (stack ROS) |
+|---|---|---|
+| ArduPilot outdoor / MAVROS (padrão) | `make sim-start` | `make sim-bridge` |
+| ArduPilot outdoor / MAVLink direto | `make sim-start FIRMWARE=ardupilot ENV=outdoor` | `make sim-bridge FIRMWARE=ardupilot ENV=outdoor PROTOCOL=mavlink` |
+| ArduPilot indoor (visão) | `make sim-start FIRMWARE=ardupilot ENV=indoor` | `make sim-bridge FIRMWARE=ardupilot ENV=indoor` |
+| PX4 outdoor / MAVROS | `make sim-start FIRMWARE=px4 ENV=outdoor` | `make sim-bridge FIRMWARE=px4 ENV=outdoor` |
+| PX4 outdoor / MAVLink direto | `make sim-start FIRMWARE=px4 ENV=outdoor` | `make sim-bridge FIRMWARE=px4 ENV=outdoor PROTOCOL=mavlink` |
+| PX4 outdoor / uXRCE-DDS | `make sim-start FIRMWARE=px4 ENV=outdoor` | `make sim-bridge FIRMWARE=px4 ENV=outdoor PROTOCOL=dds` |
+| PX4 indoor (VIO a bordo) | `make sim-start FIRMWARE=px4 ENV=indoor` | `make sim-bridge FIRMWARE=px4 ENV=indoor` |
+| PX4 indoor / MAVLink direto | `make sim-start FIRMWARE=px4 ENV=indoor` | `make sim-bridge FIRMWARE=px4 ENV=indoor PROTOCOL=mavlink` |
+
+**PX4 MAVLink direto** (`PROTOCOL=mavlink`): o terminal 2 pula o MAVROS e só inicia pontes
+de câmera; a missão se conecta ao UDP offboard `14540` do PX4 (`backend` `px4_mavlink`).
+
+**PX4 uXRCE-DDS** (`PROTOCOL=dds`): o terminal 2 roda `MicroXRCEAgent` em UDP `:8888`; use
+o backend `px4_dds` na missão. Exige a instalação única `ARGS=--native` acima.
+
+Pare tudo (os dois firmwares) com `make sim-stop`.
+
+Depois rode uma missão contra a simulação, por exemplo:
+
+```bash
+nectar-activate
+python3 nectar/nectar/examples/control/basic.py --drone mavros --mode position --side 2.0
+```
+
+Veja o [módulo Simulation](../modules/simulation.md) para a matriz completa, o
+pipeline de visão e a suíte de testes automatizados.

--- a/mkdocs.pt.yml
+++ b/mkdocs.pt.yml
@@ -1,0 +1,193 @@
+site_name: Nectar SDK
+site_url: https://black-bee-drones.github.io/nectar-sdk/pt/
+site_description: >-
+  Kit de desenvolvimento ROS 2 para sistemas aéreos autônomos — interfaces
+  unificadas para controle de voo, visão computacional e detecção de objetos.
+site_author: Black Bee Drones
+copyright: Copyright &copy; Black Bee Drones — Apache-2.0
+
+repo_url: https://github.com/Black-Bee-Drones/nectar-sdk
+repo_name: Black-Bee-Drones/nectar-sdk
+
+extra:
+  alternate:
+    - name: English
+      link: /nectar-sdk/
+      lang: en
+    - name: Português
+      link: /nectar-sdk/pt/
+      lang: pt
+  social:
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/company/blackbeedrones/
+      name: Black Bee Drones on LinkedIn
+    - icon: fontawesome/brands/instagram
+      link: https://www.instagram.com/blackbeedrones/
+      name: Black Bee Drones on Instagram
+    - icon: fontawesome/brands/github
+      link: https://github.com/Black-Bee-Drones
+      name: Black Bee Drones on GitHub
+    - icon: fontawesome/brands/docker
+      link: https://hub.docker.com/u/blackbeedrones
+      name: Black Bee Drones on Docker Hub
+    - icon: simple/huggingface
+      link: https://huggingface.co/blackbeedrones
+      name: Black Bee Drones on Hugging Face
+
+extra_css:
+  - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/mermaid.mjs
+  - javascripts/diagram-zoom.js
+  - javascripts/showcase.js
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+  - javascripts/i18n-switch.js
+
+# Edit i18n/pt/ only. Everything under build/ is generated.
+docs_dir: build/docs-pt
+site_dir: build/site-pt
+
+theme:
+  name: material
+  language: pt-BR
+  logo: assets/logo.png
+  favicon: assets/logo.png
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Montserrat
+  features:
+    - navigation.tabs
+    - navigation.indexes
+    - navigation.path
+    - navigation.top
+    - navigation.footer
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: black
+      accent: amber
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Alternar para modo escuro
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: amber
+      toggle:
+        icon: material/toggle-switch
+        name: Alternar para modo claro
+
+plugins:
+  - search
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:zensical.extensions.emoji.twemoji
+      emoji_generator: !!python/name:zensical.extensions.emoji.to_svg
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path: ["build/docs-pt/includes"]
+      auto_append:
+        - abbreviations.md
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - zensical.extensions.glightbox:
+      auto_caption: true
+
+nav:
+  - Início: index.md
+  - Começar:
+      - Visão geral: get-started/index.md
+      - Voar um drone: get-started/control.md
+      - Ver com uma câmera: get-started/vision.md
+      - Detectar, segmentar e classificar: get-started/ai.md
+      - Com e sem Nectar: get-started/with-without.md
+  - Instalação:
+      - Instalação: setup/index.md
+      - Drivers de drone: setup/drivers.md
+      - Simulação: setup/simulation.md
+      - RealSense e indoor: setup/realsense.md
+      - Docker: setup/docker.md
+      - Configuração: setup/configuration.md
+      - Compatibilidade: setup/compatibility.md
+  - Conceitos:
+      - Arquitetura: concepts/architecture.md
+  - Módulos:
+      - Control:
+          - Visão geral: modules/control/index.md
+          - Núcleo do veículo: modules/control/vehicle.md
+          - ArduPilot: modules/control/ardupilot.md
+          - PX4: modules/control/px4.md
+          - Transporte MAVROS: modules/control/mavros.md
+          - Transporte MAVLink: modules/control/mavlink.md
+          - Localização:
+              - modules/control/localization/index.md
+              - Conceitos: modules/control/localization/concepts.md
+              - T265 legado: modules/control/localization/legacy.md
+          - Obstáculos: modules/control/obstacles.md
+          - PID: modules/control/pid.md
+          - Bebop: modules/control/bebop.md
+          - Crazyflie: modules/control/crazyflie.md
+      - Vision:
+          - Visão geral: modules/vision/index.md
+          - Câmeras: modules/vision/camera.md
+          - Algoritmos: modules/vision/algorithms.md
+          - Nós ROS 2: modules/vision/nodes.md
+      - AI:
+          - Visão geral: modules/ai/index.md
+          - Detecção: modules/ai/detection.md
+          - Segmentação: modules/ai/segmentation.md
+          - Classificação: modules/ai/classification.md
+      - Sensors: modules/sensors.md
+      - Interface (GUI): modules/interface.md
+      - Simulation: modules/simulation.md
+      - Messages (nectar_interfaces): modules/interfaces.md
+      - Utils: modules/utils.md
+  - Exemplos:
+      - Visão geral: modules/examples/index.md
+      - Control: modules/examples/control.md
+      - Vision: modules/examples/vision.md
+      - AI: modules/examples/ai.md
+      - Sensors: modules/examples/sensors.md
+  - Desenvolvimento:
+      - Comandos e Makefile: development/commands.md
+      - Contribuindo: project/contributing.md
+      - Releases: project/releasing.md
+  - Projetos: projects/index.md
+  - Comunidade:
+      - Visão geral: community/index.md
+      - Código de conduta: project/code-of-conduct.md
+      - Segurança: project/security.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,13 @@ repo_url: https://github.com/Black-Bee-Drones/nectar-sdk
 repo_name: Black-Bee-Drones/nectar-sdk
 
 extra:
+  alternate:
+    - name: English
+      link: /nectar-sdk/
+      lang: en
+    - name: Português
+      link: /nectar-sdk/pt/
+      lang: pt
   social:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/blackbeedrones/
@@ -32,15 +39,17 @@ extra_css:
 
 # mermaid.mjs registers the ELK layout engine for the native Mermaid runtime;
 # diagram-zoom.js adds fullscreen pan/zoom to the rendered diagrams.
+# i18n-switch.js rewrites the language selector to the sibling page when available.
 extra_javascript:
   - javascripts/mermaid.mjs
   - javascripts/diagram-zoom.js
   - javascripts/showcase.js
   - javascripts/mathjax.js
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+  - javascripts/i18n-switch.js
 
-# edit only: the module README.md files, docs/*.md, and the authored pages in
-# website/
+# edit only: the module README.md files, docs/*.md, authored pages in website/,
+# and Portuguese pages in i18n/pt/
 # Everything under build/ is generated — never edit it.
 docs_dir: build/docs
 site_dir: build/site

--- a/nectar/nectar/vision/README.md
+++ b/nectar/nectar/vision/README.md
@@ -16,7 +16,7 @@ nectar.spin()
 nectar.shutdown()
 ```
 
-Need a single frame instead of a stream?
+Single frame (no stream):
 
 ```python
 from nectar.vision import CameraFactory

--- a/scripts/docs/sync_i18n.py
+++ b/scripts/docs/sync_i18n.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Assemble Portuguese docs into build/docs-pt/ and emit the sibling path map."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+I18N_PT = REPO / "i18n" / "pt"
+WEBSITE = REPO / "website"
+DOCS_EN = REPO / "build" / "docs"
+DOCS_PT = REPO / "build" / "docs-pt"
+
+# Shared static dirs from website/ (same assets/CSS/JS as the English site).
+SHARED_DIRS = ("assets", "stylesheets", "javascripts", "includes")
+
+SITE_BASE = "/nectar-sdk"
+
+
+def page_path(md_rel: str) -> str:
+    """MkDocs URL path for a markdown file relative to the docs root (no leading slash)."""
+    if md_rel.endswith("/index.md"):
+        return md_rel[: -len("/index.md")]
+    if md_rel == "index.md":
+        return ""
+    if md_rel.endswith(".md"):
+        return md_rel[: -len(".md")]
+    return md_rel
+
+
+def collect_pt_pages() -> list[str]:
+    pages: list[str] = []
+    if not I18N_PT.is_dir():
+        return pages
+    for path in sorted(I18N_PT.rglob("*.md")):
+        rel = path.relative_to(I18N_PT).as_posix()
+        pages.append(page_path(rel))
+    return pages
+
+
+def write_paths_json(docs_dir: Path, pages: list[str]) -> None:
+    js_dir = docs_dir / "javascripts"
+    js_dir.mkdir(parents=True, exist_ok=True)
+    payload = {"base": SITE_BASE, "paths": pages}
+    (js_dir / "i18n-paths.json").write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> None:
+    if not I18N_PT.is_dir():
+        raise SystemExit(f"missing Portuguese sources: {I18N_PT}")
+
+    DOCS_PT.parent.mkdir(parents=True, exist_ok=True)
+    if DOCS_PT.exists():
+        shutil.rmtree(DOCS_PT)
+    DOCS_PT.mkdir(parents=True)
+
+    for name in SHARED_DIRS:
+        src = WEBSITE / name
+        if src.is_dir():
+            shutil.copytree(src, DOCS_PT / name)
+
+    n_files = 0
+    for path in I18N_PT.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(I18N_PT)
+        dest = DOCS_PT / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, dest)
+        n_files += 1
+
+    pages = collect_pt_pages()
+    write_paths_json(DOCS_PT, pages)
+    if DOCS_EN.is_dir():
+        write_paths_json(DOCS_EN, pages)
+    else:
+        print(
+            "  ! English build/docs missing — run sync_readmes.py first for EN path map"
+        )
+
+    rel = DOCS_PT.relative_to(REPO).as_posix()
+    print(
+        f"assembled {n_files} Portuguese file(s) into {rel}/ "
+        f"({len(pages)} page path(s) for language switcher)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/website/get-started/ai.md
+++ b/website/get-started/ai.md
@@ -1,4 +1,4 @@
-# Detect & segment & classify
+# Detect, segment & classify
 
 Run object detection, instance segmentation, or image classification across Ultralytics
 YOLO, HuggingFace Transformers, and RF-DETR (detect/seg only) behind one
@@ -143,7 +143,7 @@ End-to-end workflows in Google Colab:
 - **Classification:** [Open in Colab](https://colab.research.google.com/drive/1mEo05wfYJRsuxKodxbFwBuxRSRh43f-X?usp=sharing)
 - **Segmentation:** [Open in Colab](https://colab.research.google.com/drive/1qZzAF_iD2sZyuWPin48XpxaY6dtak_gV?usp=sharing)
 
-## Go deeper
+## See also
 
 - [AI overview](../modules/ai/index.md) · [Detection](../modules/ai/detection.md) ·
   [Segmentation](../modules/ai/segmentation.md) · [Classification](../modules/ai/classification.md).

--- a/website/get-started/index.md
+++ b/website/get-started/index.md
@@ -1,9 +1,8 @@
 # Get started
 
-Nectar SDK gives you one Python interface for three things a mission needs: **flying**,
-**seeing**, and **detecting**, all sharing a single ROS 2 runtime. Pick a topic below, follow
-the steps for your platform, camera, or model, and follow the links when you want the full
-reference.
+Nectar SDK gives you one Python interface for **flight control**, **computer vision**, and
+**AI**, all sharing a single ROS 2 runtime. Pick a topic below, follow the steps for your
+platform, camera, or model, and follow the links when you want the full reference.
 
 ## The mental model
 
@@ -46,12 +45,13 @@ first (it takes only the modules you choose). Each topic below lists the one mod
 
     [See with a camera](vision.md)
 
--   **Detect & segment**
+-   **Detect, segment & classify**
 
-    Load a detection or segmentation model across Ultralytics YOLO, HuggingFace DETR, or
-    RF-DETR behind one `Detector` / `Segmentor`, and run it on a frame.
+    Load a detection, segmentation, or classification model across Ultralytics YOLO,
+    HuggingFace DETR, or RF-DETR behind one `Detector` / `Segmentor` / `Classifier`, and run
+    it on a frame.
 
-    [Detect & segment](ai.md)
+    [Detect, segment & classify](ai.md)
 
 -   **With and without Nectar**
 
@@ -61,5 +61,5 @@ first (it takes only the modules you choose). Each topic below lists the one mod
 
 </div>
 
-Each page is independent and shares the runtime, so you can compose them into a single
-mission that flies, sees, and detects.
+Each page is independent and shares the runtime, so you can compose control, vision, and AI
+in a single mission.

--- a/website/javascripts/i18n-switch.js
+++ b/website/javascripts/i18n-switch.js
@@ -1,0 +1,108 @@
+/**
+ * Rewrite the Zensical/Material language alternate links so switching language
+ * keeps the same page when a Portuguese sibling exists; otherwise fall back to
+ * the language home.
+ *
+ * Expects i18n-paths.json next to this script:
+ *   { "base": "/nectar-sdk", "paths": ["", "get-started", "get-started/control", ...] }
+ *
+ * `base` matches GitHub Pages (`/nectar-sdk`). Local bilingual preview serves the
+ * same prefix via `make docs-serve`. If the page is served without that prefix
+ * (site at `/` and `/pt/`), the base is detected from the URL.
+ */
+(function () {
+  var PATHS_URL = new URL("i18n-paths.json", document.currentScript.src).href;
+
+  function detectBase(configured) {
+    var path = window.location.pathname || "/";
+    if (configured && (path === configured || path.indexOf(configured + "/") === 0)) {
+      return configured;
+    }
+    if (path === "/nectar-sdk" || path.indexOf("/nectar-sdk/") === 0) {
+      return "/nectar-sdk";
+    }
+    // build/site served at server root: / and /pt/...
+    return "";
+  }
+
+  function normalizePath(pathname, base) {
+    var p = pathname || "/";
+    if (base && (p === base || p.indexOf(base + "/") === 0)) {
+      p = p.slice(base.length) || "/";
+    }
+    if (p.length > 1 && p.charAt(p.length - 1) === "/") {
+      p = p.slice(0, -1);
+    }
+    if (p.charAt(0) === "/") {
+      p = p.slice(1);
+    }
+    return p;
+  }
+
+  function stripPtPrefix(rel) {
+    if (rel === "pt") return "";
+    if (rel.indexOf("pt/") === 0) return rel.slice(3);
+    return null;
+  }
+
+  function siblingHref(base, wantPt, pageKey) {
+    var root = (base || "").replace(/\/$/, "");
+    var parts = [];
+    if (wantPt) parts.push("pt");
+    if (pageKey) parts.push(pageKey);
+    if (!root && parts.length === 0) return "/";
+    if (!root) return "/" + parts.join("/") + "/";
+    if (parts.length === 0) return root + "/";
+    return root + "/" + parts.join("/") + "/";
+  }
+
+  function homeHref(base, wantPt) {
+    return siblingHref(base, wantPt, "");
+  }
+
+  function rewrite(data) {
+    var configured = (data && data.base) || "/nectar-sdk";
+    var base = detectBase(configured);
+    var translated = Object.create(null);
+    (data.paths || []).forEach(function (p) {
+      translated[p] = true;
+    });
+
+    var rel = normalizePath(window.location.pathname, base);
+    var withoutPt = stripPtPrefix(rel);
+    var isOnPt = withoutPt !== null;
+    var pageKey = isOnPt ? withoutPt : rel;
+    var hasSibling = Object.prototype.hasOwnProperty.call(translated, pageKey);
+
+    document.querySelectorAll("a[hreflang]").forEach(function (a) {
+      var lang = (a.getAttribute("hreflang") || "").toLowerCase();
+      var wantPt = lang === "pt" || lang.indexOf("pt-") === 0;
+      if (lang !== "en" && !wantPt) return;
+
+      if (wantPt === isOnPt) {
+        a.setAttribute(
+          "href",
+          hasSibling || pageKey === ""
+            ? siblingHref(base, wantPt, pageKey)
+            : homeHref(base, wantPt)
+        );
+        return;
+      }
+
+      a.setAttribute(
+        "href",
+        hasSibling ? siblingHref(base, wantPt, pageKey) : homeHref(base, wantPt)
+      );
+    });
+  }
+
+  fetch(PATHS_URL, { credentials: "same-origin" })
+    .then(function (r) {
+      if (!r.ok) throw new Error("i18n-paths.json " + r.status);
+      return r.json();
+    })
+    .then(rewrite)
+    .catch(function () {
+      /* keep YAML alternate defaults */
+    });
+})();


### PR DESCRIPTION
Introduces full support for bilingual (English and Portuguese) documentation for the Nectar SDK. It adds infrastructure, workflows, and documentation to build, serve, and maintain both English and Portuguese versions of the docs, along with a translation workflow and glossary. It also updates the documentation commands, Makefile, and GitHub Actions to reflect these changes.

**Bilingual Documentation Infrastructure:**

- Added a translation workflow and glossary in `i18n/README.md`, detailing how to author, sync, and build Portuguese documentation alongside English, including conventions and a phase checklist for translation progress.
- Added a sample Portuguese community page at `i18n/pt/community/index.md` as part of the translated documentation set.

**Build System and Workflow Updates:**

- Updated `.github/workflows/docs.yml` to include the `i18n/**` directory and `mkdocs.pt.yml` in triggers, and modified build steps to assemble and build both English and Portuguese documentation, merging the PT build under `build/site/pt/`. [[1]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR9-R22) [[2]](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL42-R54)
- Enhanced the `Makefile` to add commands for bilingual docs (`docs-sync`, `docs`, `docs-serve`, `docs-serve-en`), updated comments, and clarified the workflow for building and serving both languages.

**Documentation and User-Facing Updates:**

- Updated references in `README.md` to link to both English and Portuguese documentation sites.
- Improved documentation in `docs/development/commands.md` to describe the new bilingual build and serve commands, and clarified the workflow for contributors.
- Clarified language in `docs/setup/index.md` for activating virtual environments.

**Minor Cleanups:**

- Removed outdated footnotes and caveats in `docs/COMPATIBILITY.md` for improved clarity. [[1]](diffhunk://#diff-0333285b158fbef700dbdf89f364f7edbada5846a67ab9d5888e056c8ea98a1dL13-R13) [[2]](diffhunk://#diff-0333285b158fbef700dbdf89f364f7edbada5846a67ab9d5888e056c8ea98a1dL54-R54) [[3]](diffhunk://#diff-0333285b158fbef700dbdf89f364f7edbada5846a67ab9d5888e056c8ea98a1dL67-R67)