### PR TITLE
fix(control): add configurable timeouts for mode and arm operations

### DIFF
--- a/nectar/nectar/control/ardupilot/drone.py
+++ b/nectar/nectar/control/ardupilot/drone.py
@@ -14,7 +14,7 @@ from typing import Optional
 from nectar.control.ardupilot.setpoint_config import SetpointNavConfig
 from nectar.control.capabilities import Capability
 from nectar.control.vehicle.drone import VehicleDrone
-from nectar.utils.log import ERR, WARN
+from nectar.utils.log import ERR
 
 
 class ArduPilotDrone(VehicleDrone):
@@ -123,11 +123,16 @@ class ArduPilotDrone(VehicleDrone):
 
     # Arm (GUIDED)
 
-    def arm(self) -> bool:
+    def arm(self, timeout: Optional[float] = None) -> bool:
         """
         Arm motors in GUIDED mode.
 
         Sets GUIDED mode and arms, polling vehicle state to confirm each step.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Seconds to wait for ``is_armed``. ``None`` uses ``arm_timeout``.
 
         Returns
         -------
@@ -137,13 +142,12 @@ class ArduPilotDrone(VehicleDrone):
         try:
             if not self.set_mode("GUIDED"):
                 return False
-            if not self._wait_until(lambda: self.flight_mode == "GUIDED", 3.0):
-                self._node.get_logger().warn(f"{WARN} Mode change slow to reflect in state")
             if self._config.apply_setpoint_params:
                 self._apply_setpoint_config()
             if not self._transport.arm():
                 return False
-            if not self._wait_until(lambda: self.is_armed, 6.0):
+            wait = self.arm_timeout if timeout is None else timeout
+            if not self._wait_until(lambda: self.is_armed, wait):
                 self._node.get_logger().error(f"{ERR} Arm command sent but vehicle did not arm")
                 return False
             return True

--- a/nectar/nectar/control/config.py
+++ b/nectar/nectar/control/config.py
@@ -53,6 +53,8 @@ class _MavrosTelemetryConfig(DroneConfig):
     pose_source: PoseSource = PoseSource.GPS
     expect_lidar: bool = True
     sensor_timeout: float = 10.0
+    mode_timeout: float = 10.0
+    arm_timeout: float = 6.0
     lidar_topic: str = "/mavros/rangefinder/rangefinder"
     vision_topic: str = "/mavros/vision_pose/pose_cov"
     gps_topic: str = "/mavros/global_position/global"
@@ -91,6 +93,8 @@ class Px4DdsConfig(DroneConfig):
     pose_source: PoseSource = PoseSource.GPS
     expect_lidar: bool = True
     sensor_timeout: float = 10.0
+    mode_timeout: float = 10.0
+    arm_timeout: float = 6.0
     pid_config_file: Optional[str] = None
     # PX4 needs offboard setpoints streamed faster than 2 Hz (500 ms timeout).
     offboard_rate_hz: float = 20.0
@@ -114,6 +118,8 @@ class _MavlinkLinkConfig(DroneConfig):
     pose_source: PoseSource = PoseSource.GPS
     expect_lidar: bool = True
     sensor_timeout: float = 10.0
+    mode_timeout: float = 10.0
+    arm_timeout: float = 6.0
     baud: int = 921600
     source_system: int = 1
     source_component: int = 191  # MAV_COMP_ID_ONBOARD_COMPUTER

--- a/nectar/nectar/control/px4/drone.py
+++ b/nectar/nectar/control/px4/drone.py
@@ -175,12 +175,17 @@ class Px4Drone(VehicleDrone):
 
     # Arm (OFFBOARD)
 
-    def arm(self) -> bool:
+    def arm(self, timeout: Optional[float] = None) -> bool:
         """
         Arm motors in OFFBOARD mode.
 
         Streams a hold setpoint so PX4 accepts the offboard switch, enters
         OFFBOARD, then arms, polling vehicle state to confirm each step.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Seconds to wait for ``is_armed``. ``None`` uses ``arm_timeout``.
 
         Returns
         -------
@@ -194,15 +199,15 @@ class Px4Drone(VehicleDrone):
 
             if not self.set_mode(_MODE_OFFBOARD):
                 return False
-            if not self._wait_until(lambda: self.flight_mode == _MODE_OFFBOARD, 3.0):
-                self._node.get_logger().warn(f"{WARN} OFFBOARD slow to reflect in state")
+
             # MPC_* speed/accel limits (no-op on the uXRCE-DDS backend, which has
             # no apply_setpoint_params field and cannot set_param).
             if getattr(self._config, "apply_setpoint_params", False):
                 self._apply_setpoint_config()
             if not self._transport.arm():
                 return False
-            if not self._wait_until(lambda: self.is_armed, 6.0):
+            wait = self.arm_timeout if timeout is None else timeout
+            if not self._wait_until(lambda: self.is_armed, wait):
                 self._node.get_logger().error(f"{ERR} Arm command sent but vehicle did not arm")
                 return False
             return True

--- a/nectar/nectar/control/vehicle/drone.py
+++ b/nectar/nectar/control/vehicle/drone.py
@@ -84,6 +84,8 @@ class VehicleDrone(BaseDrone):
         self._takeoff_local: Optional[LocalTarget] = None
         self._initial_altitude: float = 0.0
         self._initial_heading: float = 0.0
+        self.mode_timeout = float(getattr(config, "mode_timeout", 10.0))
+        self.arm_timeout = float(getattr(config, "arm_timeout", 6.0))
 
         super().__init__(config, executor)
 
@@ -100,7 +102,7 @@ class VehicleDrone(BaseDrone):
     # Firmware hooks (overridden by ArduPilot / PX4 specializations)
 
     @abstractmethod
-    def arm(self) -> bool:
+    def arm(self, timeout: Optional[float] = None) -> bool:
         """Arm the motors in the firmware's offboard/guided control mode."""
 
     @abstractmethod
@@ -1400,7 +1402,7 @@ class VehicleDrone(BaseDrone):
             self._node.get_logger().error(f"Set home failed: {e}")
             return False
 
-    def set_mode(self, mode: str) -> bool:
+    def set_mode(self, mode: str, timeout: Optional[float] = None) -> bool:
         """
         Set the FCU flight mode.
 
@@ -1408,6 +1410,9 @@ class VehicleDrone(BaseDrone):
         ----------
         mode : str
             Flight mode name (e.g. 'GUIDED', 'STABILIZE', 'LOITER', 'RTL', 'LAND').
+        timeout : float, optional
+            Seconds to wait for the FCU to report ``mode``. ``None`` uses
+            ``mode_timeout``.
 
         Returns
         -------
@@ -1422,7 +1427,8 @@ class VehicleDrone(BaseDrone):
         """
         if not self._transport.set_mode(mode):
             return False
-        if self._wait_until(lambda: (self.flight_mode or "").upper() == mode.upper(), 3.0):
+        wait = self.mode_timeout if timeout is None else timeout
+        if self._wait_until(lambda: (self.flight_mode or "").upper() == mode.upper(), wait):
             return True
         self._node.get_logger().error(
             f"{ERR} Mode '{mode}' not confirmed (still '{self.flight_mode}')"


### PR DESCRIPTION
**Configurable timeouts for arming and mode changes:**

* Added `mode_timeout` and `arm_timeout` fields to drone configuration classes (`_MavrosTelemetryConfig`, `Px4DdsConfig`, `_MavlinkLinkConfig`), allowing users to set default timeouts for mode changes and arming. [[1]](diffhunk://#diff-c6d0f0f63f97aaa07a57743f25f058adb69072c9d59758591e6a7ed3ea308e08R56-R57) [[2]](diffhunk://#diff-c6d0f0f63f97aaa07a57743f25f058adb69072c9d59758591e6a7ed3ea308e08R96-R97) [[3]](diffhunk://#diff-c6d0f0f63f97aaa07a57743f25f058adb69072c9d59758591e6a7ed3ea308e08R121-R122)
* In `VehicleDrone.__init__`, initialized `self.mode_timeout` and `self.arm_timeout` from the configuration, defaulting to 10.0s and 6.0s respectively.
* Updated the `arm` and `set_mode` methods to accept an optional `timeout` parameter, using the configured default if not provided. [[1]](diffhunk://#diff-f49ce26aac6faab8bcae1cae0eb6609ba9c69bebae3e1ce6661bb2f49018ca29L103-R105) [[2]](diffhunk://#diff-f49ce26aac6faab8bcae1cae0eb6609ba9c69bebae3e1ce6661bb2f49018ca29L1403-R1415) [[3]](diffhunk://#diff-08095d71f29c0f71cb251849bf8fff681f0f6d41563962c8265dbdb61e3c4b2eL126-R136) [[4]](diffhunk://#diff-c79673b3f8a9086ce0bc671fc91bbdc1a7eaa1439da3c04b5343f8959c481277L178-R189)


**Minor cleanup:**

* Removed an unused import of `WARN` from `nectar.utils.log` in `ardupilot/drone.py`.